### PR TITLE
Allowed users to specify podModulePrefix (ember-app)

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,19 @@ npx ember-codemod-pod-to-octane --root=<your/project/path>
 </details>
 
 
+<details>
+<summary>Optional: Specify the pod path</summary>
+
+Pass `--pod-path` if `podModulePrefix` is set in `config/environment.js` and has a different value than `modulePrefix`. "Subtract" `modulePrefix` from `podModulePrefix` to get the pod path.
+
+```sh
+# If modulePrefix is 'my-app' and podModulePrefix is 'my-app/pods'
+npx ember-codemod-pod-to-octane --pod-path=pods
+```
+
+</details>
+
+
 ### Limitations
 
 The codemod is designed to cover typical uses of an Ember app, addon, and engine. It is not designed to cover one-off cases.

--- a/bin/ember-codemod-pod-to-octane.js
+++ b/bin/ember-codemod-pod-to-octane.js
@@ -11,6 +11,11 @@ process.title = 'ember-codemod-pod-to-octane';
 
 // Set codemod options
 const { argv } = yargs(hideBin(process.argv))
+  .option('pod-path', {
+    default: '',
+    describe: 'Namespace used for the pod layout',
+    type: 'string',
+  })
   .option('root', {
     describe: 'Location of your Ember project',
     type: 'string',
@@ -28,6 +33,7 @@ const { argv } = yargs(hideBin(process.argv))
   });
 
 const options = {
+  podPath: argv['pod-path'],
   projectRoot: argv['root'] ?? process.cwd(),
   projectType: argv['type'],
   testRun: argv['test'],

--- a/src/migration/ember-addon/addon/component-classes.js
+++ b/src/migration/ember-addon/addon/component-classes.js
@@ -2,7 +2,9 @@ import glob from 'glob';
 
 import { mapPaths } from '../../../utils/map-paths.js';
 
-export function migrationStrategyForComponentClasses(projectRoot) {
+export function migrationStrategyForComponentClasses(options) {
+  const { projectRoot } = options;
+
   const oldPaths = glob.sync('addon/components/**/component.{d.ts,js,ts}', {
     cwd: projectRoot,
   });

--- a/src/migration/ember-addon/addon/component-stylesheets.js
+++ b/src/migration/ember-addon/addon/component-stylesheets.js
@@ -2,7 +2,9 @@ import glob from 'glob';
 
 import { mapPaths } from '../../../utils/map-paths.js';
 
-export function migrationStrategyForComponentStylesheets(projectRoot) {
+export function migrationStrategyForComponentStylesheets(options) {
+  const { projectRoot } = options;
+
   const oldPaths = glob.sync('addon/components/**/styles.{css,scss}', {
     cwd: projectRoot,
   });

--- a/src/migration/ember-addon/addon/component-templates.js
+++ b/src/migration/ember-addon/addon/component-templates.js
@@ -2,7 +2,9 @@ import glob from 'glob';
 
 import { mapPaths } from '../../../utils/map-paths.js';
 
-export function migrationStrategyForComponentTemplates(projectRoot) {
+export function migrationStrategyForComponentTemplates(options) {
+  const { projectRoot } = options;
+
   const oldPaths = glob.sync('addon/components/**/template.hbs', {
     cwd: projectRoot,
   });

--- a/src/migration/ember-addon/addon/index.js
+++ b/src/migration/ember-addon/addon/index.js
@@ -2,10 +2,10 @@ import { migrationStrategyForComponentClasses } from './component-classes.js';
 import { migrationStrategyForComponentStylesheets } from './component-stylesheets.js';
 import { migrationStrategyForComponentTemplates } from './component-templates.js';
 
-export function migrationStrategyForAddonFolder(projectRoot) {
+export function migrationStrategyForAddonFolder(options) {
   return new Map([
-    ...migrationStrategyForComponentClasses(projectRoot),
-    ...migrationStrategyForComponentStylesheets(projectRoot),
-    ...migrationStrategyForComponentTemplates(projectRoot),
+    ...migrationStrategyForComponentClasses(options),
+    ...migrationStrategyForComponentStylesheets(options),
+    ...migrationStrategyForComponentTemplates(options),
   ]);
 }

--- a/src/migration/ember-addon/app/component-classes.js
+++ b/src/migration/ember-addon/app/component-classes.js
@@ -2,7 +2,9 @@ import glob from 'glob';
 
 import { mapPaths } from '../../../utils/map-paths.js';
 
-export function migrationStrategyForComponentClasses(projectRoot) {
+export function migrationStrategyForComponentClasses(options) {
+  const { projectRoot } = options;
+
   const oldPaths = glob.sync('app/components/**/component.js', {
     cwd: projectRoot,
   });

--- a/src/migration/ember-addon/app/component-stylesheets.js
+++ b/src/migration/ember-addon/app/component-stylesheets.js
@@ -2,7 +2,9 @@ import glob from 'glob';
 
 import { mapPaths } from '../../../utils/map-paths.js';
 
-export function migrationStrategyForComponentStylesheets(projectRoot) {
+export function migrationStrategyForComponentStylesheets(options) {
+  const { projectRoot } = options;
+
   const oldPaths = glob.sync('app/components/**/styles.js', {
     cwd: projectRoot,
   });

--- a/src/migration/ember-addon/app/component-templates.js
+++ b/src/migration/ember-addon/app/component-templates.js
@@ -2,7 +2,9 @@ import glob from 'glob';
 
 import { mapPaths } from '../../../utils/map-paths.js';
 
-export function migrationStrategyForComponentTemplates(projectRoot) {
+export function migrationStrategyForComponentTemplates(options) {
+  const { projectRoot } = options;
+
   const oldPaths = glob.sync('app/components/**/template.js', {
     cwd: projectRoot,
   });

--- a/src/migration/ember-addon/app/index.js
+++ b/src/migration/ember-addon/app/index.js
@@ -2,10 +2,10 @@ import { migrationStrategyForComponentClasses } from './component-classes.js';
 import { migrationStrategyForComponentStylesheets } from './component-stylesheets.js';
 import { migrationStrategyForComponentTemplates } from './component-templates.js';
 
-export function migrationStrategyForAppFolder(projectRoot) {
+export function migrationStrategyForAppFolder(options) {
   return new Map([
-    ...migrationStrategyForComponentClasses(projectRoot),
-    ...migrationStrategyForComponentStylesheets(projectRoot),
-    ...migrationStrategyForComponentTemplates(projectRoot),
+    ...migrationStrategyForComponentClasses(options),
+    ...migrationStrategyForComponentStylesheets(options),
+    ...migrationStrategyForComponentTemplates(options),
   ]);
 }

--- a/src/migration/ember-addon/index.js
+++ b/src/migration/ember-addon/index.js
@@ -5,13 +5,11 @@ import { migrationStrategyForAppFolder } from './app/index.js';
 import { migrationStrategyForTestsFolder } from './tests/index.js';
 
 export function migrateEmberAddon(options) {
-  const { projectRoot, testRun } = options;
+  const migrationStrategyAddon = migrationStrategyForAddonFolder(options);
+  const migrationStrategyApp = migrationStrategyForAppFolder(options);
+  const migrationStrategyTests = migrationStrategyForTestsFolder(options);
 
-  const migrationStrategyAddon = migrationStrategyForAddonFolder(projectRoot);
-  const migrationStrategyApp = migrationStrategyForAppFolder(projectRoot);
-  const migrationStrategyTests = migrationStrategyForTestsFolder(projectRoot);
-
-  if (testRun) {
+  if (options.testRun) {
     console.log({
       migrationStrategyAddon,
       migrationStrategyApp,
@@ -21,23 +19,9 @@ export function migrateEmberAddon(options) {
     return;
   }
 
-  moveFiles({
-    migrationStrategy: migrationStrategyAddon,
-    projectRoot,
-  });
+  moveFiles(migrationStrategyAddon, options);
+  moveFiles(migrationStrategyApp, options);
+  moveFiles(migrationStrategyTests, options);
 
-  moveFiles({
-    migrationStrategy: migrationStrategyApp,
-    projectRoot,
-  });
-
-  moveFiles({
-    migrationStrategy: migrationStrategyTests,
-    projectRoot,
-  });
-
-  updatePaths({
-    migrationStrategy: migrationStrategyApp,
-    projectRoot,
-  });
+  updatePaths(migrationStrategyApp, options);
 }

--- a/src/migration/ember-addon/tests/components.js
+++ b/src/migration/ember-addon/tests/components.js
@@ -2,7 +2,9 @@ import glob from 'glob';
 
 import { mapPaths } from '../../../utils/map-paths.js';
 
-export function migrationStrategyForComponents(projectRoot) {
+export function migrationStrategyForComponents(options) {
+  const { projectRoot } = options;
+
   const oldPaths = glob.sync(
     'tests/integration/components/**/component-test.{js,ts}',
     {

--- a/src/migration/ember-addon/tests/index.js
+++ b/src/migration/ember-addon/tests/index.js
@@ -1,5 +1,5 @@
 import { migrationStrategyForComponents } from './components.js';
 
-export function migrationStrategyForTestsFolder(projectRoot) {
-  return new Map([...migrationStrategyForComponents(projectRoot)]);
+export function migrationStrategyForTestsFolder(options) {
+  return new Map([...migrationStrategyForComponents(options)]);
 }

--- a/src/migration/ember-app/app/component-classes.js
+++ b/src/migration/ember-app/app/component-classes.js
@@ -1,19 +1,23 @@
 import glob from 'glob';
+import { join } from 'node:path';
 
 import { mapPaths } from '../../../utils/map-paths.js';
 
 export function migrationStrategyForComponentClasses(options) {
-  const { projectRoot } = options;
+  const { podPath, projectRoot } = options;
 
-  const oldPaths = glob.sync('app/components/**/component.{d.ts,js,ts}', {
-    cwd: projectRoot,
-  });
+  const oldPaths = glob.sync(
+    join('app', podPath, 'components', '**', 'component.{d.ts,js,ts}'),
+    {
+      cwd: projectRoot,
+    }
+  );
 
   return oldPaths.map((oldPath) => {
     if (oldPath.endsWith('.d.ts')) {
       return mapPaths(oldPath, {
         find: {
-          directory: 'app/components',
+          directory: join('app', podPath, 'components'),
           file: 'component.d.ts',
         },
         replace(key) {
@@ -25,7 +29,7 @@ export function migrationStrategyForComponentClasses(options) {
     if (oldPath.endsWith('.ts')) {
       return mapPaths(oldPath, {
         find: {
-          directory: 'app/components',
+          directory: join('app', podPath, 'components'),
           file: 'component.ts',
         },
         replace(key) {
@@ -36,7 +40,7 @@ export function migrationStrategyForComponentClasses(options) {
 
     return mapPaths(oldPath, {
       find: {
-        directory: 'app/components',
+        directory: join('app', podPath, 'components'),
         file: 'component.js',
       },
       replace(key) {

--- a/src/migration/ember-app/app/component-classes.js
+++ b/src/migration/ember-app/app/component-classes.js
@@ -2,7 +2,9 @@ import glob from 'glob';
 
 import { mapPaths } from '../../../utils/map-paths.js';
 
-export function migrationStrategyForComponentClasses(projectRoot) {
+export function migrationStrategyForComponentClasses(options) {
+  const { projectRoot } = options;
+
   const oldPaths = glob.sync('app/components/**/component.{d.ts,js,ts}', {
     cwd: projectRoot,
   });

--- a/src/migration/ember-app/app/component-stylesheets.js
+++ b/src/migration/ember-app/app/component-stylesheets.js
@@ -2,7 +2,9 @@ import glob from 'glob';
 
 import { mapPaths } from '../../../utils/map-paths.js';
 
-export function migrationStrategyForComponentStylesheets(projectRoot) {
+export function migrationStrategyForComponentStylesheets(options) {
+  const { projectRoot } = options;
+
   const oldPaths = glob.sync('app/components/**/styles.{css,scss}', {
     cwd: projectRoot,
   });

--- a/src/migration/ember-app/app/component-stylesheets.js
+++ b/src/migration/ember-app/app/component-stylesheets.js
@@ -1,19 +1,23 @@
 import glob from 'glob';
+import { join } from 'node:path';
 
 import { mapPaths } from '../../../utils/map-paths.js';
 
 export function migrationStrategyForComponentStylesheets(options) {
-  const { projectRoot } = options;
+  const { podPath, projectRoot } = options;
 
-  const oldPaths = glob.sync('app/components/**/styles.{css,scss}', {
-    cwd: projectRoot,
-  });
+  const oldPaths = glob.sync(
+    join('app', podPath, 'components', '**', 'styles.{css,scss}'),
+    {
+      cwd: projectRoot,
+    }
+  );
 
   return oldPaths.map((oldPath) => {
     if (oldPath.endsWith('.scss')) {
       return mapPaths(oldPath, {
         find: {
-          directory: 'app/components',
+          directory: join('app', podPath, 'components'),
           file: 'styles.scss',
         },
         replace(key) {
@@ -24,7 +28,7 @@ export function migrationStrategyForComponentStylesheets(options) {
 
     return mapPaths(oldPath, {
       find: {
-        directory: 'app/components',
+        directory: join('app', podPath, 'components'),
         file: 'styles.css',
       },
       replace(key) {

--- a/src/migration/ember-app/app/component-templates.js
+++ b/src/migration/ember-app/app/component-templates.js
@@ -1,18 +1,22 @@
 import glob from 'glob';
+import { join } from 'node:path';
 
 import { mapPaths } from '../../../utils/map-paths.js';
 
 export function migrationStrategyForComponentTemplates(options) {
-  const { projectRoot } = options;
+  const { podPath, projectRoot } = options;
 
-  const oldPaths = glob.sync('app/components/**/template.hbs', {
-    cwd: projectRoot,
-  });
+  const oldPaths = glob.sync(
+    join('app', podPath, 'components', '**', 'template.hbs'),
+    {
+      cwd: projectRoot,
+    }
+  );
 
   return oldPaths.map((oldPath) => {
     return mapPaths(oldPath, {
       find: {
-        directory: 'app/components',
+        directory: join('app', podPath, 'components'),
         file: 'template.hbs',
       },
       replace(key) {

--- a/src/migration/ember-app/app/component-templates.js
+++ b/src/migration/ember-app/app/component-templates.js
@@ -2,7 +2,9 @@ import glob from 'glob';
 
 import { mapPaths } from '../../../utils/map-paths.js';
 
-export function migrationStrategyForComponentTemplates(projectRoot) {
+export function migrationStrategyForComponentTemplates(options) {
+  const { projectRoot } = options;
+
   const oldPaths = glob.sync('app/components/**/template.hbs', {
     cwd: projectRoot,
   });

--- a/src/migration/ember-app/app/index.js
+++ b/src/migration/ember-app/app/index.js
@@ -10,18 +10,18 @@ import { migrationStrategyForRouteStylesheets } from './route-stylesheets.js';
 import { migrationStrategyForRouteTemplates } from './route-templates.js';
 import { migrationStrategyForServices } from './services.js';
 
-export function migrationStrategyForAppFolder(projectRoot) {
+export function migrationStrategyForAppFolder(options) {
   return new Map([
-    ...migrationStrategyForComponentClasses(projectRoot),
-    ...migrationStrategyForComponentStylesheets(projectRoot),
-    ...migrationStrategyForComponentTemplates(projectRoot),
-    ...migrationStrategyForRouteAdapters(projectRoot),
-    ...migrationStrategyForRouteControllers(projectRoot),
-    ...migrationStrategyForRouteModels(projectRoot),
-    ...migrationStrategyForRouteRoutes(projectRoot),
-    ...migrationStrategyForRouteSerializers(projectRoot),
-    ...migrationStrategyForRouteStylesheets(projectRoot),
-    ...migrationStrategyForRouteTemplates(projectRoot),
-    ...migrationStrategyForServices(projectRoot),
+    ...migrationStrategyForComponentClasses(options),
+    ...migrationStrategyForComponentStylesheets(options),
+    ...migrationStrategyForComponentTemplates(options),
+    ...migrationStrategyForRouteAdapters(options),
+    ...migrationStrategyForRouteControllers(options),
+    ...migrationStrategyForRouteModels(options),
+    ...migrationStrategyForRouteRoutes(options),
+    ...migrationStrategyForRouteSerializers(options),
+    ...migrationStrategyForRouteStylesheets(options),
+    ...migrationStrategyForRouteTemplates(options),
+    ...migrationStrategyForServices(options),
   ]);
 }

--- a/src/migration/ember-app/app/route-adapters.js
+++ b/src/migration/ember-app/app/route-adapters.js
@@ -1,11 +1,12 @@
 import glob from 'glob';
+import { join } from 'node:path';
 
 import { mapPaths } from '../../../utils/map-paths.js';
 
 export function migrationStrategyForRouteAdapters(options) {
-  const { projectRoot } = options;
+  const { podPath, projectRoot } = options;
 
-  const oldPaths = glob.sync('app/**/adapter.{js,ts}', {
+  const oldPaths = glob.sync(join('app', podPath, '**', 'adapter.{js,ts}'), {
     cwd: projectRoot,
   });
 
@@ -13,7 +14,7 @@ export function migrationStrategyForRouteAdapters(options) {
     if (oldPath.endsWith('.ts')) {
       return mapPaths(oldPath, {
         find: {
-          directory: 'app',
+          directory: join('app', podPath),
           file: 'adapter.ts',
         },
         replace(key) {
@@ -24,7 +25,7 @@ export function migrationStrategyForRouteAdapters(options) {
 
     return mapPaths(oldPath, {
       find: {
-        directory: 'app',
+        directory: join('app', podPath),
         file: 'adapter.js',
       },
       replace(key) {

--- a/src/migration/ember-app/app/route-adapters.js
+++ b/src/migration/ember-app/app/route-adapters.js
@@ -2,7 +2,9 @@ import glob from 'glob';
 
 import { mapPaths } from '../../../utils/map-paths.js';
 
-export function migrationStrategyForRouteAdapters(projectRoot) {
+export function migrationStrategyForRouteAdapters(options) {
+  const { projectRoot } = options;
+
   const oldPaths = glob.sync('app/**/adapter.{js,ts}', {
     cwd: projectRoot,
   });

--- a/src/migration/ember-app/app/route-controllers.js
+++ b/src/migration/ember-app/app/route-controllers.js
@@ -1,11 +1,12 @@
 import glob from 'glob';
+import { join } from 'node:path';
 
 import { mapPaths } from '../../../utils/map-paths.js';
 
 export function migrationStrategyForRouteControllers(options) {
-  const { projectRoot } = options;
+  const { podPath, projectRoot } = options;
 
-  const oldPaths = glob.sync('app/**/controller.{js,ts}', {
+  const oldPaths = glob.sync(join('app', podPath, '**', 'controller.{js,ts}'), {
     cwd: projectRoot,
   });
 
@@ -13,7 +14,7 @@ export function migrationStrategyForRouteControllers(options) {
     if (oldPath.endsWith('.ts')) {
       return mapPaths(oldPath, {
         find: {
-          directory: 'app',
+          directory: join('app', podPath),
           file: 'controller.ts',
         },
         replace(key) {
@@ -24,7 +25,7 @@ export function migrationStrategyForRouteControllers(options) {
 
     return mapPaths(oldPath, {
       find: {
-        directory: 'app',
+        directory: join('app', podPath),
         file: 'controller.js',
       },
       replace(key) {

--- a/src/migration/ember-app/app/route-controllers.js
+++ b/src/migration/ember-app/app/route-controllers.js
@@ -2,7 +2,9 @@ import glob from 'glob';
 
 import { mapPaths } from '../../../utils/map-paths.js';
 
-export function migrationStrategyForRouteControllers(projectRoot) {
+export function migrationStrategyForRouteControllers(options) {
+  const { projectRoot } = options;
+
   const oldPaths = glob.sync('app/**/controller.{js,ts}', {
     cwd: projectRoot,
   });

--- a/src/migration/ember-app/app/route-models.js
+++ b/src/migration/ember-app/app/route-models.js
@@ -2,7 +2,9 @@ import glob from 'glob';
 
 import { mapPaths } from '../../../utils/map-paths.js';
 
-export function migrationStrategyForRouteModels(projectRoot) {
+export function migrationStrategyForRouteModels(options) {
+  const { projectRoot } = options;
+
   const oldPaths = glob.sync('app/**/model.{js,ts}', {
     cwd: projectRoot,
   });

--- a/src/migration/ember-app/app/route-models.js
+++ b/src/migration/ember-app/app/route-models.js
@@ -1,11 +1,12 @@
 import glob from 'glob';
+import { join } from 'node:path';
 
 import { mapPaths } from '../../../utils/map-paths.js';
 
 export function migrationStrategyForRouteModels(options) {
-  const { projectRoot } = options;
+  const { podPath, projectRoot } = options;
 
-  const oldPaths = glob.sync('app/**/model.{js,ts}', {
+  const oldPaths = glob.sync(join('app', podPath, '**', 'model.{js,ts}'), {
     cwd: projectRoot,
   });
 
@@ -13,7 +14,7 @@ export function migrationStrategyForRouteModels(options) {
     if (oldPath.endsWith('.ts')) {
       return mapPaths(oldPath, {
         find: {
-          directory: 'app',
+          directory: join('app', podPath),
           file: 'model.ts',
         },
         replace(key) {
@@ -24,7 +25,7 @@ export function migrationStrategyForRouteModels(options) {
 
     return mapPaths(oldPath, {
       find: {
-        directory: 'app',
+        directory: join('app', podPath),
         file: 'model.js',
       },
       replace(key) {

--- a/src/migration/ember-app/app/route-routes.js
+++ b/src/migration/ember-app/app/route-routes.js
@@ -2,7 +2,9 @@ import glob from 'glob';
 
 import { mapPaths } from '../../../utils/map-paths.js';
 
-export function migrationStrategyForRouteRoutes(projectRoot) {
+export function migrationStrategyForRouteRoutes(options) {
+  const { projectRoot } = options;
+
   const oldPaths = glob.sync('app/**/route.{js,ts}', {
     cwd: projectRoot,
   });

--- a/src/migration/ember-app/app/route-routes.js
+++ b/src/migration/ember-app/app/route-routes.js
@@ -1,11 +1,12 @@
 import glob from 'glob';
+import { join } from 'node:path';
 
 import { mapPaths } from '../../../utils/map-paths.js';
 
 export function migrationStrategyForRouteRoutes(options) {
-  const { projectRoot } = options;
+  const { podPath, projectRoot } = options;
 
-  const oldPaths = glob.sync('app/**/route.{js,ts}', {
+  const oldPaths = glob.sync(join('app', podPath, '**', 'route.{js,ts}'), {
     cwd: projectRoot,
   });
 
@@ -13,7 +14,7 @@ export function migrationStrategyForRouteRoutes(options) {
     if (oldPath.endsWith('.ts')) {
       return mapPaths(oldPath, {
         find: {
-          directory: 'app',
+          directory: join('app', podPath),
           file: 'route.ts',
         },
         replace(key) {
@@ -24,7 +25,7 @@ export function migrationStrategyForRouteRoutes(options) {
 
     return mapPaths(oldPath, {
       find: {
-        directory: 'app',
+        directory: join('app', podPath),
         file: 'route.js',
       },
       replace(key) {

--- a/src/migration/ember-app/app/route-serializers.js
+++ b/src/migration/ember-app/app/route-serializers.js
@@ -2,7 +2,9 @@ import glob from 'glob';
 
 import { mapPaths } from '../../../utils/map-paths.js';
 
-export function migrationStrategyForRouteSerializers(projectRoot) {
+export function migrationStrategyForRouteSerializers(options) {
+  const { projectRoot } = options;
+
   const oldPaths = glob.sync('app/**/serializer.{js,ts}', {
     cwd: projectRoot,
   });

--- a/src/migration/ember-app/app/route-serializers.js
+++ b/src/migration/ember-app/app/route-serializers.js
@@ -1,11 +1,12 @@
 import glob from 'glob';
+import { join } from 'node:path';
 
 import { mapPaths } from '../../../utils/map-paths.js';
 
 export function migrationStrategyForRouteSerializers(options) {
-  const { projectRoot } = options;
+  const { podPath, projectRoot } = options;
 
-  const oldPaths = glob.sync('app/**/serializer.{js,ts}', {
+  const oldPaths = glob.sync(join('app', podPath, '**', 'serializer.{js,ts}'), {
     cwd: projectRoot,
   });
 
@@ -13,7 +14,7 @@ export function migrationStrategyForRouteSerializers(options) {
     if (oldPath.endsWith('.ts')) {
       return mapPaths(oldPath, {
         find: {
-          directory: 'app',
+          directory: join('app', podPath),
           file: 'serializer.ts',
         },
         replace(key) {
@@ -24,7 +25,7 @@ export function migrationStrategyForRouteSerializers(options) {
 
     return mapPaths(oldPath, {
       find: {
-        directory: 'app',
+        directory: join('app', podPath),
         file: 'serializer.js',
       },
       replace(key) {

--- a/src/migration/ember-app/app/route-stylesheets.js
+++ b/src/migration/ember-app/app/route-stylesheets.js
@@ -1,19 +1,23 @@
 import glob from 'glob';
+import { join } from 'node:path';
 
 import { mapPaths } from '../../../utils/map-paths.js';
 
 export function migrationStrategyForRouteStylesheets(options) {
-  const { projectRoot } = options;
+  const { podPath, projectRoot } = options;
 
-  const oldPaths = glob.sync('app/!(components)/**/styles.{css,scss}', {
-    cwd: projectRoot,
-  });
+  const oldPaths = glob.sync(
+    join('app', podPath, '!(components)', '**', 'styles.{css,scss}'),
+    {
+      cwd: projectRoot,
+    }
+  );
 
   return oldPaths.map((oldPath) => {
     if (oldPath.endsWith('.scss')) {
       return mapPaths(oldPath, {
         find: {
-          directory: 'app',
+          directory: join('app', podPath),
           file: 'styles.scss',
         },
         replace(key) {
@@ -24,7 +28,7 @@ export function migrationStrategyForRouteStylesheets(options) {
 
     return mapPaths(oldPath, {
       find: {
-        directory: 'app',
+        directory: join('app', podPath),
         file: 'styles.css',
       },
       replace(key) {

--- a/src/migration/ember-app/app/route-stylesheets.js
+++ b/src/migration/ember-app/app/route-stylesheets.js
@@ -2,7 +2,9 @@ import glob from 'glob';
 
 import { mapPaths } from '../../../utils/map-paths.js';
 
-export function migrationStrategyForRouteStylesheets(projectRoot) {
+export function migrationStrategyForRouteStylesheets(options) {
+  const { projectRoot } = options;
+
   const oldPaths = glob.sync('app/!(components)/**/styles.{css,scss}', {
     cwd: projectRoot,
   });

--- a/src/migration/ember-app/app/route-templates.js
+++ b/src/migration/ember-app/app/route-templates.js
@@ -2,7 +2,9 @@ import glob from 'glob';
 
 import { mapPaths } from '../../../utils/map-paths.js';
 
-export function migrationStrategyForRouteTemplates(projectRoot) {
+export function migrationStrategyForRouteTemplates(options) {
+  const { projectRoot } = options;
+
   const oldPaths = glob.sync('app/!(components)/**/template.hbs', {
     cwd: projectRoot,
   });

--- a/src/migration/ember-app/app/route-templates.js
+++ b/src/migration/ember-app/app/route-templates.js
@@ -1,18 +1,22 @@
 import glob from 'glob';
+import { join } from 'node:path';
 
 import { mapPaths } from '../../../utils/map-paths.js';
 
 export function migrationStrategyForRouteTemplates(options) {
-  const { projectRoot } = options;
+  const { podPath, projectRoot } = options;
 
-  const oldPaths = glob.sync('app/!(components)/**/template.hbs', {
-    cwd: projectRoot,
-  });
+  const oldPaths = glob.sync(
+    join('app', podPath, '!(components)', '**', 'template.hbs'),
+    {
+      cwd: projectRoot,
+    }
+  );
 
   return oldPaths.map((oldPath) => {
     return mapPaths(oldPath, {
       find: {
-        directory: 'app',
+        directory: join('app', podPath),
         file: 'template.hbs',
       },
       replace(key) {

--- a/src/migration/ember-app/app/services.js
+++ b/src/migration/ember-app/app/services.js
@@ -1,11 +1,12 @@
 import glob from 'glob';
+import { join } from 'node:path';
 
 import { mapPaths } from '../../../utils/map-paths.js';
 
 export function migrationStrategyForServices(options) {
-  const { projectRoot } = options;
+  const { podPath, projectRoot } = options;
 
-  const oldPaths = glob.sync('app/**/service.{js,ts}', {
+  const oldPaths = glob.sync(join('app', podPath, '**', 'service.{js,ts}'), {
     cwd: projectRoot,
   });
 
@@ -13,7 +14,7 @@ export function migrationStrategyForServices(options) {
     if (oldPath.endsWith('.ts')) {
       return mapPaths(oldPath, {
         find: {
-          directory: 'app',
+          directory: join('app', podPath),
           file: 'service.ts',
         },
         replace(key) {
@@ -24,7 +25,7 @@ export function migrationStrategyForServices(options) {
 
     return mapPaths(oldPath, {
       find: {
-        directory: 'app',
+        directory: join('app', podPath),
         file: 'service.js',
       },
       replace(key) {

--- a/src/migration/ember-app/app/services.js
+++ b/src/migration/ember-app/app/services.js
@@ -2,7 +2,9 @@ import glob from 'glob';
 
 import { mapPaths } from '../../../utils/map-paths.js';
 
-export function migrationStrategyForServices(projectRoot) {
+export function migrationStrategyForServices(options) {
+  const { projectRoot } = options;
+
   const oldPaths = glob.sync('app/**/service.{js,ts}', {
     cwd: projectRoot,
   });

--- a/src/migration/ember-app/index.js
+++ b/src/migration/ember-app/index.js
@@ -3,12 +3,10 @@ import { migrationStrategyForAppFolder } from './app/index.js';
 import { migrationStrategyForTestsFolder } from './tests/index.js';
 
 export function migrateEmberApp(options) {
-  const { projectRoot, testRun } = options;
+  const migrationStrategyApp = migrationStrategyForAppFolder(options);
+  const migrationStrategyTests = migrationStrategyForTestsFolder(options);
 
-  const migrationStrategyApp = migrationStrategyForAppFolder(projectRoot);
-  const migrationStrategyTests = migrationStrategyForTestsFolder(projectRoot);
-
-  if (testRun) {
+  if (options.testRun) {
     console.log({
       migrationStrategyApp,
       migrationStrategyTests,
@@ -17,13 +15,6 @@ export function migrateEmberApp(options) {
     return;
   }
 
-  moveFiles({
-    migrationStrategy: migrationStrategyApp,
-    projectRoot,
-  });
-
-  moveFiles({
-    migrationStrategy: migrationStrategyTests,
-    projectRoot,
-  });
+  moveFiles(migrationStrategyApp, options);
+  moveFiles(migrationStrategyTests, options);
 }

--- a/src/migration/ember-app/tests/components.js
+++ b/src/migration/ember-app/tests/components.js
@@ -1,12 +1,19 @@
 import glob from 'glob';
+import { join } from 'node:path';
 
 import { mapPaths } from '../../../utils/map-paths.js';
 
 export function migrationStrategyForComponents(options) {
-  const { projectRoot } = options;
+  const { podPath, projectRoot } = options;
 
   const oldPaths = glob.sync(
-    'tests/integration/components/**/component-test.{js,ts}',
+    join(
+      'tests/integration',
+      podPath,
+      'components',
+      '**',
+      'component-test.{js,ts}'
+    ),
     {
       cwd: projectRoot,
     }
@@ -16,7 +23,7 @@ export function migrationStrategyForComponents(options) {
     if (oldPath.endsWith('.ts')) {
       return mapPaths(oldPath, {
         find: {
-          directory: 'tests/integration/components',
+          directory: join('tests/integration', podPath, 'components'),
           file: 'component-test.ts',
         },
         replace(key) {
@@ -27,7 +34,7 @@ export function migrationStrategyForComponents(options) {
 
     return mapPaths(oldPath, {
       find: {
-        directory: 'tests/integration/components',
+        directory: join('tests/integration', podPath, 'components'),
         file: 'component-test.js',
       },
       replace(key) {

--- a/src/migration/ember-app/tests/components.js
+++ b/src/migration/ember-app/tests/components.js
@@ -2,7 +2,9 @@ import glob from 'glob';
 
 import { mapPaths } from '../../../utils/map-paths.js';
 
-export function migrationStrategyForComponents(projectRoot) {
+export function migrationStrategyForComponents(options) {
+  const { projectRoot } = options;
+
   const oldPaths = glob.sync(
     'tests/integration/components/**/component-test.{js,ts}',
     {

--- a/src/migration/ember-app/tests/index.js
+++ b/src/migration/ember-app/tests/index.js
@@ -3,11 +3,11 @@ import { migrationStrategyForRouteControllers } from './route-controllers.js';
 import { migrationStrategyForRouteRoutes } from './route-routes.js';
 import { migrationStrategyForServices } from './services.js';
 
-export function migrationStrategyForTestsFolder(projectRoot) {
+export function migrationStrategyForTestsFolder(options) {
   return new Map([
-    ...migrationStrategyForComponents(projectRoot),
-    ...migrationStrategyForRouteControllers(projectRoot),
-    ...migrationStrategyForRouteRoutes(projectRoot),
-    ...migrationStrategyForServices(projectRoot),
+    ...migrationStrategyForComponents(options),
+    ...migrationStrategyForRouteControllers(options),
+    ...migrationStrategyForRouteRoutes(options),
+    ...migrationStrategyForServices(options),
   ]);
 }

--- a/src/migration/ember-app/tests/route-controllers.js
+++ b/src/migration/ember-app/tests/route-controllers.js
@@ -1,15 +1,22 @@
 import glob from 'glob';
+import { join } from 'node:path';
 
 import { mapPaths } from '../../../utils/map-paths.js';
 
 export function migrationStrategyForRouteControllers(options) {
-  const { projectRoot } = options;
+  const { podPath, projectRoot } = options;
 
   /*
     Case 1: Didn't pass the --pod flag, but configured { usePods: true } in .ember-cli
   */
   const oldPaths1 = glob.sync(
-    'tests/unit/!(controllers)/**/controller-test.{js,ts}',
+    join(
+      'tests/unit',
+      podPath,
+      '!(controllers)',
+      '**',
+      'controller-test.{js,ts}'
+    ),
     {
       cwd: projectRoot,
     }
@@ -19,7 +26,7 @@ export function migrationStrategyForRouteControllers(options) {
     if (oldPath.endsWith('.ts')) {
       return mapPaths(oldPath, {
         find: {
-          directory: 'tests/unit',
+          directory: join('tests/unit', podPath),
           file: 'controller-test.ts',
         },
         replace(key) {
@@ -30,7 +37,7 @@ export function migrationStrategyForRouteControllers(options) {
 
     return mapPaths(oldPath, {
       find: {
-        directory: 'tests/unit',
+        directory: join('tests/unit', podPath),
         file: 'controller-test.js',
       },
       replace(key) {
@@ -43,7 +50,7 @@ export function migrationStrategyForRouteControllers(options) {
     Case 2: Passed the --pod flag to Ember CLI
   */
   const oldPaths2 = glob.sync(
-    'tests/unit/controllers/**/controller-test.{js,ts}',
+    join('tests/unit', podPath, 'controllers/**/controller-test.{js,ts}'),
     {
       cwd: projectRoot,
     }
@@ -53,7 +60,7 @@ export function migrationStrategyForRouteControllers(options) {
     if (oldPath.endsWith('.ts')) {
       return mapPaths(oldPath, {
         find: {
-          directory: 'tests/unit/controllers',
+          directory: join('tests/unit', podPath, 'controllers'),
           file: 'controller-test.ts',
         },
         replace(key) {
@@ -64,7 +71,7 @@ export function migrationStrategyForRouteControllers(options) {
 
     return mapPaths(oldPath, {
       find: {
-        directory: 'tests/unit/controllers',
+        directory: join('tests/unit', podPath, 'controllers'),
         file: 'controller-test.js',
       },
       replace(key) {

--- a/src/migration/ember-app/tests/route-controllers.js
+++ b/src/migration/ember-app/tests/route-controllers.js
@@ -2,7 +2,9 @@ import glob from 'glob';
 
 import { mapPaths } from '../../../utils/map-paths.js';
 
-export function migrationStrategyForRouteControllers(projectRoot) {
+export function migrationStrategyForRouteControllers(options) {
+  const { projectRoot } = options;
+
   /*
     Case 1: Didn't pass the --pod flag, but configured { usePods: true } in .ember-cli
   */

--- a/src/migration/ember-app/tests/route-routes.js
+++ b/src/migration/ember-app/tests/route-routes.js
@@ -1,22 +1,26 @@
 import glob from 'glob';
+import { join } from 'node:path';
 
 import { mapPaths } from '../../../utils/map-paths.js';
 
 export function migrationStrategyForRouteRoutes(options) {
-  const { projectRoot } = options;
+  const { podPath, projectRoot } = options;
 
   /*
     Case 1: Didn't pass the --pod flag, but configured { usePods: true } in .ember-cli
   */
-  const oldPaths1 = glob.sync('tests/unit/!(routes)/**/route-test.{js,ts}', {
-    cwd: projectRoot,
-  });
+  const oldPaths1 = glob.sync(
+    join('tests/unit', podPath, '!(routes)', '**', 'route-test.{js,ts}'),
+    {
+      cwd: projectRoot,
+    }
+  );
 
   const newPaths1 = oldPaths1.map((oldPath) => {
     if (oldPath.endsWith('.ts')) {
       return mapPaths(oldPath, {
         find: {
-          directory: 'tests/unit',
+          directory: join('tests/unit', podPath),
           file: 'route-test.ts',
         },
         replace(key) {
@@ -27,7 +31,7 @@ export function migrationStrategyForRouteRoutes(options) {
 
     return mapPaths(oldPath, {
       find: {
-        directory: 'tests/unit',
+        directory: join('tests/unit', podPath),
         file: 'route-test.js',
       },
       replace(key) {
@@ -39,15 +43,18 @@ export function migrationStrategyForRouteRoutes(options) {
   /*
     Case 2: Passed the --pod flag to Ember CLI
   */
-  const oldPaths2 = glob.sync('tests/unit/routes/**/route-test.{js,ts}', {
-    cwd: projectRoot,
-  });
+  const oldPaths2 = glob.sync(
+    join('tests/unit', podPath, 'routes/**/route-test.{js,ts}'),
+    {
+      cwd: projectRoot,
+    }
+  );
 
   const newPaths2 = oldPaths2.map((oldPath) => {
     if (oldPath.endsWith('.ts')) {
       return mapPaths(oldPath, {
         find: {
-          directory: 'tests/unit/routes',
+          directory: join('tests/unit', podPath, 'routes'),
           file: 'route-test.ts',
         },
         replace(key) {
@@ -58,7 +65,7 @@ export function migrationStrategyForRouteRoutes(options) {
 
     return mapPaths(oldPath, {
       find: {
-        directory: 'tests/unit/routes',
+        directory: join('tests/unit', podPath, 'routes'),
         file: 'route-test.js',
       },
       replace(key) {

--- a/src/migration/ember-app/tests/route-routes.js
+++ b/src/migration/ember-app/tests/route-routes.js
@@ -2,7 +2,9 @@ import glob from 'glob';
 
 import { mapPaths } from '../../../utils/map-paths.js';
 
-export function migrationStrategyForRouteRoutes(projectRoot) {
+export function migrationStrategyForRouteRoutes(options) {
+  const { projectRoot } = options;
+
   /*
     Case 1: Didn't pass the --pod flag, but configured { usePods: true } in .ember-cli
   */

--- a/src/migration/ember-app/tests/services.js
+++ b/src/migration/ember-app/tests/services.js
@@ -2,7 +2,9 @@ import glob from 'glob';
 
 import { mapPaths } from '../../../utils/map-paths.js';
 
-export function migrationStrategyForServices(projectRoot) {
+export function migrationStrategyForServices(options) {
+  const { projectRoot } = options;
+
   const oldPaths = glob.sync('tests/unit/!(services)/**/service-test.{js,ts}', {
     cwd: projectRoot,
   });

--- a/src/migration/ember-app/tests/services.js
+++ b/src/migration/ember-app/tests/services.js
@@ -1,19 +1,23 @@
 import glob from 'glob';
+import { join } from 'node:path';
 
 import { mapPaths } from '../../../utils/map-paths.js';
 
 export function migrationStrategyForServices(options) {
-  const { projectRoot } = options;
+  const { podPath, projectRoot } = options;
 
-  const oldPaths = glob.sync('tests/unit/!(services)/**/service-test.{js,ts}', {
-    cwd: projectRoot,
-  });
+  const oldPaths = glob.sync(
+    join('tests/unit', podPath, '!(services)', '**', 'service-test.{js,ts}'),
+    {
+      cwd: projectRoot,
+    }
+  );
 
   return oldPaths.map((oldPath) => {
     if (oldPath.endsWith('.ts')) {
       return mapPaths(oldPath, {
         find: {
-          directory: 'tests/unit',
+          directory: join('tests/unit', podPath),
           file: 'service-test.ts',
         },
         replace(key) {
@@ -24,7 +28,7 @@ export function migrationStrategyForServices(options) {
 
     return mapPaths(oldPath, {
       find: {
-        directory: 'tests/unit',
+        directory: join('tests/unit', podPath),
         file: 'service-test.js',
       },
       replace(key) {

--- a/src/migration/ember-engine/addon/component-classes.js
+++ b/src/migration/ember-engine/addon/component-classes.js
@@ -2,7 +2,9 @@ import glob from 'glob';
 
 import { mapPaths } from '../../../utils/map-paths.js';
 
-export function migrationStrategyForComponentClasses(projectRoot) {
+export function migrationStrategyForComponentClasses(options) {
+  const { projectRoot } = options;
+
   const oldPaths = glob.sync('addon/components/**/component.{d.ts,js,ts}', {
     cwd: projectRoot,
   });

--- a/src/migration/ember-engine/addon/component-stylesheets.js
+++ b/src/migration/ember-engine/addon/component-stylesheets.js
@@ -2,7 +2,9 @@ import glob from 'glob';
 
 import { mapPaths } from '../../../utils/map-paths.js';
 
-export function migrationStrategyForComponentStylesheets(projectRoot) {
+export function migrationStrategyForComponentStylesheets(options) {
+  const { projectRoot } = options;
+
   const oldPaths = glob.sync('addon/components/**/styles.{css,scss}', {
     cwd: projectRoot,
   });

--- a/src/migration/ember-engine/addon/component-templates.js
+++ b/src/migration/ember-engine/addon/component-templates.js
@@ -2,7 +2,9 @@ import glob from 'glob';
 
 import { mapPaths } from '../../../utils/map-paths.js';
 
-export function migrationStrategyForComponentTemplates(projectRoot) {
+export function migrationStrategyForComponentTemplates(options) {
+  const { projectRoot } = options;
+
   const oldPaths = glob.sync('addon/components/**/template.hbs', {
     cwd: projectRoot,
   });

--- a/src/migration/ember-engine/addon/index.js
+++ b/src/migration/ember-engine/addon/index.js
@@ -6,14 +6,14 @@ import { migrationStrategyForRouteRoutes } from './route-routes.js';
 import { migrationStrategyForRouteStylesheets } from './route-stylesheets.js';
 import { migrationStrategyForRouteTemplates } from './route-templates.js';
 
-export function migrationStrategyForAddonFolder(projectRoot) {
+export function migrationStrategyForAddonFolder(options) {
   return new Map([
-    ...migrationStrategyForComponentClasses(projectRoot),
-    ...migrationStrategyForComponentStylesheets(projectRoot),
-    ...migrationStrategyForComponentTemplates(projectRoot),
-    ...migrationStrategyForRouteControllers(projectRoot),
-    ...migrationStrategyForRouteRoutes(projectRoot),
-    ...migrationStrategyForRouteStylesheets(projectRoot),
-    ...migrationStrategyForRouteTemplates(projectRoot),
+    ...migrationStrategyForComponentClasses(options),
+    ...migrationStrategyForComponentStylesheets(options),
+    ...migrationStrategyForComponentTemplates(options),
+    ...migrationStrategyForRouteControllers(options),
+    ...migrationStrategyForRouteRoutes(options),
+    ...migrationStrategyForRouteStylesheets(options),
+    ...migrationStrategyForRouteTemplates(options),
   ]);
 }

--- a/src/migration/ember-engine/addon/route-controllers.js
+++ b/src/migration/ember-engine/addon/route-controllers.js
@@ -2,7 +2,9 @@ import glob from 'glob';
 
 import { mapPaths } from '../../../utils/map-paths.js';
 
-export function migrationStrategyForRouteControllers(projectRoot) {
+export function migrationStrategyForRouteControllers(options) {
+  const { projectRoot } = options;
+
   const oldPaths = glob.sync('addon/**/controller.{js,ts}', {
     cwd: projectRoot,
   });

--- a/src/migration/ember-engine/addon/route-routes.js
+++ b/src/migration/ember-engine/addon/route-routes.js
@@ -2,7 +2,9 @@ import glob from 'glob';
 
 import { mapPaths } from '../../../utils/map-paths.js';
 
-export function migrationStrategyForRouteRoutes(projectRoot) {
+export function migrationStrategyForRouteRoutes(options) {
+  const { projectRoot } = options;
+
   const oldPaths = glob.sync('addon/**/route.{js,ts}', {
     cwd: projectRoot,
   });

--- a/src/migration/ember-engine/addon/route-stylesheets.js
+++ b/src/migration/ember-engine/addon/route-stylesheets.js
@@ -2,7 +2,9 @@ import glob from 'glob';
 
 import { mapPaths } from '../../../utils/map-paths.js';
 
-export function migrationStrategyForRouteStylesheets(projectRoot) {
+export function migrationStrategyForRouteStylesheets(options) {
+  const { projectRoot } = options;
+
   const oldPaths = glob.sync('addon/!(components)/**/styles.{css,scss}', {
     cwd: projectRoot,
   });

--- a/src/migration/ember-engine/addon/route-templates.js
+++ b/src/migration/ember-engine/addon/route-templates.js
@@ -2,7 +2,9 @@ import glob from 'glob';
 
 import { mapPaths } from '../../../utils/map-paths.js';
 
-export function migrationStrategyForRouteTemplates(projectRoot) {
+export function migrationStrategyForRouteTemplates(options) {
+  const { projectRoot } = options;
+
   const oldPaths = glob.sync('addon/!(components)/**/template.hbs', {
     cwd: projectRoot,
   });

--- a/src/migration/ember-engine/index.js
+++ b/src/migration/ember-engine/index.js
@@ -3,12 +3,10 @@ import { migrationStrategyForAddonFolder } from './addon/index.js';
 import { migrationStrategyForTestsFolder } from './tests/index.js';
 
 export function migrateEmberEngine(options) {
-  const { projectRoot, testRun } = options;
+  const migrationStrategyAddon = migrationStrategyForAddonFolder(options);
+  const migrationStrategyTests = migrationStrategyForTestsFolder(options);
 
-  const migrationStrategyAddon = migrationStrategyForAddonFolder(projectRoot);
-  const migrationStrategyTests = migrationStrategyForTestsFolder(projectRoot);
-
-  if (testRun) {
+  if (options.testRun) {
     console.log({
       migrationStrategyAddon,
       migrationStrategyTests,
@@ -17,13 +15,6 @@ export function migrateEmberEngine(options) {
     return;
   }
 
-  moveFiles({
-    migrationStrategy: migrationStrategyAddon,
-    projectRoot,
-  });
-
-  moveFiles({
-    migrationStrategy: migrationStrategyTests,
-    projectRoot,
-  });
+  moveFiles(migrationStrategyAddon, options);
+  moveFiles(migrationStrategyTests, options);
 }

--- a/src/migration/ember-engine/tests/components.js
+++ b/src/migration/ember-engine/tests/components.js
@@ -2,7 +2,9 @@ import glob from 'glob';
 
 import { mapPaths } from '../../../utils/map-paths.js';
 
-export function migrationStrategyForComponents(projectRoot) {
+export function migrationStrategyForComponents(options) {
+  const { projectRoot } = options;
+
   const oldPaths = glob.sync(
     'tests/integration/components/**/component-test.{js,ts}',
     {

--- a/src/migration/ember-engine/tests/index.js
+++ b/src/migration/ember-engine/tests/index.js
@@ -2,10 +2,10 @@ import { migrationStrategyForComponents } from './components.js';
 import { migrationStrategyForRouteControllers } from './route-controllers.js';
 import { migrationStrategyForRouteRoutes } from './route-routes.js';
 
-export function migrationStrategyForTestsFolder(projectRoot) {
+export function migrationStrategyForTestsFolder(options) {
   return new Map([
-    ...migrationStrategyForComponents(projectRoot),
-    ...migrationStrategyForRouteControllers(projectRoot),
-    ...migrationStrategyForRouteRoutes(projectRoot),
+    ...migrationStrategyForComponents(options),
+    ...migrationStrategyForRouteControllers(options),
+    ...migrationStrategyForRouteRoutes(options),
   ]);
 }

--- a/src/migration/ember-engine/tests/route-controllers.js
+++ b/src/migration/ember-engine/tests/route-controllers.js
@@ -2,7 +2,9 @@ import glob from 'glob';
 
 import { mapPaths } from '../../../utils/map-paths.js';
 
-export function migrationStrategyForRouteControllers(projectRoot) {
+export function migrationStrategyForRouteControllers(options) {
+  const { projectRoot } = options;
+
   /*
     Case 1: Didn't pass the --pod flag, but configured { usePods: true } in .ember-cli
   */

--- a/src/migration/ember-engine/tests/route-routes.js
+++ b/src/migration/ember-engine/tests/route-routes.js
@@ -2,7 +2,9 @@ import glob from 'glob';
 
 import { mapPaths } from '../../../utils/map-paths.js';
 
-export function migrationStrategyForRouteRoutes(projectRoot) {
+export function migrationStrategyForRouteRoutes(options) {
+  const { projectRoot } = options;
+
   /*
     Case 1: Didn't pass the --pod flag, but configured { usePods: true } in .ember-cli
   */

--- a/src/utils/ember-addon/app/components.js
+++ b/src/utils/ember-addon/app/components.js
@@ -1,7 +1,9 @@
 import { readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
-export function updatePaths({ migrationStrategy, projectRoot }) {
+export function updatePaths(migrationStrategy, options) {
+  const { projectRoot } = options;
+
   migrationStrategy.forEach((newPath, oldPath) => {
     // Read file
     const newAbsolutePath = join(projectRoot, newPath);

--- a/src/utils/move-files.js
+++ b/src/utils/move-files.js
@@ -7,7 +7,9 @@ import {
 } from 'node:fs';
 import { dirname, join } from 'node:path';
 
-export function moveFiles({ migrationStrategy, projectRoot }) {
+export function moveFiles(migrationStrategy, options) {
+  const { projectRoot } = options;
+
   migrationStrategy.forEach((newPath, oldPath) => {
     const oldAbsolutePath = join(projectRoot, oldPath);
     const oldDirectory = dirname(oldAbsolutePath);

--- a/tests/fixtures/app-pod-path.js
+++ b/tests/fixtures/app-pod-path.js
@@ -1,0 +1,451 @@
+const inputProject = {
+  app: {
+    pods: {
+      application: {
+        'adapter.js': '',
+        'route.js': '',
+        'serializer.js': '',
+        'styles.css': '',
+        'template.hbs': '',
+      },
+
+      components: {
+        'navigation-menu': {
+          'styles.css': '',
+          'template.hbs': '',
+        },
+
+        product: {
+          card: {
+            'styles.css': '',
+            'template.hbs': '',
+          },
+
+          details: {
+            'component.js': '',
+            'styles.scss': '',
+            'template.hbs': '',
+          },
+
+          image: {
+            'component.js': '',
+            'styles.css': '',
+            'template.hbs': '',
+          },
+        },
+
+        ui: {
+          form: {
+            checkbox: {
+              'component.js': '',
+              'styles.css': '',
+              'template.hbs': '',
+            },
+
+            field: {
+              'styles.css': '',
+              'template.hbs': '',
+            },
+
+            information: {
+              'styles.css': '',
+              'template.hbs': '',
+            },
+
+            input: {
+              'component.js': '',
+              'styles.css': '',
+              'template.hbs': '',
+            },
+
+            number: {
+              'component.js': '',
+              'styles.css': '',
+              'template.hbs': '',
+            },
+
+            select: {
+              'component.js': '',
+              'styles.css': '',
+              'template.hbs': '',
+            },
+
+            textarea: {
+              'component.js': '',
+              'styles.css': '',
+              'template.hbs': '',
+            },
+
+            'component.js': '',
+            'styles.css': '',
+            'template.hbs': '',
+          },
+
+          page: {
+            'styles.scss': '',
+            'template.hbs': '',
+          },
+        },
+      },
+
+      config: {
+        'service.js': '',
+      },
+
+      experiments: {
+        'service.js': '',
+      },
+
+      form: {
+        'controller.js': '',
+        'route.js': '',
+        'styles.css': '',
+        'template.hbs': '',
+      },
+
+      index: {
+        'route.js': '',
+        'styles.css': '',
+        'template.hbs': '',
+      },
+
+      product: {
+        'model.js': '',
+      },
+
+      'product-details': {
+        'route.js': '',
+        'styles.css': '',
+        'template.hbs': '',
+      },
+
+      products: {
+        product: {
+          'route.js': '',
+          'styles.scss': '',
+          'template.hbs': '',
+        },
+
+        'controller.js': '',
+        'route.js': '',
+        'styles.scss': '',
+        'template.hbs': '',
+      },
+    },
+
+    styles: {
+      'app.css': '',
+    },
+  },
+
+  tests: {
+    integration: {
+      pods: {
+        components: {
+          'navigation-menu': {
+            'component-test.js': '',
+          },
+
+          product: {
+            card: {
+              'component-test.js': '',
+            },
+
+            details: {
+              'component-test.js': '',
+            },
+
+            image: {
+              'component-test.js': '',
+            },
+          },
+
+          ui: {
+            form: {
+              checkbox: {
+                'component-test.js': '',
+              },
+
+              field: {
+                'component-test.js': '',
+              },
+
+              information: {
+                'component-test.js': '',
+              },
+
+              input: {
+                'component-test.js': '',
+              },
+
+              number: {
+                'component-test.js': '',
+              },
+
+              select: {
+                'component-test.js': '',
+              },
+
+              textarea: {
+                'component-test.js': '',
+              },
+
+              'component-test.js': '',
+            },
+
+            page: {
+              'component-test.js': '',
+            },
+          },
+        },
+      },
+    },
+
+    unit: {
+      pods: {
+        application: {
+          'route-test.js': '',
+        },
+
+        controllers: {
+          form: {
+            'controller-test.js': '',
+          },
+
+          products: {
+            'controller-test.js': '',
+          },
+        },
+
+        config: {
+          'service-test.js': '',
+        },
+
+        experiments: {
+          'service-test.js': '',
+        },
+
+        form: {
+          'controller-test.js': '',
+          'route-test.js': '',
+        },
+
+        index: {
+          'route-test.js': '',
+        },
+
+        'product-details': {
+          'route-test.js': '',
+        },
+
+        products: {
+          product: {
+            'route-test.js': '',
+          },
+
+          'controller-test.js': '',
+          'route-test.js': '',
+        },
+
+        routes: {
+          application: {
+            'route-test.js': '',
+          },
+
+          form: {
+            'route-test.js': '',
+          },
+
+          index: {
+            'route-test.js': '',
+          },
+
+          'product-details': {
+            'route-test.js': '',
+          },
+
+          products: {
+            product: {
+              'route-test.js': '',
+            },
+
+            'route-test.js': '',
+          },
+        },
+      },
+    },
+  },
+};
+
+const outputProject = {
+  app: {
+    adapters: {
+      'application.js': '',
+    },
+
+    components: {
+      'navigation-menu.css': '',
+      'navigation-menu.hbs': '',
+
+      product: {
+        'card.css': '',
+        'card.hbs': '',
+
+        'details.hbs': '',
+        'details.js': '',
+        'details.scss': '',
+
+        'image.css': '',
+        'image.hbs': '',
+        'image.js': '',
+      },
+
+      ui: {
+        form: {
+          'checkbox.css': '',
+          'checkbox.hbs': '',
+          'checkbox.js': '',
+
+          'field.css': '',
+          'field.hbs': '',
+
+          'information.css': '',
+          'information.hbs': '',
+
+          'input.css': '',
+          'input.hbs': '',
+          'input.js': '',
+
+          'number.css': '',
+          'number.hbs': '',
+          'number.js': '',
+
+          'select.css': '',
+          'select.hbs': '',
+          'select.js': '',
+
+          'textarea.css': '',
+          'textarea.hbs': '',
+          'textarea.js': '',
+        },
+
+        'form.css': '',
+        'form.hbs': '',
+        'form.js': '',
+
+        'page.hbs': '',
+        'page.scss': '',
+      },
+    },
+
+    controllers: {
+      'form.js': '',
+      'products.js': '',
+    },
+
+    models: {
+      'product.js': '',
+    },
+
+    routes: {
+      products: {
+        'product.js': '',
+      },
+
+      'application.js': '',
+      'form.js': '',
+      'index.js': '',
+      'product-details.js': '',
+      'products.js': '',
+    },
+
+    serializers: {
+      'application.js': '',
+    },
+
+    services: {
+      'config.js': '',
+      'experiments.js': '',
+    },
+
+    styles: {
+      products: {
+        'product.scss': '',
+      },
+
+      'app.css': '',
+      'application.css': '',
+      'form.css': '',
+      'index.css': '',
+      'product-details.css': '',
+      'products.scss': '',
+    },
+
+    templates: {
+      products: {
+        'product.hbs': '',
+      },
+
+      'application.hbs': '',
+      'form.hbs': '',
+      'index.hbs': '',
+      'product-details.hbs': '',
+      'products.hbs': '',
+    },
+  },
+
+  tests: {
+    integration: {
+      components: {
+        product: {
+          'card-test.js': '',
+          'details-test.js': '',
+          'image-test.js': '',
+        },
+
+        ui: {
+          form: {
+            'checkbox-test.js': '',
+            'field-test.js': '',
+            'information-test.js': '',
+            'input-test.js': '',
+            'number-test.js': '',
+            'select-test.js': '',
+            'textarea-test.js': '',
+          },
+
+          'form-test.js': '',
+          'page-test.js': '',
+        },
+
+        'navigation-menu-test.js': '',
+      },
+    },
+
+    unit: {
+      controllers: {
+        'form-test.js': '',
+        'products-test.js': '',
+      },
+
+      routes: {
+        products: {
+          'product-test.js': '',
+        },
+
+        'application-test.js': '',
+        'form-test.js': '',
+        'index-test.js': '',
+        'product-details-test.js': '',
+        'products-test.js': '',
+      },
+
+      services: {
+        'config-test.js': '',
+        'experiments-test.js': '',
+      },
+    },
+  },
+};
+
+export { inputProject, outputProject };

--- a/tests/migration/ember-addon/addon/component-classes/addon-javascript.test.js
+++ b/tests/migration/ember-addon/addon/component-classes/addon-javascript.test.js
@@ -2,12 +2,20 @@ import { migrationStrategyForComponentClasses } from '../../../../../src/migrati
 import { inputProject } from '../../../../fixtures/addon-javascript.js';
 import { assert, loadFixture, test } from '../../../../test-helpers.js';
 
-const projectRoot = 'tmp/addon-javascript';
-
 test('migration | ember-addon | addon | component-classes > JavaScript', function () {
-  loadFixture(projectRoot, inputProject);
+  const options = {
+    podPath: '',
+    projectRoot: 'tmp/addon-javascript',
+    testRun: false,
+  };
 
-  assert.deepStrictEqual(migrationStrategyForComponentClasses(projectRoot), [
+  loadFixture(inputProject, options);
+
+  const migrationStrategy = migrationStrategyForComponentClasses(
+    options.projectRoot
+  );
+
+  assert.deepStrictEqual(migrationStrategy, [
     [
       'addon/components/ui/form/checkbox/component.js',
       'addon/components/ui/form/checkbox.js',

--- a/tests/migration/ember-addon/addon/component-classes/addon-javascript.test.js
+++ b/tests/migration/ember-addon/addon/component-classes/addon-javascript.test.js
@@ -11,9 +11,7 @@ test('migration | ember-addon | addon | component-classes > JavaScript', functio
 
   loadFixture(inputProject, options);
 
-  const migrationStrategy = migrationStrategyForComponentClasses(
-    options.projectRoot
-  );
+  const migrationStrategy = migrationStrategyForComponentClasses(options);
 
   assert.deepStrictEqual(migrationStrategy, [
     [

--- a/tests/migration/ember-addon/addon/component-classes/addon-typescript.test.js
+++ b/tests/migration/ember-addon/addon/component-classes/addon-typescript.test.js
@@ -2,12 +2,20 @@ import { migrationStrategyForComponentClasses } from '../../../../../src/migrati
 import { inputProject } from '../../../../fixtures/addon-typescript.js';
 import { assert, loadFixture, test } from '../../../../test-helpers.js';
 
-const projectRoot = 'tmp/addon-typescript';
-
 test('migration | ember-addon | addon | component-classes > TypeScript', function () {
-  loadFixture(projectRoot, inputProject);
+  const options = {
+    podPath: '',
+    projectRoot: 'tmp/addon-typescript',
+    testRun: false,
+  };
 
-  assert.deepStrictEqual(migrationStrategyForComponentClasses(projectRoot), [
+  loadFixture(inputProject, options);
+
+  const migrationStrategy = migrationStrategyForComponentClasses(
+    options.projectRoot
+  );
+
+  assert.deepStrictEqual(migrationStrategy, [
     [
       'addon/components/ui/form/checkbox/component.ts',
       'addon/components/ui/form/checkbox.ts',

--- a/tests/migration/ember-addon/addon/component-classes/addon-typescript.test.js
+++ b/tests/migration/ember-addon/addon/component-classes/addon-typescript.test.js
@@ -11,9 +11,7 @@ test('migration | ember-addon | addon | component-classes > TypeScript', functio
 
   loadFixture(inputProject, options);
 
-  const migrationStrategy = migrationStrategyForComponentClasses(
-    options.projectRoot
-  );
+  const migrationStrategy = migrationStrategyForComponentClasses(options);
 
   assert.deepStrictEqual(migrationStrategy, [
     [

--- a/tests/migration/ember-addon/addon/component-stylesheets/addon-javascript.test.js
+++ b/tests/migration/ember-addon/addon/component-stylesheets/addon-javascript.test.js
@@ -11,9 +11,7 @@ test('migration | ember-addon | addon | component-stylesheets > JavaScript', fun
 
   loadFixture(inputProject, options);
 
-  const migrationStrategy = migrationStrategyForComponentStylesheets(
-    options.projectRoot
-  );
+  const migrationStrategy = migrationStrategyForComponentStylesheets(options);
 
   assert.deepStrictEqual(migrationStrategy, [
     [

--- a/tests/migration/ember-addon/addon/component-stylesheets/addon-javascript.test.js
+++ b/tests/migration/ember-addon/addon/component-stylesheets/addon-javascript.test.js
@@ -2,44 +2,49 @@ import { migrationStrategyForComponentStylesheets } from '../../../../../src/mig
 import { inputProject } from '../../../../fixtures/addon-javascript.js';
 import { assert, loadFixture, test } from '../../../../test-helpers.js';
 
-const projectRoot = 'tmp/addon-javascript';
-
 test('migration | ember-addon | addon | component-stylesheets > JavaScript', function () {
-  loadFixture(projectRoot, inputProject);
+  const options = {
+    podPath: '',
+    projectRoot: 'tmp/addon-javascript',
+    testRun: false,
+  };
 
-  assert.deepStrictEqual(
-    migrationStrategyForComponentStylesheets(projectRoot),
-    [
-      [
-        'addon/components/ui/form/checkbox/styles.css',
-        'addon/components/ui/form/checkbox.css',
-      ],
-      [
-        'addon/components/ui/form/field/styles.css',
-        'addon/components/ui/form/field.css',
-      ],
-      [
-        'addon/components/ui/form/information/styles.css',
-        'addon/components/ui/form/information.css',
-      ],
-      [
-        'addon/components/ui/form/input/styles.css',
-        'addon/components/ui/form/input.css',
-      ],
-      [
-        'addon/components/ui/form/number/styles.css',
-        'addon/components/ui/form/number.css',
-      ],
-      [
-        'addon/components/ui/form/select/styles.css',
-        'addon/components/ui/form/select.css',
-      ],
-      ['addon/components/ui/form/styles.css', 'addon/components/ui/form.css'],
-      [
-        'addon/components/ui/form/textarea/styles.css',
-        'addon/components/ui/form/textarea.css',
-      ],
-      ['addon/components/ui/page/styles.scss', 'addon/components/ui/page.scss'],
-    ]
+  loadFixture(inputProject, options);
+
+  const migrationStrategy = migrationStrategyForComponentStylesheets(
+    options.projectRoot
   );
+
+  assert.deepStrictEqual(migrationStrategy, [
+    [
+      'addon/components/ui/form/checkbox/styles.css',
+      'addon/components/ui/form/checkbox.css',
+    ],
+    [
+      'addon/components/ui/form/field/styles.css',
+      'addon/components/ui/form/field.css',
+    ],
+    [
+      'addon/components/ui/form/information/styles.css',
+      'addon/components/ui/form/information.css',
+    ],
+    [
+      'addon/components/ui/form/input/styles.css',
+      'addon/components/ui/form/input.css',
+    ],
+    [
+      'addon/components/ui/form/number/styles.css',
+      'addon/components/ui/form/number.css',
+    ],
+    [
+      'addon/components/ui/form/select/styles.css',
+      'addon/components/ui/form/select.css',
+    ],
+    ['addon/components/ui/form/styles.css', 'addon/components/ui/form.css'],
+    [
+      'addon/components/ui/form/textarea/styles.css',
+      'addon/components/ui/form/textarea.css',
+    ],
+    ['addon/components/ui/page/styles.scss', 'addon/components/ui/page.scss'],
+  ]);
 });

--- a/tests/migration/ember-addon/addon/component-stylesheets/addon-typescript.test.js
+++ b/tests/migration/ember-addon/addon/component-stylesheets/addon-typescript.test.js
@@ -2,44 +2,49 @@ import { migrationStrategyForComponentStylesheets } from '../../../../../src/mig
 import { inputProject } from '../../../../fixtures/addon-typescript.js';
 import { assert, loadFixture, test } from '../../../../test-helpers.js';
 
-const projectRoot = 'tmp/addon-typescript';
-
 test('migration | ember-addon | addon | component-stylesheets > TypeScript', function () {
-  loadFixture(projectRoot, inputProject);
+  const options = {
+    podPath: '',
+    projectRoot: 'tmp/addon-typescript',
+    testRun: false,
+  };
 
-  assert.deepStrictEqual(
-    migrationStrategyForComponentStylesheets(projectRoot),
-    [
-      [
-        'addon/components/ui/form/checkbox/styles.css',
-        'addon/components/ui/form/checkbox.css',
-      ],
-      [
-        'addon/components/ui/form/field/styles.css',
-        'addon/components/ui/form/field.css',
-      ],
-      [
-        'addon/components/ui/form/information/styles.css',
-        'addon/components/ui/form/information.css',
-      ],
-      [
-        'addon/components/ui/form/input/styles.css',
-        'addon/components/ui/form/input.css',
-      ],
-      [
-        'addon/components/ui/form/number/styles.css',
-        'addon/components/ui/form/number.css',
-      ],
-      [
-        'addon/components/ui/form/select/styles.css',
-        'addon/components/ui/form/select.css',
-      ],
-      ['addon/components/ui/form/styles.css', 'addon/components/ui/form.css'],
-      [
-        'addon/components/ui/form/textarea/styles.css',
-        'addon/components/ui/form/textarea.css',
-      ],
-      ['addon/components/ui/page/styles.scss', 'addon/components/ui/page.scss'],
-    ]
+  loadFixture(inputProject, options);
+
+  const migrationStrategy = migrationStrategyForComponentStylesheets(
+    options.projectRoot
   );
+
+  assert.deepStrictEqual(migrationStrategy, [
+    [
+      'addon/components/ui/form/checkbox/styles.css',
+      'addon/components/ui/form/checkbox.css',
+    ],
+    [
+      'addon/components/ui/form/field/styles.css',
+      'addon/components/ui/form/field.css',
+    ],
+    [
+      'addon/components/ui/form/information/styles.css',
+      'addon/components/ui/form/information.css',
+    ],
+    [
+      'addon/components/ui/form/input/styles.css',
+      'addon/components/ui/form/input.css',
+    ],
+    [
+      'addon/components/ui/form/number/styles.css',
+      'addon/components/ui/form/number.css',
+    ],
+    [
+      'addon/components/ui/form/select/styles.css',
+      'addon/components/ui/form/select.css',
+    ],
+    ['addon/components/ui/form/styles.css', 'addon/components/ui/form.css'],
+    [
+      'addon/components/ui/form/textarea/styles.css',
+      'addon/components/ui/form/textarea.css',
+    ],
+    ['addon/components/ui/page/styles.scss', 'addon/components/ui/page.scss'],
+  ]);
 });

--- a/tests/migration/ember-addon/addon/component-stylesheets/addon-typescript.test.js
+++ b/tests/migration/ember-addon/addon/component-stylesheets/addon-typescript.test.js
@@ -11,9 +11,7 @@ test('migration | ember-addon | addon | component-stylesheets > TypeScript', fun
 
   loadFixture(inputProject, options);
 
-  const migrationStrategy = migrationStrategyForComponentStylesheets(
-    options.projectRoot
-  );
+  const migrationStrategy = migrationStrategyForComponentStylesheets(options);
 
   assert.deepStrictEqual(migrationStrategy, [
     [

--- a/tests/migration/ember-addon/addon/component-templates/addon-javascript.test.js
+++ b/tests/migration/ember-addon/addon/component-templates/addon-javascript.test.js
@@ -11,9 +11,7 @@ test('migration | ember-addon | addon | component-templates > JavaScript', funct
 
   loadFixture(inputProject, options);
 
-  const migrationStrategy = migrationStrategyForComponentTemplates(
-    options.projectRoot
-  );
+  const migrationStrategy = migrationStrategyForComponentTemplates(options);
 
   assert.deepStrictEqual(migrationStrategy, [
     [

--- a/tests/migration/ember-addon/addon/component-templates/addon-javascript.test.js
+++ b/tests/migration/ember-addon/addon/component-templates/addon-javascript.test.js
@@ -2,12 +2,20 @@ import { migrationStrategyForComponentTemplates } from '../../../../../src/migra
 import { inputProject } from '../../../../fixtures/addon-javascript.js';
 import { assert, loadFixture, test } from '../../../../test-helpers.js';
 
-const projectRoot = 'tmp/addon-javascript';
-
 test('migration | ember-addon | addon | component-templates > JavaScript', function () {
-  loadFixture(projectRoot, inputProject);
+  const options = {
+    podPath: '',
+    projectRoot: 'tmp/addon-javascript',
+    testRun: false,
+  };
 
-  assert.deepStrictEqual(migrationStrategyForComponentTemplates(projectRoot), [
+  loadFixture(inputProject, options);
+
+  const migrationStrategy = migrationStrategyForComponentTemplates(
+    options.projectRoot
+  );
+
+  assert.deepStrictEqual(migrationStrategy, [
     [
       'addon/components/ui/form/checkbox/template.hbs',
       'addon/components/ui/form/checkbox.hbs',

--- a/tests/migration/ember-addon/addon/component-templates/addon-typescript.test.js
+++ b/tests/migration/ember-addon/addon/component-templates/addon-typescript.test.js
@@ -11,9 +11,7 @@ test('migration | ember-addon | addon | component-templates > TypeScript', funct
 
   loadFixture(inputProject, options);
 
-  const migrationStrategy = migrationStrategyForComponentTemplates(
-    options.projectRoot
-  );
+  const migrationStrategy = migrationStrategyForComponentTemplates(options);
 
   assert.deepStrictEqual(migrationStrategy, [
     [

--- a/tests/migration/ember-addon/addon/component-templates/addon-typescript.test.js
+++ b/tests/migration/ember-addon/addon/component-templates/addon-typescript.test.js
@@ -2,12 +2,20 @@ import { migrationStrategyForComponentTemplates } from '../../../../../src/migra
 import { inputProject } from '../../../../fixtures/addon-typescript.js';
 import { assert, loadFixture, test } from '../../../../test-helpers.js';
 
-const projectRoot = 'tmp/addon-typescript';
-
 test('migration | ember-addon | addon | component-templates > TypeScript', function () {
-  loadFixture(projectRoot, inputProject);
+  const options = {
+    podPath: '',
+    projectRoot: 'tmp/addon-typescript',
+    testRun: false,
+  };
 
-  assert.deepStrictEqual(migrationStrategyForComponentTemplates(projectRoot), [
+  loadFixture(inputProject, options);
+
+  const migrationStrategy = migrationStrategyForComponentTemplates(
+    options.projectRoot
+  );
+
+  assert.deepStrictEqual(migrationStrategy, [
     [
       'addon/components/ui/form/checkbox/template.hbs',
       'addon/components/ui/form/checkbox.hbs',

--- a/tests/migration/ember-addon/app/component-classes/addon-javascript.test.js
+++ b/tests/migration/ember-addon/app/component-classes/addon-javascript.test.js
@@ -11,9 +11,7 @@ test('migration | ember-addon | app | component-classes > JavaScript', function 
 
   loadFixture(inputProject, options);
 
-  const migrationStrategy = migrationStrategyForComponentClasses(
-    options.projectRoot
-  );
+  const migrationStrategy = migrationStrategyForComponentClasses(options);
 
   assert.deepStrictEqual(migrationStrategy, [
     [

--- a/tests/migration/ember-addon/app/component-classes/addon-javascript.test.js
+++ b/tests/migration/ember-addon/app/component-classes/addon-javascript.test.js
@@ -2,12 +2,20 @@ import { migrationStrategyForComponentClasses } from '../../../../../src/migrati
 import { inputProject } from '../../../../fixtures/addon-javascript.js';
 import { assert, loadFixture, test } from '../../../../test-helpers.js';
 
-const projectRoot = 'tmp/addon-javascript';
-
 test('migration | ember-addon | app | component-classes > JavaScript', function () {
-  loadFixture(projectRoot, inputProject);
+  const options = {
+    podPath: '',
+    projectRoot: 'tmp/addon-javascript',
+    testRun: false,
+  };
 
-  assert.deepStrictEqual(migrationStrategyForComponentClasses(projectRoot), [
+  loadFixture(inputProject, options);
+
+  const migrationStrategy = migrationStrategyForComponentClasses(
+    options.projectRoot
+  );
+
+  assert.deepStrictEqual(migrationStrategy, [
     [
       'app/components/ui/form/checkbox/component.js',
       'app/components/ui/form/checkbox.js',

--- a/tests/migration/ember-addon/app/component-classes/addon-typescript.test.js
+++ b/tests/migration/ember-addon/app/component-classes/addon-typescript.test.js
@@ -11,9 +11,7 @@ test('migration | ember-addon | app | component-classes > TypeScript', function 
 
   loadFixture(inputProject, options);
 
-  const migrationStrategy = migrationStrategyForComponentClasses(
-    options.projectRoot
-  );
+  const migrationStrategy = migrationStrategyForComponentClasses(options);
 
   assert.deepStrictEqual(migrationStrategy, [
     [

--- a/tests/migration/ember-addon/app/component-classes/addon-typescript.test.js
+++ b/tests/migration/ember-addon/app/component-classes/addon-typescript.test.js
@@ -2,12 +2,20 @@ import { migrationStrategyForComponentClasses } from '../../../../../src/migrati
 import { inputProject } from '../../../../fixtures/addon-typescript.js';
 import { assert, loadFixture, test } from '../../../../test-helpers.js';
 
-const projectRoot = 'tmp/addon-typescript';
-
 test('migration | ember-addon | app | component-classes > TypeScript', function () {
-  loadFixture(projectRoot, inputProject);
+  const options = {
+    podPath: '',
+    projectRoot: 'tmp/addon-typescript',
+    testRun: false,
+  };
 
-  assert.deepStrictEqual(migrationStrategyForComponentClasses(projectRoot), [
+  loadFixture(inputProject, options);
+
+  const migrationStrategy = migrationStrategyForComponentClasses(
+    options.projectRoot
+  );
+
+  assert.deepStrictEqual(migrationStrategy, [
     [
       'app/components/ui/form/checkbox/component.js',
       'app/components/ui/form/checkbox.js',

--- a/tests/migration/ember-addon/app/component-stylesheets/addon-javascript.test.js
+++ b/tests/migration/ember-addon/app/component-stylesheets/addon-javascript.test.js
@@ -2,23 +2,28 @@ import { migrationStrategyForComponentStylesheets } from '../../../../../src/mig
 import { inputProject } from '../../../../fixtures/addon-javascript.js';
 import { assert, loadFixture, test } from '../../../../test-helpers.js';
 
-const projectRoot = 'tmp/addon-javascript';
-
 test('migration | ember-addon | app | component-stylesheets > JavaScript', function () {
-  loadFixture(projectRoot, inputProject);
+  const options = {
+    podPath: '',
+    projectRoot: 'tmp/addon-javascript',
+    testRun: false,
+  };
 
-  assert.deepStrictEqual(
-    migrationStrategyForComponentStylesheets(projectRoot),
-    [
-      [
-        'app/components/ui/form/field/styles.js',
-        'app/components/ui/form/field.js',
-      ],
-      [
-        'app/components/ui/form/information/styles.js',
-        'app/components/ui/form/information.js',
-      ],
-      ['app/components/ui/form/styles.js', 'app/components/ui/form.js'],
-    ]
+  loadFixture(inputProject, options);
+
+  const migrationStrategy = migrationStrategyForComponentStylesheets(
+    options.projectRoot
   );
+
+  assert.deepStrictEqual(migrationStrategy, [
+    [
+      'app/components/ui/form/field/styles.js',
+      'app/components/ui/form/field.js',
+    ],
+    [
+      'app/components/ui/form/information/styles.js',
+      'app/components/ui/form/information.js',
+    ],
+    ['app/components/ui/form/styles.js', 'app/components/ui/form.js'],
+  ]);
 });

--- a/tests/migration/ember-addon/app/component-stylesheets/addon-javascript.test.js
+++ b/tests/migration/ember-addon/app/component-stylesheets/addon-javascript.test.js
@@ -11,9 +11,7 @@ test('migration | ember-addon | app | component-stylesheets > JavaScript', funct
 
   loadFixture(inputProject, options);
 
-  const migrationStrategy = migrationStrategyForComponentStylesheets(
-    options.projectRoot
-  );
+  const migrationStrategy = migrationStrategyForComponentStylesheets(options);
 
   assert.deepStrictEqual(migrationStrategy, [
     [

--- a/tests/migration/ember-addon/app/component-stylesheets/addon-typescript.test.js
+++ b/tests/migration/ember-addon/app/component-stylesheets/addon-typescript.test.js
@@ -11,9 +11,7 @@ test('migration | ember-addon | app | component-stylesheets > TypeScript', funct
 
   loadFixture(inputProject, options);
 
-  const migrationStrategy = migrationStrategyForComponentStylesheets(
-    options.projectRoot
-  );
+  const migrationStrategy = migrationStrategyForComponentStylesheets(options);
 
   assert.deepStrictEqual(migrationStrategy, [
     [

--- a/tests/migration/ember-addon/app/component-stylesheets/addon-typescript.test.js
+++ b/tests/migration/ember-addon/app/component-stylesheets/addon-typescript.test.js
@@ -2,23 +2,28 @@ import { migrationStrategyForComponentStylesheets } from '../../../../../src/mig
 import { inputProject } from '../../../../fixtures/addon-typescript.js';
 import { assert, loadFixture, test } from '../../../../test-helpers.js';
 
-const projectRoot = 'tmp/addon-typescript';
-
 test('migration | ember-addon | app | component-stylesheets > TypeScript', function () {
-  loadFixture(projectRoot, inputProject);
+  const options = {
+    podPath: '',
+    projectRoot: 'tmp/addon-typescript',
+    testRun: false,
+  };
 
-  assert.deepStrictEqual(
-    migrationStrategyForComponentStylesheets(projectRoot),
-    [
-      [
-        'app/components/ui/form/field/styles.js',
-        'app/components/ui/form/field.js',
-      ],
-      [
-        'app/components/ui/form/information/styles.js',
-        'app/components/ui/form/information.js',
-      ],
-      ['app/components/ui/form/styles.js', 'app/components/ui/form.js'],
-    ]
+  loadFixture(inputProject, options);
+
+  const migrationStrategy = migrationStrategyForComponentStylesheets(
+    options.projectRoot
   );
+
+  assert.deepStrictEqual(migrationStrategy, [
+    [
+      'app/components/ui/form/field/styles.js',
+      'app/components/ui/form/field.js',
+    ],
+    [
+      'app/components/ui/form/information/styles.js',
+      'app/components/ui/form/information.js',
+    ],
+    ['app/components/ui/form/styles.js', 'app/components/ui/form.js'],
+  ]);
 });

--- a/tests/migration/ember-addon/app/component-templates/addon-javascript.test.js
+++ b/tests/migration/ember-addon/app/component-templates/addon-javascript.test.js
@@ -2,12 +2,20 @@ import { migrationStrategyForComponentTemplates } from '../../../../../src/migra
 import { inputProject } from '../../../../fixtures/addon-javascript.js';
 import { assert, loadFixture, test } from '../../../../test-helpers.js';
 
-const projectRoot = 'tmp/addon-javascript';
-
 test('migration | ember-addon | app | component-templates > JavaScript', function () {
-  loadFixture(projectRoot, inputProject);
+  const options = {
+    podPath: '',
+    projectRoot: 'tmp/addon-javascript',
+    testRun: false,
+  };
 
-  assert.deepStrictEqual(migrationStrategyForComponentTemplates(projectRoot), [
+  loadFixture(inputProject, options);
+
+  const migrationStrategy = migrationStrategyForComponentTemplates(
+    options.projectRoot
+  );
+
+  assert.deepStrictEqual(migrationStrategy, [
     [
       'app/components/ui/form/checkbox/template.js',
       'app/components/ui/form/checkbox.js',

--- a/tests/migration/ember-addon/app/component-templates/addon-javascript.test.js
+++ b/tests/migration/ember-addon/app/component-templates/addon-javascript.test.js
@@ -11,9 +11,7 @@ test('migration | ember-addon | app | component-templates > JavaScript', functio
 
   loadFixture(inputProject, options);
 
-  const migrationStrategy = migrationStrategyForComponentTemplates(
-    options.projectRoot
-  );
+  const migrationStrategy = migrationStrategyForComponentTemplates(options);
 
   assert.deepStrictEqual(migrationStrategy, [
     [

--- a/tests/migration/ember-addon/app/component-templates/addon-typescript.test.js
+++ b/tests/migration/ember-addon/app/component-templates/addon-typescript.test.js
@@ -11,9 +11,7 @@ test('migration | ember-addon | app | component-templates > TypeScript', functio
 
   loadFixture(inputProject, options);
 
-  const migrationStrategy = migrationStrategyForComponentTemplates(
-    options.projectRoot
-  );
+  const migrationStrategy = migrationStrategyForComponentTemplates(options);
 
   assert.deepStrictEqual(migrationStrategy, [
     [

--- a/tests/migration/ember-addon/app/component-templates/addon-typescript.test.js
+++ b/tests/migration/ember-addon/app/component-templates/addon-typescript.test.js
@@ -2,12 +2,20 @@ import { migrationStrategyForComponentTemplates } from '../../../../../src/migra
 import { inputProject } from '../../../../fixtures/addon-typescript.js';
 import { assert, loadFixture, test } from '../../../../test-helpers.js';
 
-const projectRoot = 'tmp/addon-typescript';
-
 test('migration | ember-addon | app | component-templates > TypeScript', function () {
-  loadFixture(projectRoot, inputProject);
+  const options = {
+    podPath: '',
+    projectRoot: 'tmp/addon-typescript',
+    testRun: false,
+  };
 
-  assert.deepStrictEqual(migrationStrategyForComponentTemplates(projectRoot), [
+  loadFixture(inputProject, options);
+
+  const migrationStrategy = migrationStrategyForComponentTemplates(
+    options.projectRoot
+  );
+
+  assert.deepStrictEqual(migrationStrategy, [
     [
       'app/components/ui/form/checkbox/template.js',
       'app/components/ui/form/checkbox.js',

--- a/tests/migration/ember-addon/index/addon-javascript.test.js
+++ b/tests/migration/ember-addon/index/addon-javascript.test.js
@@ -5,23 +5,21 @@ import {
 } from '../../../fixtures/addon-javascript.js';
 import { assertFixture, loadFixture, test } from '../../../test-helpers.js';
 
-const projectRoot = 'tmp/addon-javascript';
-
 test('migration | ember-addon | index > JavaScript', function () {
-  loadFixture(projectRoot, inputProject);
-
-  migrateEmberAddon({
-    projectRoot,
+  const options = {
+    podPath: '',
+    projectRoot: 'tmp/addon-javascript',
     testRun: false,
-  });
+  };
 
-  assertFixture(projectRoot, outputProject);
+  loadFixture(inputProject, options);
+
+  migrateEmberAddon(options);
+
+  assertFixture(outputProject, options);
 
   // Check idempotence
-  migrateEmberAddon({
-    projectRoot,
-    testRun: false,
-  });
+  migrateEmberAddon(options);
 
-  assertFixture(projectRoot, outputProject);
+  assertFixture(outputProject, options);
 });

--- a/tests/migration/ember-addon/index/addon-typescript.test.js
+++ b/tests/migration/ember-addon/index/addon-typescript.test.js
@@ -5,23 +5,21 @@ import {
 } from '../../../fixtures/addon-typescript.js';
 import { assertFixture, loadFixture, test } from '../../../test-helpers.js';
 
-const projectRoot = 'tmp/addon-typescript';
-
 test('migration | ember-addon | index > TypeScript', function () {
-  loadFixture(projectRoot, inputProject);
-
-  migrateEmberAddon({
-    projectRoot,
+  const options = {
+    podPath: '',
+    projectRoot: 'tmp/addon-typescript',
     testRun: false,
-  });
+  };
 
-  assertFixture(projectRoot, outputProject);
+  loadFixture(inputProject, options);
+
+  migrateEmberAddon(options);
+
+  assertFixture(outputProject, options);
 
   // Check idempotence
-  migrateEmberAddon({
-    projectRoot,
-    testRun: false,
-  });
+  migrateEmberAddon(options);
 
-  assertFixture(projectRoot, outputProject);
+  assertFixture(outputProject, options);
 });

--- a/tests/migration/ember-addon/tests/components/addon-javascript.test.js
+++ b/tests/migration/ember-addon/tests/components/addon-javascript.test.js
@@ -2,12 +2,18 @@ import { migrationStrategyForComponents } from '../../../../../src/migration/emb
 import { inputProject } from '../../../../fixtures/addon-javascript.js';
 import { assert, loadFixture, test } from '../../../../test-helpers.js';
 
-const projectRoot = 'tmp/addon-javascript';
-
 test('migration | ember-addon | tests | components > JavaScript', function () {
-  loadFixture(projectRoot, inputProject);
+  const options = {
+    podPath: '',
+    projectRoot: 'tmp/addon-javascript',
+    testRun: false,
+  };
 
-  assert.deepStrictEqual(migrationStrategyForComponents(projectRoot), [
+  loadFixture(inputProject, options);
+
+  const migrationStrategy = migrationStrategyForComponents(options.projectRoot);
+
+  assert.deepStrictEqual(migrationStrategy, [
     [
       'tests/integration/components/ui/form/checkbox/component-test.js',
       'tests/integration/components/ui/form/checkbox-test.js',

--- a/tests/migration/ember-addon/tests/components/addon-javascript.test.js
+++ b/tests/migration/ember-addon/tests/components/addon-javascript.test.js
@@ -11,7 +11,7 @@ test('migration | ember-addon | tests | components > JavaScript', function () {
 
   loadFixture(inputProject, options);
 
-  const migrationStrategy = migrationStrategyForComponents(options.projectRoot);
+  const migrationStrategy = migrationStrategyForComponents(options);
 
   assert.deepStrictEqual(migrationStrategy, [
     [

--- a/tests/migration/ember-addon/tests/components/addon-typescript.test.js
+++ b/tests/migration/ember-addon/tests/components/addon-typescript.test.js
@@ -11,7 +11,7 @@ test('migration | ember-addon | tests | components > TypeScript', function () {
 
   loadFixture(inputProject, options);
 
-  const migrationStrategy = migrationStrategyForComponents(options.projectRoot);
+  const migrationStrategy = migrationStrategyForComponents(options);
 
   assert.deepStrictEqual(migrationStrategy, [
     [

--- a/tests/migration/ember-addon/tests/components/addon-typescript.test.js
+++ b/tests/migration/ember-addon/tests/components/addon-typescript.test.js
@@ -2,12 +2,18 @@ import { migrationStrategyForComponents } from '../../../../../src/migration/emb
 import { inputProject } from '../../../../fixtures/addon-typescript.js';
 import { assert, loadFixture, test } from '../../../../test-helpers.js';
 
-const projectRoot = 'tmp/addon-typescript';
-
 test('migration | ember-addon | tests | components > TypeScript', function () {
-  loadFixture(projectRoot, inputProject);
+  const options = {
+    podPath: '',
+    projectRoot: 'tmp/addon-typescript',
+    testRun: false,
+  };
 
-  assert.deepStrictEqual(migrationStrategyForComponents(projectRoot), [
+  loadFixture(inputProject, options);
+
+  const migrationStrategy = migrationStrategyForComponents(options.projectRoot);
+
+  assert.deepStrictEqual(migrationStrategy, [
     [
       'tests/integration/components/ui/form/checkbox/component-test.ts',
       'tests/integration/components/ui/form/checkbox-test.ts',

--- a/tests/migration/ember-app/app/component-classes/app-javascript.test.js
+++ b/tests/migration/ember-app/app/component-classes/app-javascript.test.js
@@ -2,12 +2,20 @@ import { migrationStrategyForComponentClasses } from '../../../../../src/migrati
 import { inputProject } from '../../../../fixtures/app-javascript.js';
 import { assert, loadFixture, test } from '../../../../test-helpers.js';
 
-const projectRoot = 'tmp/app-javascript';
-
 test('migration | ember-app | app | component-classes > JavaScript', function () {
-  loadFixture(projectRoot, inputProject);
+  const options = {
+    podPath: '',
+    projectRoot: 'tmp/app-javascript',
+    testRun: false,
+  };
 
-  assert.deepStrictEqual(migrationStrategyForComponentClasses(projectRoot), [
+  loadFixture(inputProject, options);
+
+  const migrationStrategy = migrationStrategyForComponentClasses(
+    options.projectRoot
+  );
+
+  assert.deepStrictEqual(migrationStrategy, [
     [
       'app/components/product/details/component.js',
       'app/components/product/details.js',

--- a/tests/migration/ember-app/app/component-classes/app-javascript.test.js
+++ b/tests/migration/ember-app/app/component-classes/app-javascript.test.js
@@ -11,9 +11,7 @@ test('migration | ember-app | app | component-classes > JavaScript', function ()
 
   loadFixture(inputProject, options);
 
-  const migrationStrategy = migrationStrategyForComponentClasses(
-    options.projectRoot
-  );
+  const migrationStrategy = migrationStrategyForComponentClasses(options);
 
   assert.deepStrictEqual(migrationStrategy, [
     [

--- a/tests/migration/ember-app/app/component-classes/app-pod-path.test.js
+++ b/tests/migration/ember-app/app/component-classes/app-pod-path.test.js
@@ -1,0 +1,47 @@
+import { migrationStrategyForComponentClasses } from '../../../../../src/migration/ember-app/app/component-classes.js';
+import { inputProject } from '../../../../fixtures/app-pod-path.js';
+import { assert, loadFixture, test } from '../../../../test-helpers.js';
+
+test('migration | ember-app | app | component-classes > podPath', function () {
+  const options = {
+    podPath: 'pods',
+    projectRoot: 'tmp/app-pod-path',
+    testRun: false,
+  };
+
+  loadFixture(inputProject, options);
+
+  const migrationStrategy = migrationStrategyForComponentClasses(options);
+
+  assert.deepStrictEqual(migrationStrategy, [
+    [
+      'app/pods/components/product/details/component.js',
+      'app/components/product/details.js',
+    ],
+    [
+      'app/pods/components/product/image/component.js',
+      'app/components/product/image.js',
+    ],
+    [
+      'app/pods/components/ui/form/checkbox/component.js',
+      'app/components/ui/form/checkbox.js',
+    ],
+    ['app/pods/components/ui/form/component.js', 'app/components/ui/form.js'],
+    [
+      'app/pods/components/ui/form/input/component.js',
+      'app/components/ui/form/input.js',
+    ],
+    [
+      'app/pods/components/ui/form/number/component.js',
+      'app/components/ui/form/number.js',
+    ],
+    [
+      'app/pods/components/ui/form/select/component.js',
+      'app/components/ui/form/select.js',
+    ],
+    [
+      'app/pods/components/ui/form/textarea/component.js',
+      'app/components/ui/form/textarea.js',
+    ],
+  ]);
+});

--- a/tests/migration/ember-app/app/component-classes/app-typescript.test.js
+++ b/tests/migration/ember-app/app/component-classes/app-typescript.test.js
@@ -11,9 +11,7 @@ test('migration | ember-app | app | component-classes > TypeScript', function ()
 
   loadFixture(inputProject, options);
 
-  const migrationStrategy = migrationStrategyForComponentClasses(
-    options.projectRoot
-  );
+  const migrationStrategy = migrationStrategyForComponentClasses(options);
 
   assert.deepStrictEqual(migrationStrategy, [
     [

--- a/tests/migration/ember-app/app/component-classes/app-typescript.test.js
+++ b/tests/migration/ember-app/app/component-classes/app-typescript.test.js
@@ -2,12 +2,20 @@ import { migrationStrategyForComponentClasses } from '../../../../../src/migrati
 import { inputProject } from '../../../../fixtures/app-typescript.js';
 import { assert, loadFixture, test } from '../../../../test-helpers.js';
 
-const projectRoot = 'tmp/app-typescript';
-
 test('migration | ember-app | app | component-classes > TypeScript', function () {
-  loadFixture(projectRoot, inputProject);
+  const options = {
+    podPath: '',
+    projectRoot: 'tmp/app-typescript',
+    testRun: false,
+  };
 
-  assert.deepStrictEqual(migrationStrategyForComponentClasses(projectRoot), [
+  loadFixture(inputProject, options);
+
+  const migrationStrategy = migrationStrategyForComponentClasses(
+    options.projectRoot
+  );
+
+  assert.deepStrictEqual(migrationStrategy, [
     [
       'app/components/navigation-menu/component.d.ts',
       'app/components/navigation-menu.d.ts',

--- a/tests/migration/ember-app/app/component-stylesheets/app-javascript.test.js
+++ b/tests/migration/ember-app/app/component-stylesheets/app-javascript.test.js
@@ -11,9 +11,7 @@ test('migration | ember-app | app | component-stylesheets > JavaScript', functio
 
   loadFixture(inputProject, options);
 
-  const migrationStrategy = migrationStrategyForComponentStylesheets(
-    options.projectRoot
-  );
+  const migrationStrategy = migrationStrategyForComponentStylesheets(options);
 
   assert.deepStrictEqual(migrationStrategy, [
     [

--- a/tests/migration/ember-app/app/component-stylesheets/app-javascript.test.js
+++ b/tests/migration/ember-app/app/component-stylesheets/app-javascript.test.js
@@ -2,60 +2,65 @@ import { migrationStrategyForComponentStylesheets } from '../../../../../src/mig
 import { inputProject } from '../../../../fixtures/app-javascript.js';
 import { assert, loadFixture, test } from '../../../../test-helpers.js';
 
-const projectRoot = 'tmp/app-javascript';
-
 test('migration | ember-app | app | component-stylesheets > JavaScript', function () {
-  loadFixture(projectRoot, inputProject);
+  const options = {
+    podPath: '',
+    projectRoot: 'tmp/app-javascript',
+    testRun: false,
+  };
 
-  assert.deepStrictEqual(
-    migrationStrategyForComponentStylesheets(projectRoot),
-    [
-      [
-        'app/components/navigation-menu/styles.css',
-        'app/components/navigation-menu.css',
-      ],
-      [
-        'app/components/product/card/styles.css',
-        'app/components/product/card.css',
-      ],
-      [
-        'app/components/product/details/styles.scss',
-        'app/components/product/details.scss',
-      ],
-      [
-        'app/components/product/image/styles.css',
-        'app/components/product/image.css',
-      ],
-      [
-        'app/components/ui/form/checkbox/styles.css',
-        'app/components/ui/form/checkbox.css',
-      ],
-      [
-        'app/components/ui/form/field/styles.css',
-        'app/components/ui/form/field.css',
-      ],
-      [
-        'app/components/ui/form/information/styles.css',
-        'app/components/ui/form/information.css',
-      ],
-      [
-        'app/components/ui/form/input/styles.css',
-        'app/components/ui/form/input.css',
-      ],
-      [
-        'app/components/ui/form/number/styles.css',
-        'app/components/ui/form/number.css',
-      ],
-      [
-        'app/components/ui/form/select/styles.css',
-        'app/components/ui/form/select.css',
-      ],
-      ['app/components/ui/form/styles.css', 'app/components/ui/form.css'],
-      [
-        'app/components/ui/form/textarea/styles.css',
-        'app/components/ui/form/textarea.css',
-      ],
-      ['app/components/ui/page/styles.scss', 'app/components/ui/page.scss'],
-    ]
+  loadFixture(inputProject, options);
+
+  const migrationStrategy = migrationStrategyForComponentStylesheets(
+    options.projectRoot
   );
+
+  assert.deepStrictEqual(migrationStrategy, [
+    [
+      'app/components/navigation-menu/styles.css',
+      'app/components/navigation-menu.css',
+    ],
+    [
+      'app/components/product/card/styles.css',
+      'app/components/product/card.css',
+    ],
+    [
+      'app/components/product/details/styles.scss',
+      'app/components/product/details.scss',
+    ],
+    [
+      'app/components/product/image/styles.css',
+      'app/components/product/image.css',
+    ],
+    [
+      'app/components/ui/form/checkbox/styles.css',
+      'app/components/ui/form/checkbox.css',
+    ],
+    [
+      'app/components/ui/form/field/styles.css',
+      'app/components/ui/form/field.css',
+    ],
+    [
+      'app/components/ui/form/information/styles.css',
+      'app/components/ui/form/information.css',
+    ],
+    [
+      'app/components/ui/form/input/styles.css',
+      'app/components/ui/form/input.css',
+    ],
+    [
+      'app/components/ui/form/number/styles.css',
+      'app/components/ui/form/number.css',
+    ],
+    [
+      'app/components/ui/form/select/styles.css',
+      'app/components/ui/form/select.css',
+    ],
+    ['app/components/ui/form/styles.css', 'app/components/ui/form.css'],
+    [
+      'app/components/ui/form/textarea/styles.css',
+      'app/components/ui/form/textarea.css',
+    ],
+    ['app/components/ui/page/styles.scss', 'app/components/ui/page.scss'],
+  ]);
 });

--- a/tests/migration/ember-app/app/component-stylesheets/app-pod-path.test.js
+++ b/tests/migration/ember-app/app/component-stylesheets/app-pod-path.test.js
@@ -1,0 +1,64 @@
+import { migrationStrategyForComponentStylesheets } from '../../../../../src/migration/ember-app/app/component-stylesheets.js';
+import { inputProject } from '../../../../fixtures/app-pod-path.js';
+import { assert, loadFixture, test } from '../../../../test-helpers.js';
+
+test('migration | ember-app | app | component-stylesheets > podPath', function () {
+  const options = {
+    podPath: 'pods',
+    projectRoot: 'tmp/app-pod-path',
+    testRun: false,
+  };
+
+  loadFixture(inputProject, options);
+
+  const migrationStrategy = migrationStrategyForComponentStylesheets(options);
+
+  assert.deepStrictEqual(migrationStrategy, [
+    [
+      'app/pods/components/navigation-menu/styles.css',
+      'app/components/navigation-menu.css',
+    ],
+    [
+      'app/pods/components/product/card/styles.css',
+      'app/components/product/card.css',
+    ],
+    [
+      'app/pods/components/product/details/styles.scss',
+      'app/components/product/details.scss',
+    ],
+    [
+      'app/pods/components/product/image/styles.css',
+      'app/components/product/image.css',
+    ],
+    [
+      'app/pods/components/ui/form/checkbox/styles.css',
+      'app/components/ui/form/checkbox.css',
+    ],
+    [
+      'app/pods/components/ui/form/field/styles.css',
+      'app/components/ui/form/field.css',
+    ],
+    [
+      'app/pods/components/ui/form/information/styles.css',
+      'app/components/ui/form/information.css',
+    ],
+    [
+      'app/pods/components/ui/form/input/styles.css',
+      'app/components/ui/form/input.css',
+    ],
+    [
+      'app/pods/components/ui/form/number/styles.css',
+      'app/components/ui/form/number.css',
+    ],
+    [
+      'app/pods/components/ui/form/select/styles.css',
+      'app/components/ui/form/select.css',
+    ],
+    ['app/pods/components/ui/form/styles.css', 'app/components/ui/form.css'],
+    [
+      'app/pods/components/ui/form/textarea/styles.css',
+      'app/components/ui/form/textarea.css',
+    ],
+    ['app/pods/components/ui/page/styles.scss', 'app/components/ui/page.scss'],
+  ]);
+});

--- a/tests/migration/ember-app/app/component-stylesheets/app-typescript.test.js
+++ b/tests/migration/ember-app/app/component-stylesheets/app-typescript.test.js
@@ -11,9 +11,7 @@ test('migration | ember-app | app | component-stylesheets > TypeScript', functio
 
   loadFixture(inputProject, options);
 
-  const migrationStrategy = migrationStrategyForComponentStylesheets(
-    options.projectRoot
-  );
+  const migrationStrategy = migrationStrategyForComponentStylesheets(options);
 
   assert.deepStrictEqual(migrationStrategy, [
     [

--- a/tests/migration/ember-app/app/component-stylesheets/app-typescript.test.js
+++ b/tests/migration/ember-app/app/component-stylesheets/app-typescript.test.js
@@ -2,60 +2,65 @@ import { migrationStrategyForComponentStylesheets } from '../../../../../src/mig
 import { inputProject } from '../../../../fixtures/app-typescript.js';
 import { assert, loadFixture, test } from '../../../../test-helpers.js';
 
-const projectRoot = 'tmp/app-typescript';
-
 test('migration | ember-app | app | component-stylesheets > TypeScript', function () {
-  loadFixture(projectRoot, inputProject);
+  const options = {
+    podPath: '',
+    projectRoot: 'tmp/app-typescript',
+    testRun: false,
+  };
 
-  assert.deepStrictEqual(
-    migrationStrategyForComponentStylesheets(projectRoot),
-    [
-      [
-        'app/components/navigation-menu/styles.css',
-        'app/components/navigation-menu.css',
-      ],
-      [
-        'app/components/product/card/styles.css',
-        'app/components/product/card.css',
-      ],
-      [
-        'app/components/product/details/styles.scss',
-        'app/components/product/details.scss',
-      ],
-      [
-        'app/components/product/image/styles.css',
-        'app/components/product/image.css',
-      ],
-      [
-        'app/components/ui/form/checkbox/styles.css',
-        'app/components/ui/form/checkbox.css',
-      ],
-      [
-        'app/components/ui/form/field/styles.css',
-        'app/components/ui/form/field.css',
-      ],
-      [
-        'app/components/ui/form/information/styles.css',
-        'app/components/ui/form/information.css',
-      ],
-      [
-        'app/components/ui/form/input/styles.css',
-        'app/components/ui/form/input.css',
-      ],
-      [
-        'app/components/ui/form/number/styles.css',
-        'app/components/ui/form/number.css',
-      ],
-      [
-        'app/components/ui/form/select/styles.css',
-        'app/components/ui/form/select.css',
-      ],
-      ['app/components/ui/form/styles.css', 'app/components/ui/form.css'],
-      [
-        'app/components/ui/form/textarea/styles.css',
-        'app/components/ui/form/textarea.css',
-      ],
-      ['app/components/ui/page/styles.scss', 'app/components/ui/page.scss'],
-    ]
+  loadFixture(inputProject, options);
+
+  const migrationStrategy = migrationStrategyForComponentStylesheets(
+    options.projectRoot
   );
+
+  assert.deepStrictEqual(migrationStrategy, [
+    [
+      'app/components/navigation-menu/styles.css',
+      'app/components/navigation-menu.css',
+    ],
+    [
+      'app/components/product/card/styles.css',
+      'app/components/product/card.css',
+    ],
+    [
+      'app/components/product/details/styles.scss',
+      'app/components/product/details.scss',
+    ],
+    [
+      'app/components/product/image/styles.css',
+      'app/components/product/image.css',
+    ],
+    [
+      'app/components/ui/form/checkbox/styles.css',
+      'app/components/ui/form/checkbox.css',
+    ],
+    [
+      'app/components/ui/form/field/styles.css',
+      'app/components/ui/form/field.css',
+    ],
+    [
+      'app/components/ui/form/information/styles.css',
+      'app/components/ui/form/information.css',
+    ],
+    [
+      'app/components/ui/form/input/styles.css',
+      'app/components/ui/form/input.css',
+    ],
+    [
+      'app/components/ui/form/number/styles.css',
+      'app/components/ui/form/number.css',
+    ],
+    [
+      'app/components/ui/form/select/styles.css',
+      'app/components/ui/form/select.css',
+    ],
+    ['app/components/ui/form/styles.css', 'app/components/ui/form.css'],
+    [
+      'app/components/ui/form/textarea/styles.css',
+      'app/components/ui/form/textarea.css',
+    ],
+    ['app/components/ui/page/styles.scss', 'app/components/ui/page.scss'],
+  ]);
 });

--- a/tests/migration/ember-app/app/component-templates/app-javascript.test.js
+++ b/tests/migration/ember-app/app/component-templates/app-javascript.test.js
@@ -11,9 +11,7 @@ test('migration | ember-app | app | component-templates > JavaScript', function 
 
   loadFixture(inputProject, options);
 
-  const migrationStrategy = migrationStrategyForComponentTemplates(
-    options.projectRoot
-  );
+  const migrationStrategy = migrationStrategyForComponentTemplates(options);
 
   assert.deepStrictEqual(migrationStrategy, [
     [

--- a/tests/migration/ember-app/app/component-templates/app-javascript.test.js
+++ b/tests/migration/ember-app/app/component-templates/app-javascript.test.js
@@ -2,12 +2,20 @@ import { migrationStrategyForComponentTemplates } from '../../../../../src/migra
 import { inputProject } from '../../../../fixtures/app-javascript.js';
 import { assert, loadFixture, test } from '../../../../test-helpers.js';
 
-const projectRoot = 'tmp/app-javascript';
-
 test('migration | ember-app | app | component-templates > JavaScript', function () {
-  loadFixture(projectRoot, inputProject);
+  const options = {
+    podPath: '',
+    projectRoot: 'tmp/app-javascript',
+    testRun: false,
+  };
 
-  assert.deepStrictEqual(migrationStrategyForComponentTemplates(projectRoot), [
+  loadFixture(inputProject, options);
+
+  const migrationStrategy = migrationStrategyForComponentTemplates(
+    options.projectRoot
+  );
+
+  assert.deepStrictEqual(migrationStrategy, [
     [
       'app/components/navigation-menu/template.hbs',
       'app/components/navigation-menu.hbs',

--- a/tests/migration/ember-app/app/component-templates/app-pod-path.test.js
+++ b/tests/migration/ember-app/app/component-templates/app-pod-path.test.js
@@ -1,0 +1,64 @@
+import { migrationStrategyForComponentTemplates } from '../../../../../src/migration/ember-app/app/component-templates.js';
+import { inputProject } from '../../../../fixtures/app-pod-path.js';
+import { assert, loadFixture, test } from '../../../../test-helpers.js';
+
+test('migration | ember-app | app | component-templates > podPath', function () {
+  const options = {
+    podPath: 'pods',
+    projectRoot: 'tmp/app-pod-path',
+    testRun: false,
+  };
+
+  loadFixture(inputProject, options);
+
+  const migrationStrategy = migrationStrategyForComponentTemplates(options);
+
+  assert.deepStrictEqual(migrationStrategy, [
+    [
+      'app/pods/components/navigation-menu/template.hbs',
+      'app/components/navigation-menu.hbs',
+    ],
+    [
+      'app/pods/components/product/card/template.hbs',
+      'app/components/product/card.hbs',
+    ],
+    [
+      'app/pods/components/product/details/template.hbs',
+      'app/components/product/details.hbs',
+    ],
+    [
+      'app/pods/components/product/image/template.hbs',
+      'app/components/product/image.hbs',
+    ],
+    [
+      'app/pods/components/ui/form/checkbox/template.hbs',
+      'app/components/ui/form/checkbox.hbs',
+    ],
+    [
+      'app/pods/components/ui/form/field/template.hbs',
+      'app/components/ui/form/field.hbs',
+    ],
+    [
+      'app/pods/components/ui/form/information/template.hbs',
+      'app/components/ui/form/information.hbs',
+    ],
+    [
+      'app/pods/components/ui/form/input/template.hbs',
+      'app/components/ui/form/input.hbs',
+    ],
+    [
+      'app/pods/components/ui/form/number/template.hbs',
+      'app/components/ui/form/number.hbs',
+    ],
+    [
+      'app/pods/components/ui/form/select/template.hbs',
+      'app/components/ui/form/select.hbs',
+    ],
+    ['app/pods/components/ui/form/template.hbs', 'app/components/ui/form.hbs'],
+    [
+      'app/pods/components/ui/form/textarea/template.hbs',
+      'app/components/ui/form/textarea.hbs',
+    ],
+    ['app/pods/components/ui/page/template.hbs', 'app/components/ui/page.hbs'],
+  ]);
+});

--- a/tests/migration/ember-app/app/component-templates/app-typescript.test.js
+++ b/tests/migration/ember-app/app/component-templates/app-typescript.test.js
@@ -11,9 +11,7 @@ test('migration | ember-app | app | component-templates > TypeScript', function 
 
   loadFixture(inputProject, options);
 
-  const migrationStrategy = migrationStrategyForComponentTemplates(
-    options.projectRoot
-  );
+  const migrationStrategy = migrationStrategyForComponentTemplates(options);
 
   assert.deepStrictEqual(migrationStrategy, [
     [

--- a/tests/migration/ember-app/app/component-templates/app-typescript.test.js
+++ b/tests/migration/ember-app/app/component-templates/app-typescript.test.js
@@ -2,12 +2,20 @@ import { migrationStrategyForComponentTemplates } from '../../../../../src/migra
 import { inputProject } from '../../../../fixtures/app-typescript.js';
 import { assert, loadFixture, test } from '../../../../test-helpers.js';
 
-const projectRoot = 'tmp/app-typescript';
-
 test('migration | ember-app | app | component-templates > TypeScript', function () {
-  loadFixture(projectRoot, inputProject);
+  const options = {
+    podPath: '',
+    projectRoot: 'tmp/app-typescript',
+    testRun: false,
+  };
 
-  assert.deepStrictEqual(migrationStrategyForComponentTemplates(projectRoot), [
+  loadFixture(inputProject, options);
+
+  const migrationStrategy = migrationStrategyForComponentTemplates(
+    options.projectRoot
+  );
+
+  assert.deepStrictEqual(migrationStrategy, [
     [
       'app/components/navigation-menu/template.hbs',
       'app/components/navigation-menu.hbs',

--- a/tests/migration/ember-app/app/route-adapters/app-javascript.test.js
+++ b/tests/migration/ember-app/app/route-adapters/app-javascript.test.js
@@ -2,12 +2,20 @@ import { migrationStrategyForRouteAdapters } from '../../../../../src/migration/
 import { inputProject } from '../../../../fixtures/app-javascript.js';
 import { assert, loadFixture, test } from '../../../../test-helpers.js';
 
-const projectRoot = 'tmp/app-javascript';
-
 test('migration | ember-app | app | route-adapters > JavaScript', function () {
-  loadFixture(projectRoot, inputProject);
+  const options = {
+    podPath: '',
+    projectRoot: 'tmp/app-javascript',
+    testRun: false,
+  };
 
-  assert.deepStrictEqual(migrationStrategyForRouteAdapters(projectRoot), [
+  loadFixture(inputProject, options);
+
+  const migrationStrategy = migrationStrategyForRouteAdapters(
+    options.projectRoot
+  );
+
+  assert.deepStrictEqual(migrationStrategy, [
     ['app/application/adapter.js', 'app/adapters/application.js'],
   ]);
 });

--- a/tests/migration/ember-app/app/route-adapters/app-javascript.test.js
+++ b/tests/migration/ember-app/app/route-adapters/app-javascript.test.js
@@ -11,9 +11,7 @@ test('migration | ember-app | app | route-adapters > JavaScript', function () {
 
   loadFixture(inputProject, options);
 
-  const migrationStrategy = migrationStrategyForRouteAdapters(
-    options.projectRoot
-  );
+  const migrationStrategy = migrationStrategyForRouteAdapters(options);
 
   assert.deepStrictEqual(migrationStrategy, [
     ['app/application/adapter.js', 'app/adapters/application.js'],

--- a/tests/migration/ember-app/app/route-adapters/app-pod-path.test.js
+++ b/tests/migration/ember-app/app/route-adapters/app-pod-path.test.js
@@ -1,0 +1,19 @@
+import { migrationStrategyForRouteAdapters } from '../../../../../src/migration/ember-app/app/route-adapters.js';
+import { inputProject } from '../../../../fixtures/app-pod-path.js';
+import { assert, loadFixture, test } from '../../../../test-helpers.js';
+
+test('migration | ember-app | app | route-adapters > podPath', function () {
+  const options = {
+    podPath: 'pods',
+    projectRoot: 'tmp/app-pod-path',
+    testRun: false,
+  };
+
+  loadFixture(inputProject, options);
+
+  const migrationStrategy = migrationStrategyForRouteAdapters(options);
+
+  assert.deepStrictEqual(migrationStrategy, [
+    ['app/pods/application/adapter.js', 'app/adapters/application.js'],
+  ]);
+});

--- a/tests/migration/ember-app/app/route-adapters/app-typescript.test.js
+++ b/tests/migration/ember-app/app/route-adapters/app-typescript.test.js
@@ -2,12 +2,20 @@ import { migrationStrategyForRouteAdapters } from '../../../../../src/migration/
 import { inputProject } from '../../../../fixtures/app-typescript.js';
 import { assert, loadFixture, test } from '../../../../test-helpers.js';
 
-const projectRoot = 'tmp/app-typescript';
-
 test('migration | ember-app | app | route-adapters > TypeScript', function () {
-  loadFixture(projectRoot, inputProject);
+  const options = {
+    podPath: '',
+    projectRoot: 'tmp/app-typescript',
+    testRun: false,
+  };
 
-  assert.deepStrictEqual(migrationStrategyForRouteAdapters(projectRoot), [
+  loadFixture(inputProject, options);
+
+  const migrationStrategy = migrationStrategyForRouteAdapters(
+    options.projectRoot
+  );
+
+  assert.deepStrictEqual(migrationStrategy, [
     ['app/application/adapter.ts', 'app/adapters/application.ts'],
   ]);
 });

--- a/tests/migration/ember-app/app/route-adapters/app-typescript.test.js
+++ b/tests/migration/ember-app/app/route-adapters/app-typescript.test.js
@@ -11,9 +11,7 @@ test('migration | ember-app | app | route-adapters > TypeScript', function () {
 
   loadFixture(inputProject, options);
 
-  const migrationStrategy = migrationStrategyForRouteAdapters(
-    options.projectRoot
-  );
+  const migrationStrategy = migrationStrategyForRouteAdapters(options);
 
   assert.deepStrictEqual(migrationStrategy, [
     ['app/application/adapter.ts', 'app/adapters/application.ts'],

--- a/tests/migration/ember-app/app/route-controllers/app-javascript.test.js
+++ b/tests/migration/ember-app/app/route-controllers/app-javascript.test.js
@@ -2,12 +2,20 @@ import { migrationStrategyForRouteControllers } from '../../../../../src/migrati
 import { inputProject } from '../../../../fixtures/app-javascript.js';
 import { assert, loadFixture, test } from '../../../../test-helpers.js';
 
-const projectRoot = 'tmp/app-javascript';
-
 test('migration | ember-app | app | route-controllers > JavaScript', function () {
-  loadFixture(projectRoot, inputProject);
+  const options = {
+    podPath: '',
+    projectRoot: 'tmp/app-javascript',
+    testRun: false,
+  };
 
-  assert.deepStrictEqual(migrationStrategyForRouteControllers(projectRoot), [
+  loadFixture(inputProject, options);
+
+  const migrationStrategy = migrationStrategyForRouteControllers(
+    options.projectRoot
+  );
+
+  assert.deepStrictEqual(migrationStrategy, [
     ['app/form/controller.js', 'app/controllers/form.js'],
     ['app/products/controller.js', 'app/controllers/products.js'],
   ]);

--- a/tests/migration/ember-app/app/route-controllers/app-javascript.test.js
+++ b/tests/migration/ember-app/app/route-controllers/app-javascript.test.js
@@ -11,9 +11,7 @@ test('migration | ember-app | app | route-controllers > JavaScript', function ()
 
   loadFixture(inputProject, options);
 
-  const migrationStrategy = migrationStrategyForRouteControllers(
-    options.projectRoot
-  );
+  const migrationStrategy = migrationStrategyForRouteControllers(options);
 
   assert.deepStrictEqual(migrationStrategy, [
     ['app/form/controller.js', 'app/controllers/form.js'],

--- a/tests/migration/ember-app/app/route-controllers/app-pod-path.test.js
+++ b/tests/migration/ember-app/app/route-controllers/app-pod-path.test.js
@@ -1,0 +1,20 @@
+import { migrationStrategyForRouteControllers } from '../../../../../src/migration/ember-app/app/route-controllers.js';
+import { inputProject } from '../../../../fixtures/app-pod-path.js';
+import { assert, loadFixture, test } from '../../../../test-helpers.js';
+
+test('migration | ember-app | app | route-controllers > podPath', function () {
+  const options = {
+    podPath: 'pods',
+    projectRoot: 'tmp/app-pod-path',
+    testRun: false,
+  };
+
+  loadFixture(inputProject, options);
+
+  const migrationStrategy = migrationStrategyForRouteControllers(options);
+
+  assert.deepStrictEqual(migrationStrategy, [
+    ['app/pods/form/controller.js', 'app/controllers/form.js'],
+    ['app/pods/products/controller.js', 'app/controllers/products.js'],
+  ]);
+});

--- a/tests/migration/ember-app/app/route-controllers/app-typescript.test.js
+++ b/tests/migration/ember-app/app/route-controllers/app-typescript.test.js
@@ -11,9 +11,7 @@ test('migration | ember-app | app | route-controllers > TypeScript', function ()
 
   loadFixture(inputProject, options);
 
-  const migrationStrategy = migrationStrategyForRouteControllers(
-    options.projectRoot
-  );
+  const migrationStrategy = migrationStrategyForRouteControllers(options);
 
   assert.deepStrictEqual(migrationStrategy, [
     ['app/form/controller.ts', 'app/controllers/form.ts'],

--- a/tests/migration/ember-app/app/route-controllers/app-typescript.test.js
+++ b/tests/migration/ember-app/app/route-controllers/app-typescript.test.js
@@ -2,12 +2,20 @@ import { migrationStrategyForRouteControllers } from '../../../../../src/migrati
 import { inputProject } from '../../../../fixtures/app-typescript.js';
 import { assert, loadFixture, test } from '../../../../test-helpers.js';
 
-const projectRoot = 'tmp/app-typescript';
-
 test('migration | ember-app | app | route-controllers > TypeScript', function () {
-  loadFixture(projectRoot, inputProject);
+  const options = {
+    podPath: '',
+    projectRoot: 'tmp/app-typescript',
+    testRun: false,
+  };
 
-  assert.deepStrictEqual(migrationStrategyForRouteControllers(projectRoot), [
+  loadFixture(inputProject, options);
+
+  const migrationStrategy = migrationStrategyForRouteControllers(
+    options.projectRoot
+  );
+
+  assert.deepStrictEqual(migrationStrategy, [
     ['app/form/controller.ts', 'app/controllers/form.ts'],
     ['app/products/controller.ts', 'app/controllers/products.ts'],
   ]);

--- a/tests/migration/ember-app/app/route-models/app-javascript.test.js
+++ b/tests/migration/ember-app/app/route-models/app-javascript.test.js
@@ -2,12 +2,20 @@ import { migrationStrategyForRouteModels } from '../../../../../src/migration/em
 import { inputProject } from '../../../../fixtures/app-javascript.js';
 import { assert, loadFixture, test } from '../../../../test-helpers.js';
 
-const projectRoot = 'tmp/app-javascript';
-
 test('migration | ember-app | app | route-models > JavaScript', function () {
-  loadFixture(projectRoot, inputProject);
+  const options = {
+    podPath: '',
+    projectRoot: 'tmp/app-javascript',
+    testRun: false,
+  };
 
-  assert.deepStrictEqual(migrationStrategyForRouteModels(projectRoot), [
+  loadFixture(inputProject, options);
+
+  const migrationStrategy = migrationStrategyForRouteModels(
+    options.projectRoot
+  );
+
+  assert.deepStrictEqual(migrationStrategy, [
     ['app/product/model.js', 'app/models/product.js'],
   ]);
 });

--- a/tests/migration/ember-app/app/route-models/app-javascript.test.js
+++ b/tests/migration/ember-app/app/route-models/app-javascript.test.js
@@ -11,9 +11,7 @@ test('migration | ember-app | app | route-models > JavaScript', function () {
 
   loadFixture(inputProject, options);
 
-  const migrationStrategy = migrationStrategyForRouteModels(
-    options.projectRoot
-  );
+  const migrationStrategy = migrationStrategyForRouteModels(options);
 
   assert.deepStrictEqual(migrationStrategy, [
     ['app/product/model.js', 'app/models/product.js'],

--- a/tests/migration/ember-app/app/route-models/app-pod-path.test.js
+++ b/tests/migration/ember-app/app/route-models/app-pod-path.test.js
@@ -1,0 +1,19 @@
+import { migrationStrategyForRouteModels } from '../../../../../src/migration/ember-app/app/route-models.js';
+import { inputProject } from '../../../../fixtures/app-pod-path.js';
+import { assert, loadFixture, test } from '../../../../test-helpers.js';
+
+test('migration | ember-app | app | route-models > podPath', function () {
+  const options = {
+    podPath: 'pods',
+    projectRoot: 'tmp/app-pod-path',
+    testRun: false,
+  };
+
+  loadFixture(inputProject, options);
+
+  const migrationStrategy = migrationStrategyForRouteModels(options);
+
+  assert.deepStrictEqual(migrationStrategy, [
+    ['app/pods/product/model.js', 'app/models/product.js'],
+  ]);
+});

--- a/tests/migration/ember-app/app/route-models/app-typescript.test.js
+++ b/tests/migration/ember-app/app/route-models/app-typescript.test.js
@@ -11,9 +11,7 @@ test('migration | ember-app | app | route-models > TypeScript', function () {
 
   loadFixture(inputProject, options);
 
-  const migrationStrategy = migrationStrategyForRouteModels(
-    options.projectRoot
-  );
+  const migrationStrategy = migrationStrategyForRouteModels(options);
 
   assert.deepStrictEqual(migrationStrategy, [
     ['app/product/model.ts', 'app/models/product.ts'],

--- a/tests/migration/ember-app/app/route-models/app-typescript.test.js
+++ b/tests/migration/ember-app/app/route-models/app-typescript.test.js
@@ -2,12 +2,20 @@ import { migrationStrategyForRouteModels } from '../../../../../src/migration/em
 import { inputProject } from '../../../../fixtures/app-typescript.js';
 import { assert, loadFixture, test } from '../../../../test-helpers.js';
 
-const projectRoot = 'tmp/app-typescript';
-
 test('migration | ember-app | app | route-models > TypeScript', function () {
-  loadFixture(projectRoot, inputProject);
+  const options = {
+    podPath: '',
+    projectRoot: 'tmp/app-typescript',
+    testRun: false,
+  };
 
-  assert.deepStrictEqual(migrationStrategyForRouteModels(projectRoot), [
+  loadFixture(inputProject, options);
+
+  const migrationStrategy = migrationStrategyForRouteModels(
+    options.projectRoot
+  );
+
+  assert.deepStrictEqual(migrationStrategy, [
     ['app/product/model.ts', 'app/models/product.ts'],
   ]);
 });

--- a/tests/migration/ember-app/app/route-routes/app-javascript.test.js
+++ b/tests/migration/ember-app/app/route-routes/app-javascript.test.js
@@ -2,12 +2,20 @@ import { migrationStrategyForRouteRoutes } from '../../../../../src/migration/em
 import { inputProject } from '../../../../fixtures/app-javascript.js';
 import { assert, loadFixture, test } from '../../../../test-helpers.js';
 
-const projectRoot = 'tmp/app-javascript';
-
 test('migration | ember-app | app | route-routes > JavaScript', function () {
-  loadFixture(projectRoot, inputProject);
+  const options = {
+    podPath: '',
+    projectRoot: 'tmp/app-javascript',
+    testRun: false,
+  };
 
-  assert.deepStrictEqual(migrationStrategyForRouteRoutes(projectRoot), [
+  loadFixture(inputProject, options);
+
+  const migrationStrategy = migrationStrategyForRouteRoutes(
+    options.projectRoot
+  );
+
+  assert.deepStrictEqual(migrationStrategy, [
     ['app/application/route.js', 'app/routes/application.js'],
     ['app/form/route.js', 'app/routes/form.js'],
     ['app/index/route.js', 'app/routes/index.js'],

--- a/tests/migration/ember-app/app/route-routes/app-javascript.test.js
+++ b/tests/migration/ember-app/app/route-routes/app-javascript.test.js
@@ -11,9 +11,7 @@ test('migration | ember-app | app | route-routes > JavaScript', function () {
 
   loadFixture(inputProject, options);
 
-  const migrationStrategy = migrationStrategyForRouteRoutes(
-    options.projectRoot
-  );
+  const migrationStrategy = migrationStrategyForRouteRoutes(options);
 
   assert.deepStrictEqual(migrationStrategy, [
     ['app/application/route.js', 'app/routes/application.js'],

--- a/tests/migration/ember-app/app/route-routes/app-pod-path.test.js
+++ b/tests/migration/ember-app/app/route-routes/app-pod-path.test.js
@@ -1,0 +1,24 @@
+import { migrationStrategyForRouteRoutes } from '../../../../../src/migration/ember-app/app/route-routes.js';
+import { inputProject } from '../../../../fixtures/app-pod-path.js';
+import { assert, loadFixture, test } from '../../../../test-helpers.js';
+
+test('migration | ember-app | app | route-routes > podPath', function () {
+  const options = {
+    podPath: 'pods',
+    projectRoot: 'tmp/app-pod-path',
+    testRun: false,
+  };
+
+  loadFixture(inputProject, options);
+
+  const migrationStrategy = migrationStrategyForRouteRoutes(options);
+
+  assert.deepStrictEqual(migrationStrategy, [
+    ['app/pods/application/route.js', 'app/routes/application.js'],
+    ['app/pods/form/route.js', 'app/routes/form.js'],
+    ['app/pods/index/route.js', 'app/routes/index.js'],
+    ['app/pods/product-details/route.js', 'app/routes/product-details.js'],
+    ['app/pods/products/product/route.js', 'app/routes/products/product.js'],
+    ['app/pods/products/route.js', 'app/routes/products.js'],
+  ]);
+});

--- a/tests/migration/ember-app/app/route-routes/app-typescript.test.js
+++ b/tests/migration/ember-app/app/route-routes/app-typescript.test.js
@@ -2,12 +2,20 @@ import { migrationStrategyForRouteRoutes } from '../../../../../src/migration/em
 import { inputProject } from '../../../../fixtures/app-typescript.js';
 import { assert, loadFixture, test } from '../../../../test-helpers.js';
 
-const projectRoot = 'tmp/app-typescript';
-
 test('migration | ember-app | app | route-routes > TypeScript', function () {
-  loadFixture(projectRoot, inputProject);
+  const options = {
+    podPath: '',
+    projectRoot: 'tmp/app-typescript',
+    testRun: false,
+  };
 
-  assert.deepStrictEqual(migrationStrategyForRouteRoutes(projectRoot), [
+  loadFixture(inputProject, options);
+
+  const migrationStrategy = migrationStrategyForRouteRoutes(
+    options.projectRoot
+  );
+
+  assert.deepStrictEqual(migrationStrategy, [
     ['app/application/route.ts', 'app/routes/application.ts'],
     ['app/form/route.ts', 'app/routes/form.ts'],
     ['app/index/route.ts', 'app/routes/index.ts'],

--- a/tests/migration/ember-app/app/route-routes/app-typescript.test.js
+++ b/tests/migration/ember-app/app/route-routes/app-typescript.test.js
@@ -11,9 +11,7 @@ test('migration | ember-app | app | route-routes > TypeScript', function () {
 
   loadFixture(inputProject, options);
 
-  const migrationStrategy = migrationStrategyForRouteRoutes(
-    options.projectRoot
-  );
+  const migrationStrategy = migrationStrategyForRouteRoutes(options);
 
   assert.deepStrictEqual(migrationStrategy, [
     ['app/application/route.ts', 'app/routes/application.ts'],

--- a/tests/migration/ember-app/app/route-serializers/app-javascript.test.js
+++ b/tests/migration/ember-app/app/route-serializers/app-javascript.test.js
@@ -2,12 +2,20 @@ import { migrationStrategyForRouteSerializers } from '../../../../../src/migrati
 import { inputProject } from '../../../../fixtures/app-javascript.js';
 import { assert, loadFixture, test } from '../../../../test-helpers.js';
 
-const projectRoot = 'tmp/app-javascript';
-
 test('migration | ember-app | app | route-serializers > JavaScript', function () {
-  loadFixture(projectRoot, inputProject);
+  const options = {
+    podPath: '',
+    projectRoot: 'tmp/app-javascript',
+    testRun: false,
+  };
 
-  assert.deepStrictEqual(migrationStrategyForRouteSerializers(projectRoot), [
+  loadFixture(inputProject, options);
+
+  const migrationStrategy = migrationStrategyForRouteSerializers(
+    options.projectRoot
+  );
+
+  assert.deepStrictEqual(migrationStrategy, [
     ['app/application/serializer.js', 'app/serializers/application.js'],
   ]);
 });

--- a/tests/migration/ember-app/app/route-serializers/app-javascript.test.js
+++ b/tests/migration/ember-app/app/route-serializers/app-javascript.test.js
@@ -11,9 +11,7 @@ test('migration | ember-app | app | route-serializers > JavaScript', function ()
 
   loadFixture(inputProject, options);
 
-  const migrationStrategy = migrationStrategyForRouteSerializers(
-    options.projectRoot
-  );
+  const migrationStrategy = migrationStrategyForRouteSerializers(options);
 
   assert.deepStrictEqual(migrationStrategy, [
     ['app/application/serializer.js', 'app/serializers/application.js'],

--- a/tests/migration/ember-app/app/route-serializers/app-pod-path.test.js
+++ b/tests/migration/ember-app/app/route-serializers/app-pod-path.test.js
@@ -1,0 +1,19 @@
+import { migrationStrategyForRouteSerializers } from '../../../../../src/migration/ember-app/app/route-serializers.js';
+import { inputProject } from '../../../../fixtures/app-pod-path.js';
+import { assert, loadFixture, test } from '../../../../test-helpers.js';
+
+test('migration | ember-app | app | route-serializers > podPath', function () {
+  const options = {
+    podPath: 'pods',
+    projectRoot: 'tmp/app-pod-path',
+    testRun: false,
+  };
+
+  loadFixture(inputProject, options);
+
+  const migrationStrategy = migrationStrategyForRouteSerializers(options);
+
+  assert.deepStrictEqual(migrationStrategy, [
+    ['app/pods/application/serializer.js', 'app/serializers/application.js'],
+  ]);
+});

--- a/tests/migration/ember-app/app/route-serializers/app-typescript.test.js
+++ b/tests/migration/ember-app/app/route-serializers/app-typescript.test.js
@@ -2,12 +2,20 @@ import { migrationStrategyForRouteSerializers } from '../../../../../src/migrati
 import { inputProject } from '../../../../fixtures/app-typescript.js';
 import { assert, loadFixture, test } from '../../../../test-helpers.js';
 
-const projectRoot = 'tmp/app-typescript';
-
 test('migration | ember-app | app | route-serializers > TypeScript', function () {
-  loadFixture(projectRoot, inputProject);
+  const options = {
+    podPath: '',
+    projectRoot: 'tmp/app-typescript',
+    testRun: false,
+  };
 
-  assert.deepStrictEqual(migrationStrategyForRouteSerializers(projectRoot), [
+  loadFixture(inputProject, options);
+
+  const migrationStrategy = migrationStrategyForRouteSerializers(
+    options.projectRoot
+  );
+
+  assert.deepStrictEqual(migrationStrategy, [
     ['app/application/serializer.ts', 'app/serializers/application.ts'],
   ]);
 });

--- a/tests/migration/ember-app/app/route-serializers/app-typescript.test.js
+++ b/tests/migration/ember-app/app/route-serializers/app-typescript.test.js
@@ -11,9 +11,7 @@ test('migration | ember-app | app | route-serializers > TypeScript', function ()
 
   loadFixture(inputProject, options);
 
-  const migrationStrategy = migrationStrategyForRouteSerializers(
-    options.projectRoot
-  );
+  const migrationStrategy = migrationStrategyForRouteSerializers(options);
 
   assert.deepStrictEqual(migrationStrategy, [
     ['app/application/serializer.ts', 'app/serializers/application.ts'],

--- a/tests/migration/ember-app/app/route-stylesheets/app-javascript.test.js
+++ b/tests/migration/ember-app/app/route-stylesheets/app-javascript.test.js
@@ -11,9 +11,7 @@ test('migration | ember-app | app | route-stylesheets > JavaScript', function ()
 
   loadFixture(inputProject, options);
 
-  const migrationStrategy = migrationStrategyForRouteStylesheets(
-    options.projectRoot
-  );
+  const migrationStrategy = migrationStrategyForRouteStylesheets(options);
 
   assert.deepStrictEqual(migrationStrategy, [
     ['app/application/styles.css', 'app/styles/application.css'],

--- a/tests/migration/ember-app/app/route-stylesheets/app-javascript.test.js
+++ b/tests/migration/ember-app/app/route-stylesheets/app-javascript.test.js
@@ -2,12 +2,20 @@ import { migrationStrategyForRouteStylesheets } from '../../../../../src/migrati
 import { inputProject } from '../../../../fixtures/app-javascript.js';
 import { assert, loadFixture, test } from '../../../../test-helpers.js';
 
-const projectRoot = 'tmp/app-javascript';
-
 test('migration | ember-app | app | route-stylesheets > JavaScript', function () {
-  loadFixture(projectRoot, inputProject);
+  const options = {
+    podPath: '',
+    projectRoot: 'tmp/app-javascript',
+    testRun: false,
+  };
 
-  assert.deepStrictEqual(migrationStrategyForRouteStylesheets(projectRoot), [
+  loadFixture(inputProject, options);
+
+  const migrationStrategy = migrationStrategyForRouteStylesheets(
+    options.projectRoot
+  );
+
+  assert.deepStrictEqual(migrationStrategy, [
     ['app/application/styles.css', 'app/styles/application.css'],
     ['app/form/styles.css', 'app/styles/form.css'],
     ['app/index/styles.css', 'app/styles/index.css'],

--- a/tests/migration/ember-app/app/route-stylesheets/app-pod-path.test.js
+++ b/tests/migration/ember-app/app/route-stylesheets/app-pod-path.test.js
@@ -1,0 +1,19 @@
+import { migrationStrategyForRouteSerializers } from '../../../../../src/migration/ember-app/app/route-serializers.js';
+import { inputProject } from '../../../../fixtures/app-pod-path.js';
+import { assert, loadFixture, test } from '../../../../test-helpers.js';
+
+test('migration | ember-app | app | route-serializers > podPath', function () {
+  const options = {
+    podPath: 'pods',
+    projectRoot: 'tmp/app-pod-path',
+    testRun: false,
+  };
+
+  loadFixture(inputProject, options);
+
+  const migrationStrategy = migrationStrategyForRouteSerializers(options);
+
+  assert.deepStrictEqual(migrationStrategy, [
+    ['app/pods/application/serializer.js', 'app/serializers/application.js'],
+  ]);
+});

--- a/tests/migration/ember-app/app/route-stylesheets/app-typescript.test.js
+++ b/tests/migration/ember-app/app/route-stylesheets/app-typescript.test.js
@@ -2,12 +2,20 @@ import { migrationStrategyForRouteStylesheets } from '../../../../../src/migrati
 import { inputProject } from '../../../../fixtures/app-typescript.js';
 import { assert, loadFixture, test } from '../../../../test-helpers.js';
 
-const projectRoot = 'tmp/app-typescript';
-
 test('migration | ember-app | app | route-stylesheets > TypeScript', function () {
-  loadFixture(projectRoot, inputProject);
+  const options = {
+    podPath: '',
+    projectRoot: 'tmp/app-typescript',
+    testRun: false,
+  };
 
-  assert.deepStrictEqual(migrationStrategyForRouteStylesheets(projectRoot), [
+  loadFixture(inputProject, options);
+
+  const migrationStrategy = migrationStrategyForRouteStylesheets(
+    options.projectRoot
+  );
+
+  assert.deepStrictEqual(migrationStrategy, [
     ['app/application/styles.css', 'app/styles/application.css'],
     ['app/form/styles.css', 'app/styles/form.css'],
     ['app/index/styles.css', 'app/styles/index.css'],

--- a/tests/migration/ember-app/app/route-stylesheets/app-typescript.test.js
+++ b/tests/migration/ember-app/app/route-stylesheets/app-typescript.test.js
@@ -11,9 +11,7 @@ test('migration | ember-app | app | route-stylesheets > TypeScript', function ()
 
   loadFixture(inputProject, options);
 
-  const migrationStrategy = migrationStrategyForRouteStylesheets(
-    options.projectRoot
-  );
+  const migrationStrategy = migrationStrategyForRouteStylesheets(options);
 
   assert.deepStrictEqual(migrationStrategy, [
     ['app/application/styles.css', 'app/styles/application.css'],

--- a/tests/migration/ember-app/app/route-templates/app-javascript.test.js
+++ b/tests/migration/ember-app/app/route-templates/app-javascript.test.js
@@ -2,12 +2,20 @@ import { migrationStrategyForRouteTemplates } from '../../../../../src/migration
 import { inputProject } from '../../../../fixtures/app-javascript.js';
 import { assert, loadFixture, test } from '../../../../test-helpers.js';
 
-const projectRoot = 'tmp/app-javascript';
-
 test('migration | ember-app | app | route-templates > JavaScript', function () {
-  loadFixture(projectRoot, inputProject);
+  const options = {
+    podPath: '',
+    projectRoot: 'tmp/app-javascript',
+    testRun: false,
+  };
 
-  assert.deepStrictEqual(migrationStrategyForRouteTemplates(projectRoot), [
+  loadFixture(inputProject, options);
+
+  const migrationStrategy = migrationStrategyForRouteTemplates(
+    options.projectRoot
+  );
+
+  assert.deepStrictEqual(migrationStrategy, [
     ['app/application/template.hbs', 'app/templates/application.hbs'],
     ['app/form/template.hbs', 'app/templates/form.hbs'],
     ['app/index/template.hbs', 'app/templates/index.hbs'],

--- a/tests/migration/ember-app/app/route-templates/app-javascript.test.js
+++ b/tests/migration/ember-app/app/route-templates/app-javascript.test.js
@@ -11,9 +11,7 @@ test('migration | ember-app | app | route-templates > JavaScript', function () {
 
   loadFixture(inputProject, options);
 
-  const migrationStrategy = migrationStrategyForRouteTemplates(
-    options.projectRoot
-  );
+  const migrationStrategy = migrationStrategyForRouteTemplates(options);
 
   assert.deepStrictEqual(migrationStrategy, [
     ['app/application/template.hbs', 'app/templates/application.hbs'],

--- a/tests/migration/ember-app/app/route-templates/app-pod-path.test.js
+++ b/tests/migration/ember-app/app/route-templates/app-pod-path.test.js
@@ -1,0 +1,30 @@
+import { migrationStrategyForRouteTemplates } from '../../../../../src/migration/ember-app/app/route-templates.js';
+import { inputProject } from '../../../../fixtures/app-pod-path.js';
+import { assert, loadFixture, test } from '../../../../test-helpers.js';
+
+test('migration | ember-app | app | route-templates > podPath', function () {
+  const options = {
+    podPath: 'pods',
+    projectRoot: 'tmp/app-pod-path',
+    testRun: false,
+  };
+
+  loadFixture(inputProject, options);
+
+  const migrationStrategy = migrationStrategyForRouteTemplates(options);
+
+  assert.deepStrictEqual(migrationStrategy, [
+    ['app/pods/application/template.hbs', 'app/templates/application.hbs'],
+    ['app/pods/form/template.hbs', 'app/templates/form.hbs'],
+    ['app/pods/index/template.hbs', 'app/templates/index.hbs'],
+    [
+      'app/pods/product-details/template.hbs',
+      'app/templates/product-details.hbs',
+    ],
+    [
+      'app/pods/products/product/template.hbs',
+      'app/templates/products/product.hbs',
+    ],
+    ['app/pods/products/template.hbs', 'app/templates/products.hbs'],
+  ]);
+});

--- a/tests/migration/ember-app/app/route-templates/app-typescript.test.js
+++ b/tests/migration/ember-app/app/route-templates/app-typescript.test.js
@@ -11,9 +11,7 @@ test('migration | ember-app | app | route-templates > TypeScript', function () {
 
   loadFixture(inputProject, options);
 
-  const migrationStrategy = migrationStrategyForRouteTemplates(
-    options.projectRoot
-  );
+  const migrationStrategy = migrationStrategyForRouteTemplates(options);
 
   assert.deepStrictEqual(migrationStrategy, [
     ['app/application/template.hbs', 'app/templates/application.hbs'],

--- a/tests/migration/ember-app/app/route-templates/app-typescript.test.js
+++ b/tests/migration/ember-app/app/route-templates/app-typescript.test.js
@@ -2,12 +2,20 @@ import { migrationStrategyForRouteTemplates } from '../../../../../src/migration
 import { inputProject } from '../../../../fixtures/app-typescript.js';
 import { assert, loadFixture, test } from '../../../../test-helpers.js';
 
-const projectRoot = 'tmp/app-typescript';
-
 test('migration | ember-app | app | route-templates > TypeScript', function () {
-  loadFixture(projectRoot, inputProject);
+  const options = {
+    podPath: '',
+    projectRoot: 'tmp/app-typescript',
+    testRun: false,
+  };
 
-  assert.deepStrictEqual(migrationStrategyForRouteTemplates(projectRoot), [
+  loadFixture(inputProject, options);
+
+  const migrationStrategy = migrationStrategyForRouteTemplates(
+    options.projectRoot
+  );
+
+  assert.deepStrictEqual(migrationStrategy, [
     ['app/application/template.hbs', 'app/templates/application.hbs'],
     ['app/form/template.hbs', 'app/templates/form.hbs'],
     ['app/index/template.hbs', 'app/templates/index.hbs'],

--- a/tests/migration/ember-app/app/services/app-javascript.test.js
+++ b/tests/migration/ember-app/app/services/app-javascript.test.js
@@ -11,7 +11,7 @@ test('migration | ember-app | app | services > JavaScript', function () {
 
   loadFixture(inputProject, options);
 
-  const migrationStrategy = migrationStrategyForServices(options.projectRoot);
+  const migrationStrategy = migrationStrategyForServices(options);
 
   assert.deepStrictEqual(migrationStrategy, [
     ['app/config/service.js', 'app/services/config.js'],

--- a/tests/migration/ember-app/app/services/app-javascript.test.js
+++ b/tests/migration/ember-app/app/services/app-javascript.test.js
@@ -2,12 +2,18 @@ import { migrationStrategyForServices } from '../../../../../src/migration/ember
 import { inputProject } from '../../../../fixtures/app-javascript.js';
 import { assert, loadFixture, test } from '../../../../test-helpers.js';
 
-const projectRoot = 'tmp/app-javascript';
-
 test('migration | ember-app | app | services > JavaScript', function () {
-  loadFixture(projectRoot, inputProject);
+  const options = {
+    podPath: '',
+    projectRoot: 'tmp/app-javascript',
+    testRun: false,
+  };
 
-  assert.deepStrictEqual(migrationStrategyForServices(projectRoot), [
+  loadFixture(inputProject, options);
+
+  const migrationStrategy = migrationStrategyForServices(options.projectRoot);
+
+  assert.deepStrictEqual(migrationStrategy, [
     ['app/config/service.js', 'app/services/config.js'],
     ['app/experiments/service.js', 'app/services/experiments.js'],
   ]);

--- a/tests/migration/ember-app/app/services/app-pod-path.test.js
+++ b/tests/migration/ember-app/app/services/app-pod-path.test.js
@@ -1,0 +1,20 @@
+import { migrationStrategyForServices } from '../../../../../src/migration/ember-app/app/services.js';
+import { inputProject } from '../../../../fixtures/app-pod-path.js';
+import { assert, loadFixture, test } from '../../../../test-helpers.js';
+
+test('migration | ember-app | app | services > podPath', function () {
+  const options = {
+    podPath: 'pods',
+    projectRoot: 'tmp/app-pod-path',
+    testRun: false,
+  };
+
+  loadFixture(inputProject, options);
+
+  const migrationStrategy = migrationStrategyForServices(options);
+
+  assert.deepStrictEqual(migrationStrategy, [
+    ['app/pods/config/service.js', 'app/services/config.js'],
+    ['app/pods/experiments/service.js', 'app/services/experiments.js'],
+  ]);
+});

--- a/tests/migration/ember-app/app/services/app-typescript.test.js
+++ b/tests/migration/ember-app/app/services/app-typescript.test.js
@@ -2,12 +2,18 @@ import { migrationStrategyForServices } from '../../../../../src/migration/ember
 import { inputProject } from '../../../../fixtures/app-typescript.js';
 import { assert, loadFixture, test } from '../../../../test-helpers.js';
 
-const projectRoot = 'tmp/app-typescript';
-
 test('migration | ember-app | app | services > TypeScript', function () {
-  loadFixture(projectRoot, inputProject);
+  const options = {
+    podPath: '',
+    projectRoot: 'tmp/app-typescript',
+    testRun: false,
+  };
 
-  assert.deepStrictEqual(migrationStrategyForServices(projectRoot), [
+  loadFixture(inputProject, options);
+
+  const migrationStrategy = migrationStrategyForServices(options.projectRoot);
+
+  assert.deepStrictEqual(migrationStrategy, [
     ['app/config/service.ts', 'app/services/config.ts'],
     ['app/experiments/service.ts', 'app/services/experiments.ts'],
   ]);

--- a/tests/migration/ember-app/app/services/app-typescript.test.js
+++ b/tests/migration/ember-app/app/services/app-typescript.test.js
@@ -11,7 +11,7 @@ test('migration | ember-app | app | services > TypeScript', function () {
 
   loadFixture(inputProject, options);
 
-  const migrationStrategy = migrationStrategyForServices(options.projectRoot);
+  const migrationStrategy = migrationStrategyForServices(options);
 
   assert.deepStrictEqual(migrationStrategy, [
     ['app/config/service.ts', 'app/services/config.ts'],

--- a/tests/migration/ember-app/index/app-javascript.test.js
+++ b/tests/migration/ember-app/index/app-javascript.test.js
@@ -5,23 +5,21 @@ import {
 } from '../../../fixtures/app-javascript.js';
 import { assertFixture, loadFixture, test } from '../../../test-helpers.js';
 
-const projectRoot = 'tmp/app-javascript';
-
 test('migration | ember-app | index > JavaScript', function () {
-  loadFixture(projectRoot, inputProject);
-
-  migrateEmberApp({
-    projectRoot,
+  const options = {
+    podPath: '',
+    projectRoot: 'tmp/app-javascript',
     testRun: false,
-  });
+  };
 
-  assertFixture(projectRoot, outputProject);
+  loadFixture(inputProject, options);
+
+  migrateEmberApp(options);
+
+  assertFixture(outputProject, options);
 
   // Check idempotence
-  migrateEmberApp({
-    projectRoot,
-    testRun: false,
-  });
+  migrateEmberApp(options);
 
-  assertFixture(projectRoot, outputProject);
+  assertFixture(outputProject, options);
 });

--- a/tests/migration/ember-app/index/app-pod-path.test.js
+++ b/tests/migration/ember-app/index/app-pod-path.test.js
@@ -1,0 +1,22 @@
+import { migrateEmberApp } from '../../../../src/migration/ember-app/index.js';
+import { inputProject, outputProject } from '../../../fixtures/app-pod-path.js';
+import { assertFixture, loadFixture, test } from '../../../test-helpers.js';
+
+test('migration | ember-app | index > podPath', function () {
+  const options = {
+    podPath: 'pods',
+    projectRoot: 'tmp/app-pod-path',
+    testRun: false,
+  };
+
+  loadFixture(inputProject, options);
+
+  migrateEmberApp(options);
+
+  assertFixture(outputProject, options);
+
+  // Check idempotence
+  migrateEmberApp(options);
+
+  assertFixture(outputProject, options);
+});

--- a/tests/migration/ember-app/index/app-typescript.test.js
+++ b/tests/migration/ember-app/index/app-typescript.test.js
@@ -5,23 +5,21 @@ import {
 } from '../../../fixtures/app-typescript.js';
 import { assertFixture, loadFixture, test } from '../../../test-helpers.js';
 
-const projectRoot = 'tmp/app-typescript';
-
 test('migration | ember-app | index > TypeScript', function () {
-  loadFixture(projectRoot, inputProject);
-
-  migrateEmberApp({
-    projectRoot,
+  const options = {
+    podPath: '',
+    projectRoot: 'tmp/app-typescript',
     testRun: false,
-  });
+  };
 
-  assertFixture(projectRoot, outputProject);
+  loadFixture(inputProject, options);
+
+  migrateEmberApp(options);
+
+  assertFixture(outputProject, options);
 
   // Check idempotence
-  migrateEmberApp({
-    projectRoot,
-    testRun: false,
-  });
+  migrateEmberApp(options);
 
-  assertFixture(projectRoot, outputProject);
+  assertFixture(outputProject, options);
 });

--- a/tests/migration/ember-app/tests/components/app-javascript.test.js
+++ b/tests/migration/ember-app/tests/components/app-javascript.test.js
@@ -11,7 +11,7 @@ test('migration | ember-app | tests | components > JavaScript', function () {
 
   loadFixture(inputProject, options);
 
-  const migrationStrategy = migrationStrategyForComponents(options.projectRoot);
+  const migrationStrategy = migrationStrategyForComponents(options);
 
   assert.deepStrictEqual(migrationStrategy, [
     [

--- a/tests/migration/ember-app/tests/components/app-javascript.test.js
+++ b/tests/migration/ember-app/tests/components/app-javascript.test.js
@@ -2,12 +2,18 @@ import { migrationStrategyForComponents } from '../../../../../src/migration/emb
 import { inputProject } from '../../../../fixtures/app-javascript.js';
 import { assert, loadFixture, test } from '../../../../test-helpers.js';
 
-const projectRoot = 'tmp/app-javascript';
-
 test('migration | ember-app | tests | components > JavaScript', function () {
-  loadFixture(projectRoot, inputProject);
+  const options = {
+    podPath: '',
+    projectRoot: 'tmp/app-javascript',
+    testRun: false,
+  };
 
-  assert.deepStrictEqual(migrationStrategyForComponents(projectRoot), [
+  loadFixture(inputProject, options);
+
+  const migrationStrategy = migrationStrategyForComponents(options.projectRoot);
+
+  assert.deepStrictEqual(migrationStrategy, [
     [
       'tests/integration/components/navigation-menu/component-test.js',
       'tests/integration/components/navigation-menu-test.js',

--- a/tests/migration/ember-app/tests/components/app-pod-path.test.js
+++ b/tests/migration/ember-app/tests/components/app-pod-path.test.js
@@ -1,0 +1,70 @@
+import { migrationStrategyForComponents } from '../../../../../src/migration/ember-app/tests/components.js';
+import { inputProject } from '../../../../fixtures/app-pod-path.js';
+import { assert, loadFixture, test } from '../../../../test-helpers.js';
+
+test('migration | ember-app | tests | components > podPath', function () {
+  const options = {
+    podPath: 'pods',
+    projectRoot: 'tmp/app-pod-path',
+    testRun: false,
+  };
+
+  loadFixture(inputProject, options);
+
+  const migrationStrategy = migrationStrategyForComponents(options);
+
+  assert.deepStrictEqual(migrationStrategy, [
+    [
+      'tests/integration/pods/components/navigation-menu/component-test.js',
+      'tests/integration/components/navigation-menu-test.js',
+    ],
+    [
+      'tests/integration/pods/components/product/card/component-test.js',
+      'tests/integration/components/product/card-test.js',
+    ],
+    [
+      'tests/integration/pods/components/product/details/component-test.js',
+      'tests/integration/components/product/details-test.js',
+    ],
+    [
+      'tests/integration/pods/components/product/image/component-test.js',
+      'tests/integration/components/product/image-test.js',
+    ],
+    [
+      'tests/integration/pods/components/ui/form/checkbox/component-test.js',
+      'tests/integration/components/ui/form/checkbox-test.js',
+    ],
+    [
+      'tests/integration/pods/components/ui/form/component-test.js',
+      'tests/integration/components/ui/form-test.js',
+    ],
+    [
+      'tests/integration/pods/components/ui/form/field/component-test.js',
+      'tests/integration/components/ui/form/field-test.js',
+    ],
+    [
+      'tests/integration/pods/components/ui/form/information/component-test.js',
+      'tests/integration/components/ui/form/information-test.js',
+    ],
+    [
+      'tests/integration/pods/components/ui/form/input/component-test.js',
+      'tests/integration/components/ui/form/input-test.js',
+    ],
+    [
+      'tests/integration/pods/components/ui/form/number/component-test.js',
+      'tests/integration/components/ui/form/number-test.js',
+    ],
+    [
+      'tests/integration/pods/components/ui/form/select/component-test.js',
+      'tests/integration/components/ui/form/select-test.js',
+    ],
+    [
+      'tests/integration/pods/components/ui/form/textarea/component-test.js',
+      'tests/integration/components/ui/form/textarea-test.js',
+    ],
+    [
+      'tests/integration/pods/components/ui/page/component-test.js',
+      'tests/integration/components/ui/page-test.js',
+    ],
+  ]);
+});

--- a/tests/migration/ember-app/tests/components/app-typescript.test.js
+++ b/tests/migration/ember-app/tests/components/app-typescript.test.js
@@ -11,7 +11,7 @@ test('migration | ember-app | tests | components > TypeScript', function () {
 
   loadFixture(inputProject, options);
 
-  const migrationStrategy = migrationStrategyForComponents(options.projectRoot);
+  const migrationStrategy = migrationStrategyForComponents(options);
 
   assert.deepStrictEqual(migrationStrategy, [
     [

--- a/tests/migration/ember-app/tests/components/app-typescript.test.js
+++ b/tests/migration/ember-app/tests/components/app-typescript.test.js
@@ -2,12 +2,18 @@ import { migrationStrategyForComponents } from '../../../../../src/migration/emb
 import { inputProject } from '../../../../fixtures/app-typescript.js';
 import { assert, loadFixture, test } from '../../../../test-helpers.js';
 
-const projectRoot = 'tmp/app-typescript';
-
 test('migration | ember-app | tests | components > TypeScript', function () {
-  loadFixture(projectRoot, inputProject);
+  const options = {
+    podPath: '',
+    projectRoot: 'tmp/app-typescript',
+    testRun: false,
+  };
 
-  assert.deepStrictEqual(migrationStrategyForComponents(projectRoot), [
+  loadFixture(inputProject, options);
+
+  const migrationStrategy = migrationStrategyForComponents(options.projectRoot);
+
+  assert.deepStrictEqual(migrationStrategy, [
     [
       'tests/integration/components/navigation-menu/component-test.ts',
       'tests/integration/components/navigation-menu-test.ts',

--- a/tests/migration/ember-app/tests/route-controllers/app-javascript.test.js
+++ b/tests/migration/ember-app/tests/route-controllers/app-javascript.test.js
@@ -11,9 +11,7 @@ test('migration | ember-app | tests | route-controllers > JavaScript', function 
 
   loadFixture(inputProject, options);
 
-  const migrationStrategy = migrationStrategyForRouteControllers(
-    options.projectRoot
-  );
+  const migrationStrategy = migrationStrategyForRouteControllers(options);
 
   assert.deepStrictEqual(migrationStrategy, [
     [

--- a/tests/migration/ember-app/tests/route-controllers/app-javascript.test.js
+++ b/tests/migration/ember-app/tests/route-controllers/app-javascript.test.js
@@ -2,12 +2,20 @@ import { migrationStrategyForRouteControllers } from '../../../../../src/migrati
 import { inputProject } from '../../../../fixtures/app-javascript.js';
 import { assert, loadFixture, test } from '../../../../test-helpers.js';
 
-const projectRoot = 'tmp/app-javascript';
-
 test('migration | ember-app | tests | route-controllers > JavaScript', function () {
-  loadFixture(projectRoot, inputProject);
+  const options = {
+    podPath: '',
+    projectRoot: 'tmp/app-javascript',
+    testRun: false,
+  };
 
-  assert.deepStrictEqual(migrationStrategyForRouteControllers(projectRoot), [
+  loadFixture(inputProject, options);
+
+  const migrationStrategy = migrationStrategyForRouteControllers(
+    options.projectRoot
+  );
+
+  assert.deepStrictEqual(migrationStrategy, [
     [
       'tests/unit/form/controller-test.js',
       'tests/unit/controllers/form-test.js',

--- a/tests/migration/ember-app/tests/route-controllers/app-pod-path.test.js
+++ b/tests/migration/ember-app/tests/route-controllers/app-pod-path.test.js
@@ -1,0 +1,34 @@
+import { migrationStrategyForRouteControllers } from '../../../../../src/migration/ember-app/tests/route-controllers.js';
+import { inputProject } from '../../../../fixtures/app-pod-path.js';
+import { assert, loadFixture, test } from '../../../../test-helpers.js';
+
+test('migration | ember-app | tests | route-controllers > podPath', function () {
+  const options = {
+    podPath: 'pods',
+    projectRoot: 'tmp/app-pod-path',
+    testRun: false,
+  };
+
+  loadFixture(inputProject, options);
+
+  const migrationStrategy = migrationStrategyForRouteControllers(options);
+
+  assert.deepStrictEqual(migrationStrategy, [
+    [
+      'tests/unit/pods/form/controller-test.js',
+      'tests/unit/controllers/form-test.js',
+    ],
+    [
+      'tests/unit/pods/products/controller-test.js',
+      'tests/unit/controllers/products-test.js',
+    ],
+    [
+      'tests/unit/pods/controllers/form/controller-test.js',
+      'tests/unit/controllers/form-test.js',
+    ],
+    [
+      'tests/unit/pods/controllers/products/controller-test.js',
+      'tests/unit/controllers/products-test.js',
+    ],
+  ]);
+});

--- a/tests/migration/ember-app/tests/route-controllers/app-typescript.test.js
+++ b/tests/migration/ember-app/tests/route-controllers/app-typescript.test.js
@@ -2,12 +2,20 @@ import { migrationStrategyForRouteControllers } from '../../../../../src/migrati
 import { inputProject } from '../../../../fixtures/app-typescript.js';
 import { assert, loadFixture, test } from '../../../../test-helpers.js';
 
-const projectRoot = 'tmp/app-typescript';
-
 test('migration | ember-app | tests | route-controllers > TypeScript', function () {
-  loadFixture(projectRoot, inputProject);
+  const options = {
+    podPath: '',
+    projectRoot: 'tmp/app-typescript',
+    testRun: false,
+  };
 
-  assert.deepStrictEqual(migrationStrategyForRouteControllers(projectRoot), [
+  loadFixture(inputProject, options);
+
+  const migrationStrategy = migrationStrategyForRouteControllers(
+    options.projectRoot
+  );
+
+  assert.deepStrictEqual(migrationStrategy, [
     [
       'tests/unit/form/controller-test.ts',
       'tests/unit/controllers/form-test.ts',

--- a/tests/migration/ember-app/tests/route-controllers/app-typescript.test.js
+++ b/tests/migration/ember-app/tests/route-controllers/app-typescript.test.js
@@ -11,9 +11,7 @@ test('migration | ember-app | tests | route-controllers > TypeScript', function 
 
   loadFixture(inputProject, options);
 
-  const migrationStrategy = migrationStrategyForRouteControllers(
-    options.projectRoot
-  );
+  const migrationStrategy = migrationStrategyForRouteControllers(options);
 
   assert.deepStrictEqual(migrationStrategy, [
     [

--- a/tests/migration/ember-app/tests/route-routes/app-javascript.test.js
+++ b/tests/migration/ember-app/tests/route-routes/app-javascript.test.js
@@ -11,9 +11,7 @@ test('migration | ember-app | tests | route-routes > JavaScript', function () {
 
   loadFixture(inputProject, options);
 
-  const migrationStrategy = migrationStrategyForRouteRoutes(
-    options.projectRoot
-  );
+  const migrationStrategy = migrationStrategyForRouteRoutes(options);
 
   assert.deepStrictEqual(migrationStrategy, [
     [

--- a/tests/migration/ember-app/tests/route-routes/app-javascript.test.js
+++ b/tests/migration/ember-app/tests/route-routes/app-javascript.test.js
@@ -2,12 +2,20 @@ import { migrationStrategyForRouteRoutes } from '../../../../../src/migration/em
 import { inputProject } from '../../../../fixtures/app-javascript.js';
 import { assert, loadFixture, test } from '../../../../test-helpers.js';
 
-const projectRoot = 'tmp/app-javascript';
-
 test('migration | ember-app | tests | route-routes > JavaScript', function () {
-  loadFixture(projectRoot, inputProject);
+  const options = {
+    podPath: '',
+    projectRoot: 'tmp/app-javascript',
+    testRun: false,
+  };
 
-  assert.deepStrictEqual(migrationStrategyForRouteRoutes(projectRoot), [
+  loadFixture(inputProject, options);
+
+  const migrationStrategy = migrationStrategyForRouteRoutes(
+    options.projectRoot
+  );
+
+  assert.deepStrictEqual(migrationStrategy, [
     [
       'tests/unit/application/route-test.js',
       'tests/unit/routes/application-test.js',

--- a/tests/migration/ember-app/tests/route-routes/app-pod-path.test.js
+++ b/tests/migration/ember-app/tests/route-routes/app-pod-path.test.js
@@ -1,0 +1,60 @@
+import { migrationStrategyForRouteRoutes } from '../../../../../src/migration/ember-app/tests/route-routes.js';
+import { inputProject } from '../../../../fixtures/app-pod-path.js';
+import { assert, loadFixture, test } from '../../../../test-helpers.js';
+
+test('migration | ember-app | tests | route-routes > podPath', function () {
+  const options = {
+    podPath: 'pods',
+    projectRoot: 'tmp/app-pod-path',
+    testRun: false,
+  };
+
+  loadFixture(inputProject, options);
+
+  const migrationStrategy = migrationStrategyForRouteRoutes(options);
+
+  assert.deepStrictEqual(migrationStrategy, [
+    [
+      'tests/unit/pods/application/route-test.js',
+      'tests/unit/routes/application-test.js',
+    ],
+    ['tests/unit/pods/form/route-test.js', 'tests/unit/routes/form-test.js'],
+    ['tests/unit/pods/index/route-test.js', 'tests/unit/routes/index-test.js'],
+    [
+      'tests/unit/pods/product-details/route-test.js',
+      'tests/unit/routes/product-details-test.js',
+    ],
+    [
+      'tests/unit/pods/products/product/route-test.js',
+      'tests/unit/routes/products/product-test.js',
+    ],
+    [
+      'tests/unit/pods/products/route-test.js',
+      'tests/unit/routes/products-test.js',
+    ],
+    [
+      'tests/unit/pods/routes/application/route-test.js',
+      'tests/unit/routes/application-test.js',
+    ],
+    [
+      'tests/unit/pods/routes/form/route-test.js',
+      'tests/unit/routes/form-test.js',
+    ],
+    [
+      'tests/unit/pods/routes/index/route-test.js',
+      'tests/unit/routes/index-test.js',
+    ],
+    [
+      'tests/unit/pods/routes/product-details/route-test.js',
+      'tests/unit/routes/product-details-test.js',
+    ],
+    [
+      'tests/unit/pods/routes/products/product/route-test.js',
+      'tests/unit/routes/products/product-test.js',
+    ],
+    [
+      'tests/unit/pods/routes/products/route-test.js',
+      'tests/unit/routes/products-test.js',
+    ],
+  ]);
+});

--- a/tests/migration/ember-app/tests/route-routes/app-typescript.test.js
+++ b/tests/migration/ember-app/tests/route-routes/app-typescript.test.js
@@ -2,12 +2,20 @@ import { migrationStrategyForRouteRoutes } from '../../../../../src/migration/em
 import { inputProject } from '../../../../fixtures/app-typescript.js';
 import { assert, loadFixture, test } from '../../../../test-helpers.js';
 
-const projectRoot = 'tmp/app-typescript';
-
 test('migration | ember-app | tests | route-routes > TypeScript', function () {
-  loadFixture(projectRoot, inputProject);
+  const options = {
+    podPath: '',
+    projectRoot: 'tmp/app-typescript',
+    testRun: false,
+  };
 
-  assert.deepStrictEqual(migrationStrategyForRouteRoutes(projectRoot), [
+  loadFixture(inputProject, options);
+
+  const migrationStrategy = migrationStrategyForRouteRoutes(
+    options.projectRoot
+  );
+
+  assert.deepStrictEqual(migrationStrategy, [
     [
       'tests/unit/application/route-test.ts',
       'tests/unit/routes/application-test.ts',

--- a/tests/migration/ember-app/tests/route-routes/app-typescript.test.js
+++ b/tests/migration/ember-app/tests/route-routes/app-typescript.test.js
@@ -11,9 +11,7 @@ test('migration | ember-app | tests | route-routes > TypeScript', function () {
 
   loadFixture(inputProject, options);
 
-  const migrationStrategy = migrationStrategyForRouteRoutes(
-    options.projectRoot
-  );
+  const migrationStrategy = migrationStrategyForRouteRoutes(options);
 
   assert.deepStrictEqual(migrationStrategy, [
     [

--- a/tests/migration/ember-app/tests/services/app-javascript.test.js
+++ b/tests/migration/ember-app/tests/services/app-javascript.test.js
@@ -2,12 +2,18 @@ import { migrationStrategyForServices } from '../../../../../src/migration/ember
 import { inputProject } from '../../../../fixtures/app-javascript.js';
 import { assert, loadFixture, test } from '../../../../test-helpers.js';
 
-const projectRoot = 'tmp/app-javascript';
-
 test('migration | ember-app | tests | services > JavaScript', function () {
-  loadFixture(projectRoot, inputProject);
+  const options = {
+    podPath: '',
+    projectRoot: 'tmp/app-javascript',
+    testRun: false,
+  };
 
-  assert.deepStrictEqual(migrationStrategyForServices(projectRoot), [
+  loadFixture(inputProject, options);
+
+  const migrationStrategy = migrationStrategyForServices(options.projectRoot);
+
+  assert.deepStrictEqual(migrationStrategy, [
     ['tests/unit/config/service-test.js', 'tests/unit/services/config-test.js'],
     [
       'tests/unit/experiments/service-test.js',

--- a/tests/migration/ember-app/tests/services/app-javascript.test.js
+++ b/tests/migration/ember-app/tests/services/app-javascript.test.js
@@ -11,7 +11,7 @@ test('migration | ember-app | tests | services > JavaScript', function () {
 
   loadFixture(inputProject, options);
 
-  const migrationStrategy = migrationStrategyForServices(options.projectRoot);
+  const migrationStrategy = migrationStrategyForServices(options);
 
   assert.deepStrictEqual(migrationStrategy, [
     ['tests/unit/config/service-test.js', 'tests/unit/services/config-test.js'],

--- a/tests/migration/ember-app/tests/services/app-pod-path.test.js
+++ b/tests/migration/ember-app/tests/services/app-pod-path.test.js
@@ -1,0 +1,26 @@
+import { migrationStrategyForServices } from '../../../../../src/migration/ember-app/tests/services.js';
+import { inputProject } from '../../../../fixtures/app-pod-path.js';
+import { assert, loadFixture, test } from '../../../../test-helpers.js';
+
+test('migration | ember-app | tests | services > podPath', function () {
+  const options = {
+    podPath: 'pods',
+    projectRoot: 'tmp/app-pod-path',
+    testRun: false,
+  };
+
+  loadFixture(inputProject, options);
+
+  const migrationStrategy = migrationStrategyForServices(options);
+
+  assert.deepStrictEqual(migrationStrategy, [
+    [
+      'tests/unit/pods/config/service-test.js',
+      'tests/unit/services/config-test.js',
+    ],
+    [
+      'tests/unit/pods/experiments/service-test.js',
+      'tests/unit/services/experiments-test.js',
+    ],
+  ]);
+});

--- a/tests/migration/ember-app/tests/services/app-typescript.test.js
+++ b/tests/migration/ember-app/tests/services/app-typescript.test.js
@@ -11,7 +11,7 @@ test('migration | ember-app | tests | services > TypeScript', function () {
 
   loadFixture(inputProject, options);
 
-  const migrationStrategy = migrationStrategyForServices(options.projectRoot);
+  const migrationStrategy = migrationStrategyForServices(options);
 
   assert.deepStrictEqual(migrationStrategy, [
     ['tests/unit/config/service-test.ts', 'tests/unit/services/config-test.ts'],

--- a/tests/migration/ember-app/tests/services/app-typescript.test.js
+++ b/tests/migration/ember-app/tests/services/app-typescript.test.js
@@ -2,12 +2,18 @@ import { migrationStrategyForServices } from '../../../../../src/migration/ember
 import { inputProject } from '../../../../fixtures/app-typescript.js';
 import { assert, loadFixture, test } from '../../../../test-helpers.js';
 
-const projectRoot = 'tmp/app-typescript';
-
 test('migration | ember-app | tests | services > TypeScript', function () {
-  loadFixture(projectRoot, inputProject);
+  const options = {
+    podPath: '',
+    projectRoot: 'tmp/app-typescript',
+    testRun: false,
+  };
 
-  assert.deepStrictEqual(migrationStrategyForServices(projectRoot), [
+  loadFixture(inputProject, options);
+
+  const migrationStrategy = migrationStrategyForServices(options.projectRoot);
+
+  assert.deepStrictEqual(migrationStrategy, [
     ['tests/unit/config/service-test.ts', 'tests/unit/services/config-test.ts'],
     [
       'tests/unit/experiments/service-test.ts',

--- a/tests/migration/ember-engine/addon/component-classes/engine-javascript.test.js
+++ b/tests/migration/ember-engine/addon/component-classes/engine-javascript.test.js
@@ -11,9 +11,7 @@ test('migration | ember-engine | addon | component-classes > JavaScript', functi
 
   loadFixture(inputProject, options);
 
-  const migrationStrategy = migrationStrategyForComponentClasses(
-    options.projectRoot
-  );
+  const migrationStrategy = migrationStrategyForComponentClasses(options);
 
   assert.deepStrictEqual(migrationStrategy, [
     [

--- a/tests/migration/ember-engine/addon/component-classes/engine-javascript.test.js
+++ b/tests/migration/ember-engine/addon/component-classes/engine-javascript.test.js
@@ -2,12 +2,20 @@ import { migrationStrategyForComponentClasses } from '../../../../../src/migrati
 import { inputProject } from '../../../../fixtures/engine-javascript.js';
 import { assert, loadFixture, test } from '../../../../test-helpers.js';
 
-const projectRoot = 'tmp/engine-javascript';
-
 test('migration | ember-engine | addon | component-classes > JavaScript', function () {
-  loadFixture(projectRoot, inputProject);
+  const options = {
+    podPath: '',
+    projectRoot: 'tmp/engine-javascript',
+    testRun: false,
+  };
 
-  assert.deepStrictEqual(migrationStrategyForComponentClasses(projectRoot), [
+  loadFixture(inputProject, options);
+
+  const migrationStrategy = migrationStrategyForComponentClasses(
+    options.projectRoot
+  );
+
+  assert.deepStrictEqual(migrationStrategy, [
     [
       'addon/components/product/details/component.js',
       'addon/components/product/details.js',

--- a/tests/migration/ember-engine/addon/component-classes/engine-typescript.test.js
+++ b/tests/migration/ember-engine/addon/component-classes/engine-typescript.test.js
@@ -2,12 +2,20 @@ import { migrationStrategyForComponentClasses } from '../../../../../src/migrati
 import { inputProject } from '../../../../fixtures/engine-typescript.js';
 import { assert, loadFixture, test } from '../../../../test-helpers.js';
 
-const projectRoot = 'tmp/engine-typescript';
-
 test('migration | ember-engine | addon | component-classes > TypeScript', function () {
-  loadFixture(projectRoot, inputProject);
+  const options = {
+    podPath: '',
+    projectRoot: 'tmp/engine-typescript',
+    testRun: false,
+  };
 
-  assert.deepStrictEqual(migrationStrategyForComponentClasses(projectRoot), [
+  loadFixture(inputProject, options);
+
+  const migrationStrategy = migrationStrategyForComponentClasses(
+    options.projectRoot
+  );
+
+  assert.deepStrictEqual(migrationStrategy, [
     [
       'addon/components/product/card/component.d.ts',
       'addon/components/product/card.d.ts',

--- a/tests/migration/ember-engine/addon/component-classes/engine-typescript.test.js
+++ b/tests/migration/ember-engine/addon/component-classes/engine-typescript.test.js
@@ -11,9 +11,7 @@ test('migration | ember-engine | addon | component-classes > TypeScript', functi
 
   loadFixture(inputProject, options);
 
-  const migrationStrategy = migrationStrategyForComponentClasses(
-    options.projectRoot
-  );
+  const migrationStrategy = migrationStrategyForComponentClasses(options);
 
   assert.deepStrictEqual(migrationStrategy, [
     [

--- a/tests/migration/ember-engine/addon/component-stylesheets/engine-javascript.test.js
+++ b/tests/migration/ember-engine/addon/component-stylesheets/engine-javascript.test.js
@@ -11,9 +11,7 @@ test('migration | ember-engine | addon | component-stylesheets > JavaScript', fu
 
   loadFixture(inputProject, options);
 
-  const migrationStrategy = migrationStrategyForComponentStylesheets(
-    options.projectRoot
-  );
+  const migrationStrategy = migrationStrategyForComponentStylesheets(options);
 
   assert.deepStrictEqual(migrationStrategy, [
     [

--- a/tests/migration/ember-engine/addon/component-stylesheets/engine-javascript.test.js
+++ b/tests/migration/ember-engine/addon/component-stylesheets/engine-javascript.test.js
@@ -2,26 +2,31 @@ import { migrationStrategyForComponentStylesheets } from '../../../../../src/mig
 import { inputProject } from '../../../../fixtures/engine-javascript.js';
 import { assert, loadFixture, test } from '../../../../test-helpers.js';
 
-const projectRoot = 'tmp/engine-javascript';
-
 test('migration | ember-engine | addon | component-stylesheets > JavaScript', function () {
-  loadFixture(projectRoot, inputProject);
+  const options = {
+    podPath: '',
+    projectRoot: 'tmp/engine-javascript',
+    testRun: false,
+  };
 
-  assert.deepStrictEqual(
-    migrationStrategyForComponentStylesheets(projectRoot),
-    [
-      [
-        'addon/components/product/card/styles.css',
-        'addon/components/product/card.css',
-      ],
-      [
-        'addon/components/product/details/styles.scss',
-        'addon/components/product/details.scss',
-      ],
-      [
-        'addon/components/product/image/styles.css',
-        'addon/components/product/image.css',
-      ],
-    ]
+  loadFixture(inputProject, options);
+
+  const migrationStrategy = migrationStrategyForComponentStylesheets(
+    options.projectRoot
   );
+
+  assert.deepStrictEqual(migrationStrategy, [
+    [
+      'addon/components/product/card/styles.css',
+      'addon/components/product/card.css',
+    ],
+    [
+      'addon/components/product/details/styles.scss',
+      'addon/components/product/details.scss',
+    ],
+    [
+      'addon/components/product/image/styles.css',
+      'addon/components/product/image.css',
+    ],
+  ]);
 });

--- a/tests/migration/ember-engine/addon/component-stylesheets/engine-typescript.test.js
+++ b/tests/migration/ember-engine/addon/component-stylesheets/engine-typescript.test.js
@@ -2,26 +2,31 @@ import { migrationStrategyForComponentStylesheets } from '../../../../../src/mig
 import { inputProject } from '../../../../fixtures/engine-typescript.js';
 import { assert, loadFixture, test } from '../../../../test-helpers.js';
 
-const projectRoot = 'tmp/engine-typescript';
-
 test('migration | ember-engine | addon | component-stylesheets > TypeScript', function () {
-  loadFixture(projectRoot, inputProject);
+  const options = {
+    podPath: '',
+    projectRoot: 'tmp/engine-typescript',
+    testRun: false,
+  };
 
-  assert.deepStrictEqual(
-    migrationStrategyForComponentStylesheets(projectRoot),
-    [
-      [
-        'addon/components/product/card/styles.css',
-        'addon/components/product/card.css',
-      ],
-      [
-        'addon/components/product/details/styles.scss',
-        'addon/components/product/details.scss',
-      ],
-      [
-        'addon/components/product/image/styles.css',
-        'addon/components/product/image.css',
-      ],
-    ]
+  loadFixture(inputProject, options);
+
+  const migrationStrategy = migrationStrategyForComponentStylesheets(
+    options.projectRoot
   );
+
+  assert.deepStrictEqual(migrationStrategy, [
+    [
+      'addon/components/product/card/styles.css',
+      'addon/components/product/card.css',
+    ],
+    [
+      'addon/components/product/details/styles.scss',
+      'addon/components/product/details.scss',
+    ],
+    [
+      'addon/components/product/image/styles.css',
+      'addon/components/product/image.css',
+    ],
+  ]);
 });

--- a/tests/migration/ember-engine/addon/component-stylesheets/engine-typescript.test.js
+++ b/tests/migration/ember-engine/addon/component-stylesheets/engine-typescript.test.js
@@ -11,9 +11,7 @@ test('migration | ember-engine | addon | component-stylesheets > TypeScript', fu
 
   loadFixture(inputProject, options);
 
-  const migrationStrategy = migrationStrategyForComponentStylesheets(
-    options.projectRoot
-  );
+  const migrationStrategy = migrationStrategyForComponentStylesheets(options);
 
   assert.deepStrictEqual(migrationStrategy, [
     [

--- a/tests/migration/ember-engine/addon/component-templates/engine-javascript.test.js
+++ b/tests/migration/ember-engine/addon/component-templates/engine-javascript.test.js
@@ -11,9 +11,7 @@ test('migration | ember-engine | addon | component-templates > JavaScript', func
 
   loadFixture(inputProject, options);
 
-  const migrationStrategy = migrationStrategyForComponentTemplates(
-    options.projectRoot
-  );
+  const migrationStrategy = migrationStrategyForComponentTemplates(options);
 
   assert.deepStrictEqual(migrationStrategy, [
     [

--- a/tests/migration/ember-engine/addon/component-templates/engine-javascript.test.js
+++ b/tests/migration/ember-engine/addon/component-templates/engine-javascript.test.js
@@ -2,12 +2,20 @@ import { migrationStrategyForComponentTemplates } from '../../../../../src/migra
 import { inputProject } from '../../../../fixtures/engine-javascript.js';
 import { assert, loadFixture, test } from '../../../../test-helpers.js';
 
-const projectRoot = 'tmp/engine-javascript';
-
 test('migration | ember-engine | addon | component-templates > JavaScript', function () {
-  loadFixture(projectRoot, inputProject);
+  const options = {
+    podPath: '',
+    projectRoot: 'tmp/engine-javascript',
+    testRun: false,
+  };
 
-  assert.deepStrictEqual(migrationStrategyForComponentTemplates(projectRoot), [
+  loadFixture(inputProject, options);
+
+  const migrationStrategy = migrationStrategyForComponentTemplates(
+    options.projectRoot
+  );
+
+  assert.deepStrictEqual(migrationStrategy, [
     [
       'addon/components/product/card/template.hbs',
       'addon/components/product/card.hbs',

--- a/tests/migration/ember-engine/addon/component-templates/engine-typescript.test.js
+++ b/tests/migration/ember-engine/addon/component-templates/engine-typescript.test.js
@@ -2,12 +2,20 @@ import { migrationStrategyForComponentTemplates } from '../../../../../src/migra
 import { inputProject } from '../../../../fixtures/engine-typescript.js';
 import { assert, loadFixture, test } from '../../../../test-helpers.js';
 
-const projectRoot = 'tmp/engine-typescript';
-
 test('migration | ember-engine | addon | component-templates > TypeScript', function () {
-  loadFixture(projectRoot, inputProject);
+  const options = {
+    podPath: '',
+    projectRoot: 'tmp/engine-typescript',
+    testRun: false,
+  };
 
-  assert.deepStrictEqual(migrationStrategyForComponentTemplates(projectRoot), [
+  loadFixture(inputProject, options);
+
+  const migrationStrategy = migrationStrategyForComponentTemplates(
+    options.projectRoot
+  );
+
+  assert.deepStrictEqual(migrationStrategy, [
     [
       'addon/components/product/card/template.hbs',
       'addon/components/product/card.hbs',

--- a/tests/migration/ember-engine/addon/component-templates/engine-typescript.test.js
+++ b/tests/migration/ember-engine/addon/component-templates/engine-typescript.test.js
@@ -11,9 +11,7 @@ test('migration | ember-engine | addon | component-templates > TypeScript', func
 
   loadFixture(inputProject, options);
 
-  const migrationStrategy = migrationStrategyForComponentTemplates(
-    options.projectRoot
-  );
+  const migrationStrategy = migrationStrategyForComponentTemplates(options);
 
   assert.deepStrictEqual(migrationStrategy, [
     [

--- a/tests/migration/ember-engine/addon/route-controllers/engine-javascript.test.js
+++ b/tests/migration/ember-engine/addon/route-controllers/engine-javascript.test.js
@@ -11,9 +11,7 @@ test('migration | ember-engine | addon | route-controllers > JavaScript', functi
 
   loadFixture(inputProject, options);
 
-  const migrationStrategy = migrationStrategyForRouteControllers(
-    options.projectRoot
-  );
+  const migrationStrategy = migrationStrategyForRouteControllers(options);
 
   assert.deepStrictEqual(migrationStrategy, [
     ['addon/products/controller.js', 'addon/controllers/products.js'],

--- a/tests/migration/ember-engine/addon/route-controllers/engine-javascript.test.js
+++ b/tests/migration/ember-engine/addon/route-controllers/engine-javascript.test.js
@@ -2,12 +2,20 @@ import { migrationStrategyForRouteControllers } from '../../../../../src/migrati
 import { inputProject } from '../../../../fixtures/engine-javascript.js';
 import { assert, loadFixture, test } from '../../../../test-helpers.js';
 
-const projectRoot = 'tmp/engine-javascript';
-
 test('migration | ember-engine | addon | route-controllers > JavaScript', function () {
-  loadFixture(projectRoot, inputProject);
+  const options = {
+    podPath: '',
+    projectRoot: 'tmp/engine-javascript',
+    testRun: false,
+  };
 
-  assert.deepStrictEqual(migrationStrategyForRouteControllers(projectRoot), [
+  loadFixture(inputProject, options);
+
+  const migrationStrategy = migrationStrategyForRouteControllers(
+    options.projectRoot
+  );
+
+  assert.deepStrictEqual(migrationStrategy, [
     ['addon/products/controller.js', 'addon/controllers/products.js'],
   ]);
 });

--- a/tests/migration/ember-engine/addon/route-controllers/engine-typescript.test.js
+++ b/tests/migration/ember-engine/addon/route-controllers/engine-typescript.test.js
@@ -11,9 +11,7 @@ test('migration | ember-engine | addon | route-controllers > TypeScript', functi
 
   loadFixture(inputProject, options);
 
-  const migrationStrategy = migrationStrategyForRouteControllers(
-    options.projectRoot
-  );
+  const migrationStrategy = migrationStrategyForRouteControllers(options);
 
   assert.deepStrictEqual(migrationStrategy, [
     ['addon/products/controller.ts', 'addon/controllers/products.ts'],

--- a/tests/migration/ember-engine/addon/route-controllers/engine-typescript.test.js
+++ b/tests/migration/ember-engine/addon/route-controllers/engine-typescript.test.js
@@ -2,12 +2,20 @@ import { migrationStrategyForRouteControllers } from '../../../../../src/migrati
 import { inputProject } from '../../../../fixtures/engine-typescript.js';
 import { assert, loadFixture, test } from '../../../../test-helpers.js';
 
-const projectRoot = 'tmp/engine-typescript';
-
 test('migration | ember-engine | addon | route-controllers > TypeScript', function () {
-  loadFixture(projectRoot, inputProject);
+  const options = {
+    podPath: '',
+    projectRoot: 'tmp/engine-typescript',
+    testRun: false,
+  };
 
-  assert.deepStrictEqual(migrationStrategyForRouteControllers(projectRoot), [
+  loadFixture(inputProject, options);
+
+  const migrationStrategy = migrationStrategyForRouteControllers(
+    options.projectRoot
+  );
+
+  assert.deepStrictEqual(migrationStrategy, [
     ['addon/products/controller.ts', 'addon/controllers/products.ts'],
   ]);
 });

--- a/tests/migration/ember-engine/addon/route-routes/engine-javascript.test.js
+++ b/tests/migration/ember-engine/addon/route-routes/engine-javascript.test.js
@@ -2,12 +2,20 @@ import { migrationStrategyForRouteRoutes } from '../../../../../src/migration/em
 import { inputProject } from '../../../../fixtures/engine-javascript.js';
 import { assert, loadFixture, test } from '../../../../test-helpers.js';
 
-const projectRoot = 'tmp/engine-javascript';
-
 test('migration | ember-engine | addon | route-routes > JavaScript', function () {
-  loadFixture(projectRoot, inputProject);
+  const options = {
+    podPath: '',
+    projectRoot: 'tmp/engine-javascript',
+    testRun: false,
+  };
 
-  assert.deepStrictEqual(migrationStrategyForRouteRoutes(projectRoot), [
+  loadFixture(inputProject, options);
+
+  const migrationStrategy = migrationStrategyForRouteRoutes(
+    options.projectRoot
+  );
+
+  assert.deepStrictEqual(migrationStrategy, [
     ['addon/product-details/route.js', 'addon/routes/product-details.js'],
     ['addon/products/product/route.js', 'addon/routes/products/product.js'],
     ['addon/products/route.js', 'addon/routes/products.js'],

--- a/tests/migration/ember-engine/addon/route-routes/engine-javascript.test.js
+++ b/tests/migration/ember-engine/addon/route-routes/engine-javascript.test.js
@@ -11,9 +11,7 @@ test('migration | ember-engine | addon | route-routes > JavaScript', function ()
 
   loadFixture(inputProject, options);
 
-  const migrationStrategy = migrationStrategyForRouteRoutes(
-    options.projectRoot
-  );
+  const migrationStrategy = migrationStrategyForRouteRoutes(options);
 
   assert.deepStrictEqual(migrationStrategy, [
     ['addon/product-details/route.js', 'addon/routes/product-details.js'],

--- a/tests/migration/ember-engine/addon/route-routes/engine-typescript.test.js
+++ b/tests/migration/ember-engine/addon/route-routes/engine-typescript.test.js
@@ -11,9 +11,7 @@ test('migration | ember-engine | addon | route-routes > TypeScript', function ()
 
   loadFixture(inputProject, options);
 
-  const migrationStrategy = migrationStrategyForRouteRoutes(
-    options.projectRoot
-  );
+  const migrationStrategy = migrationStrategyForRouteRoutes(options);
 
   assert.deepStrictEqual(migrationStrategy, [
     ['addon/product-details/route.ts', 'addon/routes/product-details.ts'],

--- a/tests/migration/ember-engine/addon/route-routes/engine-typescript.test.js
+++ b/tests/migration/ember-engine/addon/route-routes/engine-typescript.test.js
@@ -2,12 +2,20 @@ import { migrationStrategyForRouteRoutes } from '../../../../../src/migration/em
 import { inputProject } from '../../../../fixtures/engine-typescript.js';
 import { assert, loadFixture, test } from '../../../../test-helpers.js';
 
-const projectRoot = 'tmp/engine-typescript';
-
 test('migration | ember-engine | addon | route-routes > TypeScript', function () {
-  loadFixture(projectRoot, inputProject);
+  const options = {
+    podPath: '',
+    projectRoot: 'tmp/engine-typescript',
+    testRun: false,
+  };
 
-  assert.deepStrictEqual(migrationStrategyForRouteRoutes(projectRoot), [
+  loadFixture(inputProject, options);
+
+  const migrationStrategy = migrationStrategyForRouteRoutes(
+    options.projectRoot
+  );
+
+  assert.deepStrictEqual(migrationStrategy, [
     ['addon/product-details/route.ts', 'addon/routes/product-details.ts'],
     ['addon/products/product/route.ts', 'addon/routes/products/product.ts'],
     ['addon/products/route.ts', 'addon/routes/products.ts'],

--- a/tests/migration/ember-engine/addon/route-stylesheets/engine-javascript.test.js
+++ b/tests/migration/ember-engine/addon/route-stylesheets/engine-javascript.test.js
@@ -11,9 +11,7 @@ test('migration | ember-engine | addon | route-stylesheets > JavaScript', functi
 
   loadFixture(inputProject, options);
 
-  const migrationStrategy = migrationStrategyForRouteStylesheets(
-    options.projectRoot
-  );
+  const migrationStrategy = migrationStrategyForRouteStylesheets(options);
 
   assert.deepStrictEqual(migrationStrategy, [
     ['addon/product-details/styles.css', 'addon/styles/product-details.css'],

--- a/tests/migration/ember-engine/addon/route-stylesheets/engine-javascript.test.js
+++ b/tests/migration/ember-engine/addon/route-stylesheets/engine-javascript.test.js
@@ -2,12 +2,20 @@ import { migrationStrategyForRouteStylesheets } from '../../../../../src/migrati
 import { inputProject } from '../../../../fixtures/engine-javascript.js';
 import { assert, loadFixture, test } from '../../../../test-helpers.js';
 
-const projectRoot = 'tmp/engine-javascript';
-
 test('migration | ember-engine | addon | route-stylesheets > JavaScript', function () {
-  loadFixture(projectRoot, inputProject);
+  const options = {
+    podPath: '',
+    projectRoot: 'tmp/engine-javascript',
+    testRun: false,
+  };
 
-  assert.deepStrictEqual(migrationStrategyForRouteStylesheets(projectRoot), [
+  loadFixture(inputProject, options);
+
+  const migrationStrategy = migrationStrategyForRouteStylesheets(
+    options.projectRoot
+  );
+
+  assert.deepStrictEqual(migrationStrategy, [
     ['addon/product-details/styles.css', 'addon/styles/product-details.css'],
     [
       'addon/products/product/styles.scss',

--- a/tests/migration/ember-engine/addon/route-stylesheets/engine-typescript.test.js
+++ b/tests/migration/ember-engine/addon/route-stylesheets/engine-typescript.test.js
@@ -2,12 +2,20 @@ import { migrationStrategyForRouteStylesheets } from '../../../../../src/migrati
 import { inputProject } from '../../../../fixtures/engine-typescript.js';
 import { assert, loadFixture, test } from '../../../../test-helpers.js';
 
-const projectRoot = 'tmp/engine-typescript';
-
 test('migration | ember-engine | addon | route-stylesheets > TypeScript', function () {
-  loadFixture(projectRoot, inputProject);
+  const options = {
+    podPath: '',
+    projectRoot: 'tmp/engine-typescript',
+    testRun: false,
+  };
 
-  assert.deepStrictEqual(migrationStrategyForRouteStylesheets(projectRoot), [
+  loadFixture(inputProject, options);
+
+  const migrationStrategy = migrationStrategyForRouteStylesheets(
+    options.projectRoot
+  );
+
+  assert.deepStrictEqual(migrationStrategy, [
     ['addon/product-details/styles.css', 'addon/styles/product-details.css'],
     [
       'addon/products/product/styles.scss',

--- a/tests/migration/ember-engine/addon/route-stylesheets/engine-typescript.test.js
+++ b/tests/migration/ember-engine/addon/route-stylesheets/engine-typescript.test.js
@@ -11,9 +11,7 @@ test('migration | ember-engine | addon | route-stylesheets > TypeScript', functi
 
   loadFixture(inputProject, options);
 
-  const migrationStrategy = migrationStrategyForRouteStylesheets(
-    options.projectRoot
-  );
+  const migrationStrategy = migrationStrategyForRouteStylesheets(options);
 
   assert.deepStrictEqual(migrationStrategy, [
     ['addon/product-details/styles.css', 'addon/styles/product-details.css'],

--- a/tests/migration/ember-engine/addon/route-templates/engine-javascript.test.js
+++ b/tests/migration/ember-engine/addon/route-templates/engine-javascript.test.js
@@ -11,9 +11,7 @@ test('migration | ember-engine | addon | route-templates > JavaScript', function
 
   loadFixture(inputProject, options);
 
-  const migrationStrategy = migrationStrategyForRouteTemplates(
-    options.projectRoot
-  );
+  const migrationStrategy = migrationStrategyForRouteTemplates(options);
 
   assert.deepStrictEqual(migrationStrategy, [
     [

--- a/tests/migration/ember-engine/addon/route-templates/engine-javascript.test.js
+++ b/tests/migration/ember-engine/addon/route-templates/engine-javascript.test.js
@@ -2,12 +2,20 @@ import { migrationStrategyForRouteTemplates } from '../../../../../src/migration
 import { inputProject } from '../../../../fixtures/engine-javascript.js';
 import { assert, loadFixture, test } from '../../../../test-helpers.js';
 
-const projectRoot = 'tmp/engine-javascript';
-
 test('migration | ember-engine | addon | route-templates > JavaScript', function () {
-  loadFixture(projectRoot, inputProject);
+  const options = {
+    podPath: '',
+    projectRoot: 'tmp/engine-javascript',
+    testRun: false,
+  };
 
-  assert.deepStrictEqual(migrationStrategyForRouteTemplates(projectRoot), [
+  loadFixture(inputProject, options);
+
+  const migrationStrategy = migrationStrategyForRouteTemplates(
+    options.projectRoot
+  );
+
+  assert.deepStrictEqual(migrationStrategy, [
     [
       'addon/product-details/template.hbs',
       'addon/templates/product-details.hbs',

--- a/tests/migration/ember-engine/addon/route-templates/engine-typescript.test.js
+++ b/tests/migration/ember-engine/addon/route-templates/engine-typescript.test.js
@@ -11,9 +11,7 @@ test('migration | ember-engine | addon | route-templates > TypeScript', function
 
   loadFixture(inputProject, options);
 
-  const migrationStrategy = migrationStrategyForRouteTemplates(
-    options.projectRoot
-  );
+  const migrationStrategy = migrationStrategyForRouteTemplates(options);
 
   assert.deepStrictEqual(migrationStrategy, [
     [

--- a/tests/migration/ember-engine/addon/route-templates/engine-typescript.test.js
+++ b/tests/migration/ember-engine/addon/route-templates/engine-typescript.test.js
@@ -2,12 +2,20 @@ import { migrationStrategyForRouteTemplates } from '../../../../../src/migration
 import { inputProject } from '../../../../fixtures/engine-typescript.js';
 import { assert, loadFixture, test } from '../../../../test-helpers.js';
 
-const projectRoot = 'tmp/engine-typescript';
-
 test('migration | ember-engine | addon | route-templates > TypeScript', function () {
-  loadFixture(projectRoot, inputProject);
+  const options = {
+    podPath: '',
+    projectRoot: 'tmp/engine-typescript',
+    testRun: false,
+  };
 
-  assert.deepStrictEqual(migrationStrategyForRouteTemplates(projectRoot), [
+  loadFixture(inputProject, options);
+
+  const migrationStrategy = migrationStrategyForRouteTemplates(
+    options.projectRoot
+  );
+
+  assert.deepStrictEqual(migrationStrategy, [
     [
       'addon/product-details/template.hbs',
       'addon/templates/product-details.hbs',

--- a/tests/migration/ember-engine/index/engine-javascript.test.js
+++ b/tests/migration/ember-engine/index/engine-javascript.test.js
@@ -5,23 +5,21 @@ import {
 } from '../../../fixtures/engine-javascript.js';
 import { assertFixture, loadFixture, test } from '../../../test-helpers.js';
 
-const projectRoot = 'tmp/engine-javascript';
-
 test('migration | ember-engine | index > JavaScript', function () {
-  loadFixture(projectRoot, inputProject);
-
-  migrateEmberEngine({
-    projectRoot,
+  const options = {
+    podPath: '',
+    projectRoot: 'tmp/engine-javascript',
     testRun: false,
-  });
+  };
 
-  assertFixture(projectRoot, outputProject);
+  loadFixture(inputProject, options);
+
+  migrateEmberEngine(options);
+
+  assertFixture(outputProject, options);
 
   // Check idempotence
-  migrateEmberEngine({
-    projectRoot,
-    testRun: false,
-  });
+  migrateEmberEngine(options);
 
-  assertFixture(projectRoot, outputProject);
+  assertFixture(outputProject, options);
 });

--- a/tests/migration/ember-engine/index/engine-typescript.test.js
+++ b/tests/migration/ember-engine/index/engine-typescript.test.js
@@ -5,23 +5,21 @@ import {
 } from '../../../fixtures/engine-typescript.js';
 import { assertFixture, loadFixture, test } from '../../../test-helpers.js';
 
-const projectRoot = 'tmp/engine-typescript';
-
 test('migration | ember-engine | index > TypeScript', function () {
-  loadFixture(projectRoot, inputProject);
-
-  migrateEmberEngine({
-    projectRoot,
+  const options = {
+    podPath: '',
+    projectRoot: 'tmp/engine-typescript',
     testRun: false,
-  });
+  };
 
-  assertFixture(projectRoot, outputProject);
+  loadFixture(inputProject, options);
+
+  migrateEmberEngine(options);
+
+  assertFixture(outputProject, options);
 
   // Check idempotence
-  migrateEmberEngine({
-    projectRoot,
-    testRun: false,
-  });
+  migrateEmberEngine(options);
 
-  assertFixture(projectRoot, outputProject);
+  assertFixture(outputProject, options);
 });

--- a/tests/migration/ember-engine/tests/components/engine-javascript.test.js
+++ b/tests/migration/ember-engine/tests/components/engine-javascript.test.js
@@ -11,7 +11,7 @@ test('migration | ember-engine | tests | components > JavaScript', function () {
 
   loadFixture(inputProject, options);
 
-  const migrationStrategy = migrationStrategyForComponents(options.projectRoot);
+  const migrationStrategy = migrationStrategyForComponents(options);
 
   assert.deepStrictEqual(migrationStrategy, [
     [

--- a/tests/migration/ember-engine/tests/components/engine-javascript.test.js
+++ b/tests/migration/ember-engine/tests/components/engine-javascript.test.js
@@ -2,12 +2,18 @@ import { migrationStrategyForComponents } from '../../../../../src/migration/emb
 import { inputProject } from '../../../../fixtures/engine-javascript.js';
 import { assert, loadFixture, test } from '../../../../test-helpers.js';
 
-const projectRoot = 'tmp/engine-javascript';
-
 test('migration | ember-engine | tests | components > JavaScript', function () {
-  loadFixture(projectRoot, inputProject);
+  const options = {
+    podPath: '',
+    projectRoot: 'tmp/engine-javascript',
+    testRun: false,
+  };
 
-  assert.deepStrictEqual(migrationStrategyForComponents(projectRoot), [
+  loadFixture(inputProject, options);
+
+  const migrationStrategy = migrationStrategyForComponents(options.projectRoot);
+
+  assert.deepStrictEqual(migrationStrategy, [
     [
       'tests/integration/components/product/card/component-test.js',
       'tests/integration/components/product/card-test.js',

--- a/tests/migration/ember-engine/tests/components/engine-typescript.test.js
+++ b/tests/migration/ember-engine/tests/components/engine-typescript.test.js
@@ -11,7 +11,7 @@ test('migration | ember-engine | tests | components > TypeScript', function () {
 
   loadFixture(inputProject, options);
 
-  const migrationStrategy = migrationStrategyForComponents(options.projectRoot);
+  const migrationStrategy = migrationStrategyForComponents(options);
 
   assert.deepStrictEqual(migrationStrategy, [
     [

--- a/tests/migration/ember-engine/tests/components/engine-typescript.test.js
+++ b/tests/migration/ember-engine/tests/components/engine-typescript.test.js
@@ -2,12 +2,18 @@ import { migrationStrategyForComponents } from '../../../../../src/migration/emb
 import { inputProject } from '../../../../fixtures/engine-typescript.js';
 import { assert, loadFixture, test } from '../../../../test-helpers.js';
 
-const projectRoot = 'tmp/engine-typescript';
-
 test('migration | ember-engine | tests | components > TypeScript', function () {
-  loadFixture(projectRoot, inputProject);
+  const options = {
+    podPath: '',
+    projectRoot: 'tmp/engine-typescript',
+    testRun: false,
+  };
 
-  assert.deepStrictEqual(migrationStrategyForComponents(projectRoot), [
+  loadFixture(inputProject, options);
+
+  const migrationStrategy = migrationStrategyForComponents(options.projectRoot);
+
+  assert.deepStrictEqual(migrationStrategy, [
     [
       'tests/integration/components/product/card/component-test.ts',
       'tests/integration/components/product/card-test.ts',

--- a/tests/migration/ember-engine/tests/route-controllers/engine-javascript.test.js
+++ b/tests/migration/ember-engine/tests/route-controllers/engine-javascript.test.js
@@ -2,12 +2,20 @@ import { migrationStrategyForRouteControllers } from '../../../../../src/migrati
 import { inputProject } from '../../../../fixtures/engine-javascript.js';
 import { assert, loadFixture, test } from '../../../../test-helpers.js';
 
-const projectRoot = 'tmp/engine-javascript';
-
 test('migration | ember-engine | tests | route-controllers > JavaScript', function () {
-  loadFixture(projectRoot, inputProject);
+  const options = {
+    podPath: '',
+    projectRoot: 'tmp/engine-javascript',
+    testRun: false,
+  };
 
-  assert.deepStrictEqual(migrationStrategyForRouteControllers(projectRoot), [
+  loadFixture(inputProject, options);
+
+  const migrationStrategy = migrationStrategyForRouteControllers(
+    options.projectRoot
+  );
+
+  assert.deepStrictEqual(migrationStrategy, [
     [
       'tests/unit/products/controller-test.js',
       'tests/unit/controllers/products-test.js',

--- a/tests/migration/ember-engine/tests/route-controllers/engine-javascript.test.js
+++ b/tests/migration/ember-engine/tests/route-controllers/engine-javascript.test.js
@@ -11,9 +11,7 @@ test('migration | ember-engine | tests | route-controllers > JavaScript', functi
 
   loadFixture(inputProject, options);
 
-  const migrationStrategy = migrationStrategyForRouteControllers(
-    options.projectRoot
-  );
+  const migrationStrategy = migrationStrategyForRouteControllers(options);
 
   assert.deepStrictEqual(migrationStrategy, [
     [

--- a/tests/migration/ember-engine/tests/route-controllers/engine-typescript.test.js
+++ b/tests/migration/ember-engine/tests/route-controllers/engine-typescript.test.js
@@ -2,12 +2,20 @@ import { migrationStrategyForRouteControllers } from '../../../../../src/migrati
 import { inputProject } from '../../../../fixtures/engine-typescript.js';
 import { assert, loadFixture, test } from '../../../../test-helpers.js';
 
-const projectRoot = 'tmp/engine-typescript';
-
 test('migration | ember-engine | tests | route-controllers > TypeScript', function () {
-  loadFixture(projectRoot, inputProject);
+  const options = {
+    podPath: '',
+    projectRoot: 'tmp/engine-typescript',
+    testRun: false,
+  };
 
-  assert.deepStrictEqual(migrationStrategyForRouteControllers(projectRoot), [
+  loadFixture(inputProject, options);
+
+  const migrationStrategy = migrationStrategyForRouteControllers(
+    options.projectRoot
+  );
+
+  assert.deepStrictEqual(migrationStrategy, [
     [
       'tests/unit/products/controller-test.ts',
       'tests/unit/controllers/products-test.ts',

--- a/tests/migration/ember-engine/tests/route-controllers/engine-typescript.test.js
+++ b/tests/migration/ember-engine/tests/route-controllers/engine-typescript.test.js
@@ -11,9 +11,7 @@ test('migration | ember-engine | tests | route-controllers > TypeScript', functi
 
   loadFixture(inputProject, options);
 
-  const migrationStrategy = migrationStrategyForRouteControllers(
-    options.projectRoot
-  );
+  const migrationStrategy = migrationStrategyForRouteControllers(options);
 
   assert.deepStrictEqual(migrationStrategy, [
     [

--- a/tests/migration/ember-engine/tests/route-routes/engine-javascript.test.js
+++ b/tests/migration/ember-engine/tests/route-routes/engine-javascript.test.js
@@ -11,9 +11,7 @@ test('migration | ember-engine | tests | route-routes > JavaScript', function ()
 
   loadFixture(inputProject, options);
 
-  const migrationStrategy = migrationStrategyForRouteRoutes(
-    options.projectRoot
-  );
+  const migrationStrategy = migrationStrategyForRouteRoutes(options);
 
   assert.deepStrictEqual(migrationStrategy, [
     [

--- a/tests/migration/ember-engine/tests/route-routes/engine-javascript.test.js
+++ b/tests/migration/ember-engine/tests/route-routes/engine-javascript.test.js
@@ -2,12 +2,20 @@ import { migrationStrategyForRouteRoutes } from '../../../../../src/migration/em
 import { inputProject } from '../../../../fixtures/engine-javascript.js';
 import { assert, loadFixture, test } from '../../../../test-helpers.js';
 
-const projectRoot = 'tmp/engine-javascript';
-
 test('migration | ember-engine | tests | route-routes > JavaScript', function () {
-  loadFixture(projectRoot, inputProject);
+  const options = {
+    podPath: '',
+    projectRoot: 'tmp/engine-javascript',
+    testRun: false,
+  };
 
-  assert.deepStrictEqual(migrationStrategyForRouteRoutes(projectRoot), [
+  loadFixture(inputProject, options);
+
+  const migrationStrategy = migrationStrategyForRouteRoutes(
+    options.projectRoot
+  );
+
+  assert.deepStrictEqual(migrationStrategy, [
     [
       'tests/unit/product-details/route-test.js',
       'tests/unit/routes/product-details-test.js',

--- a/tests/migration/ember-engine/tests/route-routes/engine-typescript.test.js
+++ b/tests/migration/ember-engine/tests/route-routes/engine-typescript.test.js
@@ -11,9 +11,7 @@ test('migration | ember-engine | tests | route-routes > TypeScript', function ()
 
   loadFixture(inputProject, options);
 
-  const migrationStrategy = migrationStrategyForRouteRoutes(
-    options.projectRoot
-  );
+  const migrationStrategy = migrationStrategyForRouteRoutes(options);
 
   assert.deepStrictEqual(migrationStrategy, [
     [

--- a/tests/migration/ember-engine/tests/route-routes/engine-typescript.test.js
+++ b/tests/migration/ember-engine/tests/route-routes/engine-typescript.test.js
@@ -2,12 +2,20 @@ import { migrationStrategyForRouteRoutes } from '../../../../../src/migration/em
 import { inputProject } from '../../../../fixtures/engine-typescript.js';
 import { assert, loadFixture, test } from '../../../../test-helpers.js';
 
-const projectRoot = 'tmp/engine-typescript';
-
 test('migration | ember-engine | tests | route-routes > TypeScript', function () {
-  loadFixture(projectRoot, inputProject);
+  const options = {
+    podPath: '',
+    projectRoot: 'tmp/engine-typescript',
+    testRun: false,
+  };
 
-  assert.deepStrictEqual(migrationStrategyForRouteRoutes(projectRoot), [
+  loadFixture(inputProject, options);
+
+  const migrationStrategy = migrationStrategyForRouteRoutes(
+    options.projectRoot
+  );
+
+  assert.deepStrictEqual(migrationStrategy, [
     [
       'tests/unit/product-details/route-test.ts',
       'tests/unit/routes/product-details-test.ts',

--- a/tests/test-helpers.js
+++ b/tests/test-helpers.js
@@ -3,11 +3,15 @@ import fixturify from 'fixturify';
 import { strict as assert } from 'node:assert';
 import { existsSync, rmSync } from 'node:fs';
 
-export function assertFixture(projectRoot, outputProject) {
+export function assertFixture(outputProject, options) {
+  const { projectRoot } = options;
+
   assert.deepStrictEqual(fixturify.readSync(projectRoot), outputProject);
 }
 
-export function loadFixture(projectRoot, inputProject) {
+export function loadFixture(inputProject, options) {
+  const { projectRoot } = options;
+
   if (existsSync(projectRoot)) {
     rmSync(projectRoot, { recursive: true });
   }

--- a/tests/utils/ember-addon/app/components.test.js
+++ b/tests/utils/ember-addon/app/components.test.js
@@ -9,23 +9,35 @@ test('utils | ember-addon | app | components', function () {
     testRun: false,
   };
 
-  loadFixture(
-    {
-      app: {
-        components: {
-          ui: {
-            form: {
-              checkbox: {
-                'component.js':
-                  "export { default } from 'addon-javascript/components/ui/form/checkbox/component';\n",
-              },
+  const inputProject = {
+    app: {
+      components: {
+        ui: {
+          form: {
+            checkbox: {
+              'component.js':
+                "export { default } from 'addon-javascript/components/ui/form/checkbox/component';\n",
             },
           },
         },
       },
     },
-    options
-  );
+  };
+
+  const outputProject = {
+    app: {
+      components: {
+        ui: {
+          form: {
+            'checkbox.js':
+              "export { default } from 'addon-javascript/components/ui/form/checkbox';\n",
+          },
+        },
+      },
+    },
+  };
+
+  loadFixture(inputProject, options);
 
   const migrationStrategy = new Map([
     [
@@ -38,19 +50,5 @@ test('utils | ember-addon | app | components', function () {
 
   updatePaths(migrationStrategy, options);
 
-  assertFixture(
-    {
-      app: {
-        components: {
-          ui: {
-            form: {
-              'checkbox.js':
-                "export { default } from 'addon-javascript/components/ui/form/checkbox';\n",
-            },
-          },
-        },
-      },
-    },
-    options
-  );
+  assertFixture(outputProject, options);
 });

--- a/tests/utils/ember-addon/app/components.test.js
+++ b/tests/utils/ember-addon/app/components.test.js
@@ -2,23 +2,30 @@ import { updatePaths } from '../../../../src/utils/ember-addon/app/components.js
 import { moveFiles } from '../../../../src/utils/move-files.js';
 import { assertFixture, loadFixture, test } from '../../../test-helpers.js';
 
-const projectRoot = 'tmp/addon-javascript';
-
 test('utils | ember-addon | app | components', function () {
-  loadFixture(projectRoot, {
-    app: {
-      components: {
-        ui: {
-          form: {
-            checkbox: {
-              'component.js':
-                "export { default } from 'addon-javascript/components/ui/form/checkbox/component';\n",
+  const options = {
+    podPath: '',
+    projectRoot: 'tmp/addon-javascript',
+    testRun: false,
+  };
+
+  loadFixture(
+    {
+      app: {
+        components: {
+          ui: {
+            form: {
+              checkbox: {
+                'component.js':
+                  "export { default } from 'addon-javascript/components/ui/form/checkbox/component';\n",
+              },
             },
           },
         },
       },
     },
-  });
+    options
+  );
 
   const migrationStrategy = new Map([
     [
@@ -29,24 +36,27 @@ test('utils | ember-addon | app | components', function () {
 
   moveFiles({
     migrationStrategy,
-    projectRoot,
+    projectRoot: options.projectRoot,
   });
 
   updatePaths({
     migrationStrategy,
-    projectRoot,
+    projectRoot: options.projectRoot,
   });
 
-  assertFixture(projectRoot, {
-    app: {
-      components: {
-        ui: {
-          form: {
-            'checkbox.js':
-              "export { default } from 'addon-javascript/components/ui/form/checkbox';\n",
+  assertFixture(
+    {
+      app: {
+        components: {
+          ui: {
+            form: {
+              'checkbox.js':
+                "export { default } from 'addon-javascript/components/ui/form/checkbox';\n",
+            },
           },
         },
       },
     },
-  });
+    options
+  );
 });

--- a/tests/utils/ember-addon/app/components.test.js
+++ b/tests/utils/ember-addon/app/components.test.js
@@ -34,15 +34,9 @@ test('utils | ember-addon | app | components', function () {
     ],
   ]);
 
-  moveFiles({
-    migrationStrategy,
-    projectRoot: options.projectRoot,
-  });
+  moveFiles(migrationStrategy, options);
 
-  updatePaths({
-    migrationStrategy,
-    projectRoot: options.projectRoot,
-  });
+  updatePaths(migrationStrategy, options);
 
   assertFixture(
     {

--- a/tests/utils/move-files.test.js
+++ b/tests/utils/move-files.test.js
@@ -32,10 +32,7 @@ test('utils | move-files', function () {
     ],
   ]);
 
-  moveFiles({
-    migrationStrategy,
-    projectRoot: options.projectRoot,
-  });
+  moveFiles(migrationStrategy, options);
 
   assertFixture(
     {

--- a/tests/utils/move-files.test.js
+++ b/tests/utils/move-files.test.js
@@ -1,22 +1,29 @@
 import { moveFiles } from '../../src/utils/move-files.js';
 import { assertFixture, loadFixture, test } from '../test-helpers.js';
 
-const projectRoot = 'tmp/addon-javascript';
-
 test('utils | move-files', function () {
-  loadFixture(projectRoot, {
-    addon: {
-      components: {
-        ui: {
-          form: {
-            checkbox: {
-              'component.js': '',
+  const options = {
+    podPath: '',
+    projectRoot: 'tmp/addon-javascript',
+    testRun: false,
+  };
+
+  loadFixture(
+    {
+      addon: {
+        components: {
+          ui: {
+            form: {
+              checkbox: {
+                'component.js': '',
+              },
             },
           },
         },
       },
     },
-  });
+    options
+  );
 
   const migrationStrategy = new Map([
     [
@@ -27,18 +34,21 @@ test('utils | move-files', function () {
 
   moveFiles({
     migrationStrategy,
-    projectRoot,
+    projectRoot: options.projectRoot,
   });
 
-  assertFixture(projectRoot, {
-    addon: {
-      components: {
-        ui: {
-          form: {
-            'checkbox.js': '',
+  assertFixture(
+    {
+      addon: {
+        components: {
+          ui: {
+            form: {
+              'checkbox.js': '',
+            },
           },
         },
       },
     },
-  });
+    options
+  );
 });

--- a/tests/utils/move-files.test.js
+++ b/tests/utils/move-files.test.js
@@ -8,22 +8,33 @@ test('utils | move-files', function () {
     testRun: false,
   };
 
-  loadFixture(
-    {
-      addon: {
-        components: {
-          ui: {
-            form: {
-              checkbox: {
-                'component.js': '',
-              },
+  const inputProject = {
+    addon: {
+      components: {
+        ui: {
+          form: {
+            checkbox: {
+              'component.js': '',
             },
           },
         },
       },
     },
-    options
-  );
+  };
+
+  const outputProject = {
+    addon: {
+      components: {
+        ui: {
+          form: {
+            'checkbox.js': '',
+          },
+        },
+      },
+    },
+  };
+
+  loadFixture(inputProject, options);
 
   const migrationStrategy = new Map([
     [
@@ -34,18 +45,5 @@ test('utils | move-files', function () {
 
   moveFiles(migrationStrategy, options);
 
-  assertFixture(
-    {
-      addon: {
-        components: {
-          ui: {
-            form: {
-              'checkbox.js': '',
-            },
-          },
-        },
-      },
-    },
-    options
-  );
+  assertFixture(outputProject, options);
 });

--- a/tests/utils/move-files.test.js
+++ b/tests/utils/move-files.test.js
@@ -47,3 +47,52 @@ test('utils | move-files', function () {
 
   assertFixture(outputProject, options);
 });
+
+test('utils | move-files > removeDirectoryIfEmpty', function () {
+  const options = {
+    podPath: 'pods',
+    projectRoot: 'tmp/app-pod-path',
+    testRun: false,
+  };
+
+  const inputProject = {
+    app: {
+      pods: {
+        components: {
+          ui: {
+            form: {
+              checkbox: {
+                'component.js': '',
+              },
+            },
+          },
+        },
+      },
+    },
+  };
+
+  const outputProject = {
+    app: {
+      components: {
+        ui: {
+          form: {
+            'checkbox.js': '',
+          },
+        },
+      },
+    },
+  };
+
+  loadFixture(inputProject, options);
+
+  const migrationStrategy = new Map([
+    [
+      'app/pods/components/ui/form/checkbox/component.js',
+      'app/components/ui/form/checkbox.js',
+    ],
+  ]);
+
+  moveFiles(migrationStrategy, options);
+
+  assertFixture(outputProject, options);
+});


### PR DESCRIPTION
## Description

Closes #1. If a user specified `podModulePrefix` in their `config/environment.js`, they can pass the argument `--pod-path` to the codemod. At the moment, the `--pod-path` argument affects only Ember apps.

Note, the name `podPath` came from the [`emberjs/ember.js` repo](https://github.com/emberjs/ember.js/blob/v4.6.0/blueprints/route-test/index.js#L46). The value refers to the "difference" between `podModulePrefix` and `modulePrefix`. For example, if a user has the following `config/environment.js`:

```js
/* config/environment.js */
'use strict';

module.exports = function (environment) {
  let ENV = {
    modulePrefix: 'my-app',
    podModulePrefix: 'my-app/pods',
    ...
  };

  return ENV;
};
```

then:

```sh
podPath = 'my-app/pods' - 'my-app' = 'pods'
```

So the user will need to enter the following command:

```sh
npx ember-codemod-pod-to-octane --pod-path=pods --type=app
```

Due to a change in APIs, this pull request unfortunately became large. There may be opportunities to refactor code. Let's do in a separate issue and pull request.