### PR TITLE
Added migration strategy for services (ember-app)

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ To better meet your needs, consider forking the repo and running the codemod loc
 
 ```sh
 cd <your/forked/repo>
-./bin/ember-codemod-pod-to-octane <arguments>
+./bin/ember-codemod-pod-to-octane.js <arguments>
 ```
 
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/ijlee2/ember-codemod-pods-to-octane.git"
+    "url": "https://github.com/ijlee2/ember-codemod-pod-to-octane.git"
   },
   "license": "MIT",
   "author": "Isaac J. Lee",

--- a/src/migration/ember-app/app/index.js
+++ b/src/migration/ember-app/app/index.js
@@ -8,6 +8,7 @@ import { migrationStrategyForRouteRoutes } from './route-routes.js';
 import { migrationStrategyForRouteSerializers } from './route-serializers.js';
 import { migrationStrategyForRouteStylesheets } from './route-stylesheets.js';
 import { migrationStrategyForRouteTemplates } from './route-templates.js';
+import { migrationStrategyForServices } from './services.js';
 
 export function migrationStrategyForAppFolder(projectRoot) {
   return new Map([
@@ -21,5 +22,6 @@ export function migrationStrategyForAppFolder(projectRoot) {
     ...migrationStrategyForRouteSerializers(projectRoot),
     ...migrationStrategyForRouteStylesheets(projectRoot),
     ...migrationStrategyForRouteTemplates(projectRoot),
+    ...migrationStrategyForServices(projectRoot),
   ]);
 }

--- a/src/migration/ember-app/app/services.js
+++ b/src/migration/ember-app/app/services.js
@@ -1,0 +1,33 @@
+import glob from 'glob';
+
+import { mapPaths } from '../../../utils/map-paths.js';
+
+export function migrationStrategyForServices(projectRoot) {
+  const oldPaths = glob.sync('app/**/service.{js,ts}', {
+    cwd: projectRoot,
+  });
+
+  return oldPaths.map((oldPath) => {
+    if (oldPath.endsWith('.ts')) {
+      return mapPaths(oldPath, {
+        find: {
+          directory: 'app',
+          file: 'service.ts',
+        },
+        replace(key) {
+          return `app/services/${key}.ts`;
+        },
+      });
+    }
+
+    return mapPaths(oldPath, {
+      find: {
+        directory: 'app',
+        file: 'service.js',
+      },
+      replace(key) {
+        return `app/services/${key}.js`;
+      },
+    });
+  });
+}

--- a/src/migration/ember-app/tests/index.js
+++ b/src/migration/ember-app/tests/index.js
@@ -1,11 +1,13 @@
 import { migrationStrategyForComponents } from './components.js';
 import { migrationStrategyForRouteControllers } from './route-controllers.js';
 import { migrationStrategyForRouteRoutes } from './route-routes.js';
+import { migrationStrategyForServices } from './services.js';
 
 export function migrationStrategyForTestsFolder(projectRoot) {
   return new Map([
     ...migrationStrategyForComponents(projectRoot),
     ...migrationStrategyForRouteControllers(projectRoot),
     ...migrationStrategyForRouteRoutes(projectRoot),
+    ...migrationStrategyForServices(projectRoot),
   ]);
 }

--- a/src/migration/ember-app/tests/services.js
+++ b/src/migration/ember-app/tests/services.js
@@ -1,0 +1,33 @@
+import glob from 'glob';
+
+import { mapPaths } from '../../../utils/map-paths.js';
+
+export function migrationStrategyForServices(projectRoot) {
+  const oldPaths = glob.sync('tests/unit/!(services)/**/service-test.{js,ts}', {
+    cwd: projectRoot,
+  });
+
+  return oldPaths.map((oldPath) => {
+    if (oldPath.endsWith('.ts')) {
+      return mapPaths(oldPath, {
+        find: {
+          directory: 'tests/unit',
+          file: 'service-test.ts',
+        },
+        replace(key) {
+          return `tests/unit/services/${key}-test.ts`;
+        },
+      });
+    }
+
+    return mapPaths(oldPath, {
+      find: {
+        directory: 'tests/unit',
+        file: 'service-test.js',
+      },
+      replace(key) {
+        return `tests/unit/services/${key}-test.js`;
+      },
+    });
+  });
+}

--- a/tests/fixtures/app-javascript.js
+++ b/tests/fixtures/app-javascript.js
@@ -87,6 +87,14 @@ const inputProject = {
       },
     },
 
+    config: {
+      'service.js': '',
+    },
+
+    experiments: {
+      'service.js': '',
+    },
+
     form: {
       'controller.js': '',
       'route.js': '',
@@ -202,6 +210,14 @@ const inputProject = {
         products: {
           'controller-test.js': '',
         },
+      },
+
+      config: {
+        'service-test.js': '',
+      },
+
+      experiments: {
+        'service-test.js': '',
       },
 
       form: {
@@ -341,6 +357,11 @@ const outputProject = {
       'application.js': '',
     },
 
+    services: {
+      'config.js': '',
+      'experiments.js': '',
+    },
+
     styles: {
       products: {
         'product.css': '',
@@ -411,6 +432,11 @@ const outputProject = {
         'index-test.js': '',
         'product-details-test.js': '',
         'products-test.js': '',
+      },
+
+      services: {
+        'config-test.js': '',
+        'experiments-test.js': '',
       },
     },
   },

--- a/tests/fixtures/app-typescript.js
+++ b/tests/fixtures/app-typescript.js
@@ -92,6 +92,14 @@ const inputProject = {
       },
     },
 
+    config: {
+      'service.ts': '',
+    },
+
+    experiments: {
+      'service.ts': '',
+    },
+
     form: {
       'controller.ts': '',
       'route.ts': '',
@@ -207,6 +215,14 @@ const inputProject = {
         products: {
           'controller-test.ts': '',
         },
+      },
+
+      config: {
+        'service-test.ts': '',
+      },
+
+      experiments: {
+        'service-test.ts': '',
       },
 
       form: {
@@ -351,6 +367,11 @@ const outputProject = {
       'application.ts': '',
     },
 
+    services: {
+      'config.ts': '',
+      'experiments.ts': '',
+    },
+
     styles: {
       products: {
         'product.css': '',
@@ -421,6 +442,11 @@ const outputProject = {
         'index-test.ts': '',
         'product-details-test.ts': '',
         'products-test.ts': '',
+      },
+
+      services: {
+        'config-test.ts': '',
+        'experiments-test.ts': '',
       },
     },
   },

--- a/tests/migration/ember-app/app/services/app-javascript.test.js
+++ b/tests/migration/ember-app/app/services/app-javascript.test.js
@@ -1,0 +1,14 @@
+import { migrationStrategyForServices } from '../../../../../src/migration/ember-app/app/services.js';
+import { inputProject } from '../../../../fixtures/app-javascript.js';
+import { assert, loadFixture, test } from '../../../../test-helpers.js';
+
+const projectRoot = 'tmp/app-javascript';
+
+test('migration | ember-app | app | services > JavaScript', function () {
+  loadFixture(projectRoot, inputProject);
+
+  assert.deepStrictEqual(migrationStrategyForServices(projectRoot), [
+    ['app/config/service.js', 'app/services/config.js'],
+    ['app/experiments/service.js', 'app/services/experiments.js'],
+  ]);
+});

--- a/tests/migration/ember-app/app/services/app-typescript.test.js
+++ b/tests/migration/ember-app/app/services/app-typescript.test.js
@@ -1,0 +1,14 @@
+import { migrationStrategyForServices } from '../../../../../src/migration/ember-app/app/services.js';
+import { inputProject } from '../../../../fixtures/app-typescript.js';
+import { assert, loadFixture, test } from '../../../../test-helpers.js';
+
+const projectRoot = 'tmp/app-typescript';
+
+test('migration | ember-app | app | services > TypeScript', function () {
+  loadFixture(projectRoot, inputProject);
+
+  assert.deepStrictEqual(migrationStrategyForServices(projectRoot), [
+    ['app/config/service.ts', 'app/services/config.ts'],
+    ['app/experiments/service.ts', 'app/services/experiments.ts'],
+  ]);
+});

--- a/tests/migration/ember-app/tests/services/app-javascript.test.js
+++ b/tests/migration/ember-app/tests/services/app-javascript.test.js
@@ -1,0 +1,17 @@
+import { migrationStrategyForServices } from '../../../../../src/migration/ember-app/tests/services.js';
+import { inputProject } from '../../../../fixtures/app-javascript.js';
+import { assert, loadFixture, test } from '../../../../test-helpers.js';
+
+const projectRoot = 'tmp/app-javascript';
+
+test('migration | ember-app | tests | services > JavaScript', function () {
+  loadFixture(projectRoot, inputProject);
+
+  assert.deepStrictEqual(migrationStrategyForServices(projectRoot), [
+    ['tests/unit/config/service-test.js', 'tests/unit/services/config-test.js'],
+    [
+      'tests/unit/experiments/service-test.js',
+      'tests/unit/services/experiments-test.js',
+    ],
+  ]);
+});

--- a/tests/migration/ember-app/tests/services/app-typescript.test.js
+++ b/tests/migration/ember-app/tests/services/app-typescript.test.js
@@ -1,0 +1,17 @@
+import { migrationStrategyForServices } from '../../../../../src/migration/ember-app/tests/services.js';
+import { inputProject } from '../../../../fixtures/app-typescript.js';
+import { assert, loadFixture, test } from '../../../../test-helpers.js';
+
+const projectRoot = 'tmp/app-typescript';
+
+test('migration | ember-app | tests | services > TypeScript', function () {
+  loadFixture(projectRoot, inputProject);
+
+  assert.deepStrictEqual(migrationStrategyForServices(projectRoot), [
+    ['tests/unit/config/service-test.ts', 'tests/unit/services/config-test.ts'],
+    [
+      'tests/unit/experiments/service-test.ts',
+      'tests/unit/services/experiments-test.ts',
+    ],
+  ]);
+});


### PR DESCRIPTION
## Description

Closes #3. `migrateEmberApp()` can now find services that are placed in a pod directory and move them to `app/services`.

In a production app (with many addons and engines), I found only one example of a service that had been placed in a custom directory. To reduce the scope of work and future maintenance, I didn't add a migration strategy for addons and engines.