### PR TITLE
Separated two types of options

### DIFF
--- a/bin/ember-codemod-pod-to-octane.js
+++ b/bin/ember-codemod-pod-to-octane.js
@@ -32,11 +32,11 @@ const { argv } = yargs(hideBin(process.argv))
     type: 'string',
   });
 
-const options = {
+const codemodOptions = {
   podPath: argv['pod-path'],
   projectRoot: argv['root'] ?? process.cwd(),
   projectType: argv['type'],
   testRun: argv['test'],
 };
 
-runCodemod(options);
+runCodemod(codemodOptions);

--- a/src/index.js
+++ b/src/index.js
@@ -4,25 +4,25 @@ import {
   migrateEmberEngine,
 } from './migration/index.js';
 
-export function runCodemod(options) {
-  switch (options.projectType) {
+export function runCodemod(codemodOptions) {
+  switch (codemodOptions.projectType) {
     case 'addon': {
-      migrateEmberAddon(options);
+      migrateEmberAddon(codemodOptions);
       break;
     }
 
     case 'app': {
-      migrateEmberApp(options);
+      migrateEmberApp(codemodOptions);
       break;
     }
 
     case 'engine': {
-      migrateEmberEngine(options);
+      migrateEmberEngine(codemodOptions);
       break;
     }
 
     default: {
-      console.error(`Unknown project type: ${options.projectType}`);
+      console.error(`Unknown project type: ${codemodOptions.projectType}`);
     }
   }
 }

--- a/src/migration/ember-addon/index.js
+++ b/src/migration/ember-addon/index.js
@@ -2,9 +2,12 @@ import { updatePaths } from '../../utils/ember-addon/app/components.js';
 import { moveFiles } from '../../utils/files.js';
 import { migrationStrategyForAddonFolder } from './addon/index.js';
 import { migrationStrategyForAppFolder } from './app/index.js';
+import { createOptions } from './steps/index.js';
 import { migrationStrategyForTestsFolder } from './tests/index.js';
 
-export function migrateEmberAddon(options) {
+export function migrateEmberAddon(codemodOptions) {
+  const options = createOptions(codemodOptions);
+
   const migrationStrategyAddon = migrationStrategyForAddonFolder(options);
   const migrationStrategyApp = migrationStrategyForAppFolder(options);
   const migrationStrategyTests = migrationStrategyForTestsFolder(options);

--- a/src/migration/ember-addon/steps/create-options.js
+++ b/src/migration/ember-addon/steps/create-options.js
@@ -1,0 +1,46 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+function analyzePackageJson(codemodOptions) {
+  const { projectRoot } = codemodOptions;
+
+  try {
+    const packageJsonFile = readFileSync(
+      join(projectRoot, 'package.json'),
+      'utf8'
+    );
+
+    const { name } = JSON.parse(packageJsonFile);
+
+    if (!name) {
+      throw new SyntaxError('Package name is missing.');
+    }
+
+    if (name.includes('/')) {
+      // eslint-disable-next-line no-unused-vars
+      const [scope, packageName] = name.split('/');
+
+      if (!packageName) {
+        throw new SyntaxError('Package name is missing.');
+      }
+    }
+
+    return name;
+  } catch (e) {
+    throw new SyntaxError(
+      `ERROR: package.json is missing or is not valid. (${e.message})\n`
+    );
+  }
+}
+
+export function createOptions(codemodOptions) {
+  const projectName = analyzePackageJson(codemodOptions);
+
+  return {
+    podPath: codemodOptions.podPath,
+    projectName,
+    projectRoot: codemodOptions.projectRoot,
+    projectType: codemodOptions.projectType,
+    testRun: codemodOptions.testRun,
+  };
+}

--- a/src/migration/ember-addon/steps/index.js
+++ b/src/migration/ember-addon/steps/index.js
@@ -1,0 +1,1 @@
+export * from './create-options.js';

--- a/src/migration/ember-app/index.js
+++ b/src/migration/ember-app/index.js
@@ -1,8 +1,11 @@
 import { moveFiles } from '../../utils/files.js';
 import { migrationStrategyForAppFolder } from './app/index.js';
+import { createOptions } from './steps/index.js';
 import { migrationStrategyForTestsFolder } from './tests/index.js';
 
-export function migrateEmberApp(options) {
+export function migrateEmberApp(codemodOptions) {
+  const options = createOptions(codemodOptions);
+
   const migrationStrategyApp = migrationStrategyForAppFolder(options);
   const migrationStrategyTests = migrationStrategyForTestsFolder(options);
 

--- a/src/migration/ember-app/steps/create-options.js
+++ b/src/migration/ember-app/steps/create-options.js
@@ -1,0 +1,46 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+function analyzePackageJson(codemodOptions) {
+  const { projectRoot } = codemodOptions;
+
+  try {
+    const packageJsonFile = readFileSync(
+      join(projectRoot, 'package.json'),
+      'utf8'
+    );
+
+    const { name } = JSON.parse(packageJsonFile);
+
+    if (!name) {
+      throw new SyntaxError('Package name is missing.');
+    }
+
+    if (name.includes('/')) {
+      // eslint-disable-next-line no-unused-vars
+      const [scope, packageName] = name.split('/');
+
+      if (!packageName) {
+        throw new SyntaxError('Package name is missing.');
+      }
+    }
+
+    return name;
+  } catch (e) {
+    throw new SyntaxError(
+      `ERROR: package.json is missing or is not valid. (${e.message})\n`
+    );
+  }
+}
+
+export function createOptions(codemodOptions) {
+  const projectName = analyzePackageJson(codemodOptions);
+
+  return {
+    podPath: codemodOptions.podPath,
+    projectName,
+    projectRoot: codemodOptions.projectRoot,
+    projectType: codemodOptions.projectType,
+    testRun: codemodOptions.testRun,
+  };
+}

--- a/src/migration/ember-app/steps/index.js
+++ b/src/migration/ember-app/steps/index.js
@@ -1,0 +1,1 @@
+export * from './create-options.js';

--- a/src/migration/ember-engine/index.js
+++ b/src/migration/ember-engine/index.js
@@ -1,8 +1,11 @@
 import { moveFiles } from '../../utils/files.js';
 import { migrationStrategyForAddonFolder } from './addon/index.js';
+import { createOptions } from './steps/index.js';
 import { migrationStrategyForTestsFolder } from './tests/index.js';
 
-export function migrateEmberEngine(options) {
+export function migrateEmberEngine(codemodOptions) {
+  const options = createOptions(codemodOptions);
+
   const migrationStrategyAddon = migrationStrategyForAddonFolder(options);
   const migrationStrategyTests = migrationStrategyForTestsFolder(options);
 

--- a/src/migration/ember-engine/steps/create-options.js
+++ b/src/migration/ember-engine/steps/create-options.js
@@ -1,0 +1,46 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+function analyzePackageJson(codemodOptions) {
+  const { projectRoot } = codemodOptions;
+
+  try {
+    const packageJsonFile = readFileSync(
+      join(projectRoot, 'package.json'),
+      'utf8'
+    );
+
+    const { name } = JSON.parse(packageJsonFile);
+
+    if (!name) {
+      throw new SyntaxError('Package name is missing.');
+    }
+
+    if (name.includes('/')) {
+      // eslint-disable-next-line no-unused-vars
+      const [scope, packageName] = name.split('/');
+
+      if (!packageName) {
+        throw new SyntaxError('Package name is missing.');
+      }
+    }
+
+    return name;
+  } catch (e) {
+    throw new SyntaxError(
+      `ERROR: package.json is missing or is not valid. (${e.message})\n`
+    );
+  }
+}
+
+export function createOptions(codemodOptions) {
+  const projectName = analyzePackageJson(codemodOptions);
+
+  return {
+    podPath: codemodOptions.podPath,
+    projectName,
+    projectRoot: codemodOptions.projectRoot,
+    projectType: codemodOptions.projectType,
+    testRun: codemodOptions.testRun,
+  };
+}

--- a/src/migration/ember-engine/steps/index.js
+++ b/src/migration/ember-engine/steps/index.js
@@ -1,0 +1,1 @@
+export * from './create-options.js';

--- a/tests/helpers/shared-test-setups/ember-addon/javascript.js
+++ b/tests/helpers/shared-test-setups/ember-addon/javascript.js
@@ -1,8 +1,16 @@
-const options = {
+const codemodOptions = {
   podPath: '',
   projectRoot: 'tmp/ember-addon/javascript',
   projectType: 'addon',
   testRun: false,
 };
 
-export { options };
+const options = {
+  podPath: '',
+  projectName: '@ijlee2/ember-workshop-addon',
+  projectRoot: 'tmp/ember-addon/javascript',
+  projectType: 'addon',
+  testRun: false,
+};
+
+export { codemodOptions, options };

--- a/tests/helpers/shared-test-setups/ember-addon/sass.js
+++ b/tests/helpers/shared-test-setups/ember-addon/sass.js
@@ -1,8 +1,16 @@
-const options = {
+const codemodOptions = {
   podPath: '',
   projectRoot: 'tmp/ember-addon/sass',
   projectType: 'addon',
   testRun: false,
 };
 
-export { options };
+const options = {
+  podPath: '',
+  projectName: '@ijlee2/ember-workshop-addon',
+  projectRoot: 'tmp/ember-addon/sass',
+  projectType: 'addon',
+  testRun: false,
+};
+
+export { codemodOptions, options };

--- a/tests/helpers/shared-test-setups/ember-addon/typescript.js
+++ b/tests/helpers/shared-test-setups/ember-addon/typescript.js
@@ -1,8 +1,16 @@
-const options = {
+const codemodOptions = {
   podPath: '',
   projectRoot: 'tmp/ember-addon/typescript',
   projectType: 'addon',
   testRun: false,
 };
 
-export { options };
+const options = {
+  podPath: '',
+  projectName: '@ijlee2/ember-workshop-addon',
+  projectRoot: 'tmp/ember-addon/typescript',
+  projectType: 'addon',
+  testRun: false,
+};
+
+export { codemodOptions, options };

--- a/tests/helpers/shared-test-setups/ember-app/javascript.js
+++ b/tests/helpers/shared-test-setups/ember-app/javascript.js
@@ -1,8 +1,16 @@
-const options = {
+const codemodOptions = {
   podPath: '',
   projectRoot: 'tmp/ember-app/javascript',
   projectType: 'app',
   testRun: false,
 };
 
-export { options };
+const options = {
+  podPath: '',
+  projectName: '@ijlee2/ember-workshop-app',
+  projectRoot: 'tmp/ember-app/javascript',
+  projectType: 'app',
+  testRun: false,
+};
+
+export { codemodOptions, options };

--- a/tests/helpers/shared-test-setups/ember-app/pod-path.js
+++ b/tests/helpers/shared-test-setups/ember-app/pod-path.js
@@ -1,8 +1,16 @@
-const options = {
+const codemodOptions = {
   podPath: 'pods',
   projectRoot: 'tmp/ember-app/pod-path',
   projectType: 'app',
   testRun: false,
 };
 
-export { options };
+const options = {
+  podPath: 'pods',
+  projectName: '@ijlee2/ember-workshop-app',
+  projectRoot: 'tmp/ember-app/pod-path',
+  projectType: 'app',
+  testRun: false,
+};
+
+export { codemodOptions, options };

--- a/tests/helpers/shared-test-setups/ember-app/sass.js
+++ b/tests/helpers/shared-test-setups/ember-app/sass.js
@@ -1,8 +1,16 @@
-const options = {
+const codemodOptions = {
   podPath: '',
   projectRoot: 'tmp/ember-app/sass',
   projectType: 'app',
   testRun: false,
 };
 
-export { options };
+const options = {
+  podPath: '',
+  projectName: '@ijlee2/ember-workshop-app',
+  projectRoot: 'tmp/ember-app/sass',
+  projectType: 'app',
+  testRun: false,
+};
+
+export { codemodOptions, options };

--- a/tests/helpers/shared-test-setups/ember-app/typescript.js
+++ b/tests/helpers/shared-test-setups/ember-app/typescript.js
@@ -1,8 +1,16 @@
-const options = {
+const codemodOptions = {
   podPath: '',
   projectRoot: 'tmp/ember-app/typescript',
   projectType: 'app',
   testRun: false,
 };
 
-export { options };
+const options = {
+  podPath: '',
+  projectName: '@ijlee2/ember-workshop-app',
+  projectRoot: 'tmp/ember-app/typescript',
+  projectType: 'app',
+  testRun: false,
+};
+
+export { codemodOptions, options };

--- a/tests/helpers/shared-test-setups/ember-engine/javascript.js
+++ b/tests/helpers/shared-test-setups/ember-engine/javascript.js
@@ -1,8 +1,16 @@
-const options = {
+const codemodOptions = {
   podPath: '',
   projectRoot: 'tmp/ember-engine/javascript',
   projectType: 'engine',
   testRun: false,
 };
 
-export { options };
+const options = {
+  podPath: '',
+  projectName: '@ijlee2/ember-workshop-engine',
+  projectRoot: 'tmp/ember-engine/javascript',
+  projectType: 'engine',
+  testRun: false,
+};
+
+export { codemodOptions, options };

--- a/tests/helpers/shared-test-setups/ember-engine/sass.js
+++ b/tests/helpers/shared-test-setups/ember-engine/sass.js
@@ -1,8 +1,16 @@
-const options = {
+const codemodOptions = {
   podPath: '',
   projectRoot: 'tmp/ember-engine/sass',
   projectType: 'engine',
   testRun: false,
 };
 
-export { options };
+const options = {
+  podPath: '',
+  projectName: '@ijlee2/ember-workshop-engine',
+  projectRoot: 'tmp/ember-engine/sass',
+  projectType: 'engine',
+  testRun: false,
+};
+
+export { codemodOptions, options };

--- a/tests/helpers/shared-test-setups/ember-engine/typescript.js
+++ b/tests/helpers/shared-test-setups/ember-engine/typescript.js
@@ -1,8 +1,16 @@
-const options = {
+const codemodOptions = {
   podPath: '',
   projectRoot: 'tmp/ember-engine/typescript',
   projectType: 'engine',
   testRun: false,
 };
 
-export { options };
+const options = {
+  podPath: '',
+  projectName: '@ijlee2/ember-workshop-engine',
+  projectRoot: 'tmp/ember-engine/typescript',
+  projectType: 'engine',
+  testRun: false,
+};
+
+export { codemodOptions, options };

--- a/tests/migration/ember-addon/addon/component-classes/javascript.test.js
+++ b/tests/migration/ember-addon/addon/component-classes/javascript.test.js
@@ -1,10 +1,13 @@
 import { migrationStrategyForComponentClasses } from '../../../../../src/migration/ember-addon/addon/component-classes.js';
 import { inputProject } from '../../../../fixtures/ember-addon/javascript/index.js';
-import { options } from '../../../../helpers/shared-test-setups/ember-addon/javascript.js';
+import {
+  codemodOptions,
+  options,
+} from '../../../../helpers/shared-test-setups/ember-addon/javascript.js';
 import { assert, loadFixture, test } from '../../../../helpers/testing.js';
 
 test('migration | ember-addon | addon | component-classes > javascript', function () {
-  loadFixture(inputProject, options);
+  loadFixture(inputProject, codemodOptions);
 
   const migrationStrategy = migrationStrategyForComponentClasses(options);
 

--- a/tests/migration/ember-addon/addon/component-classes/typescript.test.js
+++ b/tests/migration/ember-addon/addon/component-classes/typescript.test.js
@@ -1,10 +1,13 @@
 import { migrationStrategyForComponentClasses } from '../../../../../src/migration/ember-addon/addon/component-classes.js';
 import { inputProject } from '../../../../fixtures/ember-addon/typescript/index.js';
-import { options } from '../../../../helpers/shared-test-setups/ember-addon/typescript.js';
+import {
+  codemodOptions,
+  options,
+} from '../../../../helpers/shared-test-setups/ember-addon/typescript.js';
 import { assert, loadFixture, test } from '../../../../helpers/testing.js';
 
 test('migration | ember-addon | addon | component-classes > typescript', function () {
-  loadFixture(inputProject, options);
+  loadFixture(inputProject, codemodOptions);
 
   const migrationStrategy = migrationStrategyForComponentClasses(options);
 

--- a/tests/migration/ember-addon/addon/component-stylesheets/javascript.test.js
+++ b/tests/migration/ember-addon/addon/component-stylesheets/javascript.test.js
@@ -1,10 +1,13 @@
 import { migrationStrategyForComponentStylesheets } from '../../../../../src/migration/ember-addon/addon/component-stylesheets.js';
 import { inputProject } from '../../../../fixtures/ember-addon/javascript/index.js';
-import { options } from '../../../../helpers/shared-test-setups/ember-addon/javascript.js';
+import {
+  codemodOptions,
+  options,
+} from '../../../../helpers/shared-test-setups/ember-addon/javascript.js';
 import { assert, loadFixture, test } from '../../../../helpers/testing.js';
 
 test('migration | ember-addon | addon | component-stylesheets > javascript', function () {
-  loadFixture(inputProject, options);
+  loadFixture(inputProject, codemodOptions);
 
   const migrationStrategy = migrationStrategyForComponentStylesheets(options);
 

--- a/tests/migration/ember-addon/addon/component-stylesheets/sass.test.js
+++ b/tests/migration/ember-addon/addon/component-stylesheets/sass.test.js
@@ -1,10 +1,13 @@
 import { migrationStrategyForComponentStylesheets } from '../../../../../src/migration/ember-addon/addon/component-stylesheets.js';
 import { inputProject } from '../../../../fixtures/ember-addon/sass/index.js';
-import { options } from '../../../../helpers/shared-test-setups/ember-addon/sass.js';
+import {
+  codemodOptions,
+  options,
+} from '../../../../helpers/shared-test-setups/ember-addon/sass.js';
 import { assert, loadFixture, test } from '../../../../helpers/testing.js';
 
 test('migration | ember-addon | addon | component-stylesheets > sass', function () {
-  loadFixture(inputProject, options);
+  loadFixture(inputProject, codemodOptions);
 
   const migrationStrategy = migrationStrategyForComponentStylesheets(options);
 

--- a/tests/migration/ember-addon/addon/component-stylesheets/typescript.test.js
+++ b/tests/migration/ember-addon/addon/component-stylesheets/typescript.test.js
@@ -1,10 +1,13 @@
 import { migrationStrategyForComponentStylesheets } from '../../../../../src/migration/ember-addon/addon/component-stylesheets.js';
 import { inputProject } from '../../../../fixtures/ember-addon/typescript/index.js';
-import { options } from '../../../../helpers/shared-test-setups/ember-addon/typescript.js';
+import {
+  codemodOptions,
+  options,
+} from '../../../../helpers/shared-test-setups/ember-addon/typescript.js';
 import { assert, loadFixture, test } from '../../../../helpers/testing.js';
 
 test('migration | ember-addon | addon | component-stylesheets > typescript', function () {
-  loadFixture(inputProject, options);
+  loadFixture(inputProject, codemodOptions);
 
   const migrationStrategy = migrationStrategyForComponentStylesheets(options);
 

--- a/tests/migration/ember-addon/addon/component-templates/javascript.test.js
+++ b/tests/migration/ember-addon/addon/component-templates/javascript.test.js
@@ -1,10 +1,13 @@
 import { migrationStrategyForComponentTemplates } from '../../../../../src/migration/ember-addon/addon/component-templates.js';
 import { inputProject } from '../../../../fixtures/ember-addon/javascript/index.js';
-import { options } from '../../../../helpers/shared-test-setups/ember-addon/javascript.js';
+import {
+  codemodOptions,
+  options,
+} from '../../../../helpers/shared-test-setups/ember-addon/javascript.js';
 import { assert, loadFixture, test } from '../../../../helpers/testing.js';
 
 test('migration | ember-addon | addon | component-templates > javascript', function () {
-  loadFixture(inputProject, options);
+  loadFixture(inputProject, codemodOptions);
 
   const migrationStrategy = migrationStrategyForComponentTemplates(options);
 

--- a/tests/migration/ember-addon/addon/component-templates/typescript.test.js
+++ b/tests/migration/ember-addon/addon/component-templates/typescript.test.js
@@ -1,10 +1,13 @@
 import { migrationStrategyForComponentTemplates } from '../../../../../src/migration/ember-addon/addon/component-templates.js';
 import { inputProject } from '../../../../fixtures/ember-addon/typescript/index.js';
-import { options } from '../../../../helpers/shared-test-setups/ember-addon/typescript.js';
+import {
+  codemodOptions,
+  options,
+} from '../../../../helpers/shared-test-setups/ember-addon/typescript.js';
 import { assert, loadFixture, test } from '../../../../helpers/testing.js';
 
 test('migration | ember-addon | addon | component-templates > typescript', function () {
-  loadFixture(inputProject, options);
+  loadFixture(inputProject, codemodOptions);
 
   const migrationStrategy = migrationStrategyForComponentTemplates(options);
 

--- a/tests/migration/ember-addon/app/component-classes/javascript.test.js
+++ b/tests/migration/ember-addon/app/component-classes/javascript.test.js
@@ -1,10 +1,13 @@
 import { migrationStrategyForComponentClasses } from '../../../../../src/migration/ember-addon/app/component-classes.js';
 import { inputProject } from '../../../../fixtures/ember-addon/javascript/index.js';
-import { options } from '../../../../helpers/shared-test-setups/ember-addon/javascript.js';
+import {
+  codemodOptions,
+  options,
+} from '../../../../helpers/shared-test-setups/ember-addon/javascript.js';
 import { assert, loadFixture, test } from '../../../../helpers/testing.js';
 
 test('migration | ember-addon | app | component-classes > javascript', function () {
-  loadFixture(inputProject, options);
+  loadFixture(inputProject, codemodOptions);
 
   const migrationStrategy = migrationStrategyForComponentClasses(options);
 

--- a/tests/migration/ember-addon/app/component-classes/typescript.test.js
+++ b/tests/migration/ember-addon/app/component-classes/typescript.test.js
@@ -1,10 +1,13 @@
 import { migrationStrategyForComponentClasses } from '../../../../../src/migration/ember-addon/app/component-classes.js';
 import { inputProject } from '../../../../fixtures/ember-addon/typescript/index.js';
-import { options } from '../../../../helpers/shared-test-setups/ember-addon/typescript.js';
+import {
+  codemodOptions,
+  options,
+} from '../../../../helpers/shared-test-setups/ember-addon/typescript.js';
 import { assert, loadFixture, test } from '../../../../helpers/testing.js';
 
 test('migration | ember-addon | app | component-classes > typescript', function () {
-  loadFixture(inputProject, options);
+  loadFixture(inputProject, codemodOptions);
 
   const migrationStrategy = migrationStrategyForComponentClasses(options);
 

--- a/tests/migration/ember-addon/app/component-stylesheets/javascript.test.js
+++ b/tests/migration/ember-addon/app/component-stylesheets/javascript.test.js
@@ -1,10 +1,13 @@
 import { migrationStrategyForComponentStylesheets } from '../../../../../src/migration/ember-addon/app/component-stylesheets.js';
 import { inputProject } from '../../../../fixtures/ember-addon/javascript/index.js';
-import { options } from '../../../../helpers/shared-test-setups/ember-addon/javascript.js';
+import {
+  codemodOptions,
+  options,
+} from '../../../../helpers/shared-test-setups/ember-addon/javascript.js';
 import { assert, loadFixture, test } from '../../../../helpers/testing.js';
 
 test('migration | ember-addon | app | component-stylesheets > javascript', function () {
-  loadFixture(inputProject, options);
+  loadFixture(inputProject, codemodOptions);
 
   const migrationStrategy = migrationStrategyForComponentStylesheets(options);
 

--- a/tests/migration/ember-addon/app/component-stylesheets/sass.test.js
+++ b/tests/migration/ember-addon/app/component-stylesheets/sass.test.js
@@ -1,10 +1,13 @@
 import { migrationStrategyForComponentStylesheets } from '../../../../../src/migration/ember-addon/app/component-stylesheets.js';
 import { inputProject } from '../../../../fixtures/ember-addon/sass/index.js';
-import { options } from '../../../../helpers/shared-test-setups/ember-addon/sass.js';
+import {
+  codemodOptions,
+  options,
+} from '../../../../helpers/shared-test-setups/ember-addon/sass.js';
 import { assert, loadFixture, test } from '../../../../helpers/testing.js';
 
 test('migration | ember-addon | app | component-stylesheets > sass', function () {
-  loadFixture(inputProject, options);
+  loadFixture(inputProject, codemodOptions);
 
   const migrationStrategy = migrationStrategyForComponentStylesheets(options);
 

--- a/tests/migration/ember-addon/app/component-stylesheets/typescript.test.js
+++ b/tests/migration/ember-addon/app/component-stylesheets/typescript.test.js
@@ -1,10 +1,13 @@
 import { migrationStrategyForComponentStylesheets } from '../../../../../src/migration/ember-addon/app/component-stylesheets.js';
 import { inputProject } from '../../../../fixtures/ember-addon/typescript/index.js';
-import { options } from '../../../../helpers/shared-test-setups/ember-addon/typescript.js';
+import {
+  codemodOptions,
+  options,
+} from '../../../../helpers/shared-test-setups/ember-addon/typescript.js';
 import { assert, loadFixture, test } from '../../../../helpers/testing.js';
 
 test('migration | ember-addon | app | component-stylesheets > typescript', function () {
-  loadFixture(inputProject, options);
+  loadFixture(inputProject, codemodOptions);
 
   const migrationStrategy = migrationStrategyForComponentStylesheets(options);
 

--- a/tests/migration/ember-addon/app/component-templates/javascript.test.js
+++ b/tests/migration/ember-addon/app/component-templates/javascript.test.js
@@ -1,10 +1,13 @@
 import { migrationStrategyForComponentTemplates } from '../../../../../src/migration/ember-addon/app/component-templates.js';
 import { inputProject } from '../../../../fixtures/ember-addon/javascript/index.js';
-import { options } from '../../../../helpers/shared-test-setups/ember-addon/javascript.js';
+import {
+  codemodOptions,
+  options,
+} from '../../../../helpers/shared-test-setups/ember-addon/javascript.js';
 import { assert, loadFixture, test } from '../../../../helpers/testing.js';
 
 test('migration | ember-addon | app | component-templates > javascript', function () {
-  loadFixture(inputProject, options);
+  loadFixture(inputProject, codemodOptions);
 
   const migrationStrategy = migrationStrategyForComponentTemplates(options);
 

--- a/tests/migration/ember-addon/app/component-templates/typescript.test.js
+++ b/tests/migration/ember-addon/app/component-templates/typescript.test.js
@@ -1,10 +1,13 @@
 import { migrationStrategyForComponentTemplates } from '../../../../../src/migration/ember-addon/app/component-templates.js';
 import { inputProject } from '../../../../fixtures/ember-addon/typescript/index.js';
-import { options } from '../../../../helpers/shared-test-setups/ember-addon/typescript.js';
+import {
+  codemodOptions,
+  options,
+} from '../../../../helpers/shared-test-setups/ember-addon/typescript.js';
 import { assert, loadFixture, test } from '../../../../helpers/testing.js';
 
 test('migration | ember-addon | app | component-templates > typescript', function () {
-  loadFixture(inputProject, options);
+  loadFixture(inputProject, codemodOptions);
 
   const migrationStrategy = migrationStrategyForComponentTemplates(options);
 

--- a/tests/migration/ember-addon/index/javascript.test.js
+++ b/tests/migration/ember-addon/index/javascript.test.js
@@ -3,18 +3,18 @@ import {
   inputProject,
   outputProject,
 } from '../../../fixtures/ember-addon/javascript/index.js';
-import { options } from '../../../helpers/shared-test-setups/ember-addon/javascript.js';
+import { codemodOptions } from '../../../helpers/shared-test-setups/ember-addon/javascript.js';
 import { assertFixture, loadFixture, test } from '../../../helpers/testing.js';
 
 test('migration | ember-addon | index > javascript', function () {
-  loadFixture(inputProject, options);
+  loadFixture(inputProject, codemodOptions);
 
-  migrateEmberAddon(options);
+  migrateEmberAddon(codemodOptions);
 
-  assertFixture(outputProject, options);
+  assertFixture(outputProject, codemodOptions);
 
   // Check idempotence
-  migrateEmberAddon(options);
+  migrateEmberAddon(codemodOptions);
 
-  assertFixture(outputProject, options);
+  assertFixture(outputProject, codemodOptions);
 });

--- a/tests/migration/ember-addon/index/sass.test.js
+++ b/tests/migration/ember-addon/index/sass.test.js
@@ -3,18 +3,18 @@ import {
   inputProject,
   outputProject,
 } from '../../../fixtures/ember-addon/sass/index.js';
-import { options } from '../../../helpers/shared-test-setups/ember-addon/sass.js';
+import { codemodOptions } from '../../../helpers/shared-test-setups/ember-addon/sass.js';
 import { assertFixture, loadFixture, test } from '../../../helpers/testing.js';
 
 test('migration | ember-addon | index > sass', function () {
-  loadFixture(inputProject, options);
+  loadFixture(inputProject, codemodOptions);
 
-  migrateEmberAddon(options);
+  migrateEmberAddon(codemodOptions);
 
-  assertFixture(outputProject, options);
+  assertFixture(outputProject, codemodOptions);
 
   // Check idempotence
-  migrateEmberAddon(options);
+  migrateEmberAddon(codemodOptions);
 
-  assertFixture(outputProject, options);
+  assertFixture(outputProject, codemodOptions);
 });

--- a/tests/migration/ember-addon/index/typescript.test.js
+++ b/tests/migration/ember-addon/index/typescript.test.js
@@ -3,18 +3,18 @@ import {
   inputProject,
   outputProject,
 } from '../../../fixtures/ember-addon/typescript/index.js';
-import { options } from '../../../helpers/shared-test-setups/ember-addon/typescript.js';
+import { codemodOptions } from '../../../helpers/shared-test-setups/ember-addon/typescript.js';
 import { assertFixture, loadFixture, test } from '../../../helpers/testing.js';
 
 test('migration | ember-addon | index > typescript', function () {
-  loadFixture(inputProject, options);
+  loadFixture(inputProject, codemodOptions);
 
-  migrateEmberAddon(options);
+  migrateEmberAddon(codemodOptions);
 
-  assertFixture(outputProject, options);
+  assertFixture(outputProject, codemodOptions);
 
   // Check idempotence
-  migrateEmberAddon(options);
+  migrateEmberAddon(codemodOptions);
 
-  assertFixture(outputProject, options);
+  assertFixture(outputProject, codemodOptions);
 });

--- a/tests/migration/ember-addon/steps/create-options/error-handling-package-json-is-an-empty-file.test.js
+++ b/tests/migration/ember-addon/steps/create-options/error-handling-package-json-is-an-empty-file.test.js
@@ -1,0 +1,25 @@
+import { createOptions } from '../../../../../src/migration/ember-addon/steps/index.js';
+import { codemodOptions } from '../../../../helpers/shared-test-setups/ember-addon/javascript.js';
+import { assert, loadFixture, test } from '../../../../helpers/testing.js';
+
+test('migration | ember-addon | steps | create-options > error handling (package.json is an empty file)', function () {
+  const inputProject = {
+    'package.json': '',
+  };
+
+  loadFixture(inputProject, codemodOptions);
+
+  assert.throws(
+    () => {
+      createOptions(codemodOptions);
+    },
+    (error) => {
+      assert.strictEqual(
+        error.message,
+        'ERROR: package.json is missing or is not valid. (Unexpected end of JSON input)\n'
+      );
+
+      return true;
+    }
+  );
+});

--- a/tests/migration/ember-addon/steps/create-options/error-handling-package-json-is-not-a-valid-json.test.js
+++ b/tests/migration/ember-addon/steps/create-options/error-handling-package-json-is-not-a-valid-json.test.js
@@ -1,0 +1,25 @@
+import { createOptions } from '../../../../../src/migration/ember-addon/steps/index.js';
+import { codemodOptions } from '../../../../helpers/shared-test-setups/ember-addon/javascript.js';
+import { assert, loadFixture, test } from '../../../../helpers/testing.js';
+
+test('migration | ember-addon | steps | create-options > error handling (package.json is not a valid JSON)', function () {
+  const inputProject = {
+    'package.json': '{\n  "name": }',
+  };
+
+  loadFixture(inputProject, codemodOptions);
+
+  assert.throws(
+    () => {
+      createOptions(codemodOptions);
+    },
+    (error) => {
+      assert.strictEqual(
+        error.message,
+        'ERROR: package.json is missing or is not valid. (Unexpected token } in JSON at position 12)\n'
+      );
+
+      return true;
+    }
+  );
+});

--- a/tests/migration/ember-addon/steps/create-options/error-handling-package-name-is-missing.test.js
+++ b/tests/migration/ember-addon/steps/create-options/error-handling-package-name-is-missing.test.js
@@ -1,0 +1,25 @@
+import { createOptions } from '../../../../../src/migration/ember-addon/steps/index.js';
+import { codemodOptions } from '../../../../helpers/shared-test-setups/ember-addon/javascript.js';
+import { assert, loadFixture, test } from '../../../../helpers/testing.js';
+
+test('migration | ember-addon | steps | create-options > error handling (package name is missing)', function () {
+  const inputProject = {
+    'package.json': '{}',
+  };
+
+  loadFixture(inputProject, codemodOptions);
+
+  assert.throws(
+    () => {
+      createOptions(codemodOptions);
+    },
+    (error) => {
+      assert.strictEqual(
+        error.message,
+        'ERROR: package.json is missing or is not valid. (Package name is missing.)\n'
+      );
+
+      return true;
+    }
+  );
+});

--- a/tests/migration/ember-addon/steps/create-options/error-handling-package-name-is-not-valid.test.js
+++ b/tests/migration/ember-addon/steps/create-options/error-handling-package-name-is-not-valid.test.js
@@ -1,0 +1,32 @@
+import { createOptions } from '../../../../../src/migration/ember-addon/steps/index.js';
+import { codemodOptions } from '../../../../helpers/shared-test-setups/ember-addon/javascript.js';
+import { assert, loadFixture, test } from '../../../../helpers/testing.js';
+
+test('migration | ember-addon | steps | create-options > error handling (package name is not valid)', function () {
+  const inputProject = {
+    'package.json': JSON.stringify(
+      {
+        name: '@ijlee2/',
+        version: '0.0.0',
+      },
+      null,
+      2
+    ),
+  };
+
+  loadFixture(inputProject, codemodOptions);
+
+  assert.throws(
+    () => {
+      createOptions(codemodOptions);
+    },
+    (error) => {
+      assert.strictEqual(
+        error.message,
+        'ERROR: package.json is missing or is not valid. (Package name is missing.)\n'
+      );
+
+      return true;
+    }
+  );
+});

--- a/tests/migration/ember-addon/steps/create-options/javascript.test.js
+++ b/tests/migration/ember-addon/steps/create-options/javascript.test.js
@@ -1,0 +1,23 @@
+import { createOptions } from '../../../../../src/migration/ember-addon/steps/index.js';
+import {
+  codemodOptions,
+  options,
+} from '../../../../helpers/shared-test-setups/ember-addon/javascript.js';
+import { assert, loadFixture, test } from '../../../../helpers/testing.js';
+
+test('migration | ember-addon | steps | create-options > javascript', function () {
+  const inputProject = {
+    'package.json': JSON.stringify(
+      {
+        name: '@ijlee2/ember-workshop-addon',
+        version: '0.0.0',
+      },
+      null,
+      2
+    ),
+  };
+
+  loadFixture(inputProject, codemodOptions);
+
+  assert.deepEqual(createOptions(codemodOptions), options);
+});

--- a/tests/migration/ember-addon/tests/components/javascript.test.js
+++ b/tests/migration/ember-addon/tests/components/javascript.test.js
@@ -1,10 +1,13 @@
 import { migrationStrategyForComponents } from '../../../../../src/migration/ember-addon/tests/components.js';
 import { inputProject } from '../../../../fixtures/ember-addon/javascript/index.js';
-import { options } from '../../../../helpers/shared-test-setups/ember-addon/javascript.js';
+import {
+  codemodOptions,
+  options,
+} from '../../../../helpers/shared-test-setups/ember-addon/javascript.js';
 import { assert, loadFixture, test } from '../../../../helpers/testing.js';
 
 test('migration | ember-addon | tests | components > javascript', function () {
-  loadFixture(inputProject, options);
+  loadFixture(inputProject, codemodOptions);
 
   const migrationStrategy = migrationStrategyForComponents(options);
 

--- a/tests/migration/ember-addon/tests/components/typescript.test.js
+++ b/tests/migration/ember-addon/tests/components/typescript.test.js
@@ -1,10 +1,13 @@
 import { migrationStrategyForComponents } from '../../../../../src/migration/ember-addon/tests/components.js';
 import { inputProject } from '../../../../fixtures/ember-addon/typescript/index.js';
-import { options } from '../../../../helpers/shared-test-setups/ember-addon/typescript.js';
+import {
+  codemodOptions,
+  options,
+} from '../../../../helpers/shared-test-setups/ember-addon/typescript.js';
 import { assert, loadFixture, test } from '../../../../helpers/testing.js';
 
 test('migration | ember-addon | tests | components > typescript', function () {
-  loadFixture(inputProject, options);
+  loadFixture(inputProject, codemodOptions);
 
   const migrationStrategy = migrationStrategyForComponents(options);
 

--- a/tests/migration/ember-app/app/component-classes/javascript.test.js
+++ b/tests/migration/ember-app/app/component-classes/javascript.test.js
@@ -1,10 +1,13 @@
 import { migrationStrategyForComponentClasses } from '../../../../../src/migration/ember-app/app/component-classes.js';
 import { inputProject } from '../../../../fixtures/ember-app/javascript/index.js';
-import { options } from '../../../../helpers/shared-test-setups/ember-app/javascript.js';
+import {
+  codemodOptions,
+  options,
+} from '../../../../helpers/shared-test-setups/ember-app/javascript.js';
 import { assert, loadFixture, test } from '../../../../helpers/testing.js';
 
 test('migration | ember-app | app | component-classes > javascript', function () {
-  loadFixture(inputProject, options);
+  loadFixture(inputProject, codemodOptions);
 
   const migrationStrategy = migrationStrategyForComponentClasses(options);
 

--- a/tests/migration/ember-app/app/component-classes/pod-path.test.js
+++ b/tests/migration/ember-app/app/component-classes/pod-path.test.js
@@ -1,10 +1,13 @@
 import { migrationStrategyForComponentClasses } from '../../../../../src/migration/ember-app/app/component-classes.js';
 import { inputProject } from '../../../../fixtures/ember-app/pod-path/index.js';
-import { options } from '../../../../helpers/shared-test-setups/ember-app/pod-path.js';
+import {
+  codemodOptions,
+  options,
+} from '../../../../helpers/shared-test-setups/ember-app/pod-path.js';
 import { assert, loadFixture, test } from '../../../../helpers/testing.js';
 
 test('migration | ember-app | app | component-classes > pod path', function () {
-  loadFixture(inputProject, options);
+  loadFixture(inputProject, codemodOptions);
 
   const migrationStrategy = migrationStrategyForComponentClasses(options);
 

--- a/tests/migration/ember-app/app/component-classes/typescript.test.js
+++ b/tests/migration/ember-app/app/component-classes/typescript.test.js
@@ -1,10 +1,13 @@
 import { migrationStrategyForComponentClasses } from '../../../../../src/migration/ember-app/app/component-classes.js';
 import { inputProject } from '../../../../fixtures/ember-app/typescript/index.js';
-import { options } from '../../../../helpers/shared-test-setups/ember-app/typescript.js';
+import {
+  codemodOptions,
+  options,
+} from '../../../../helpers/shared-test-setups/ember-app/typescript.js';
 import { assert, loadFixture, test } from '../../../../helpers/testing.js';
 
 test('migration | ember-app | app | component-classes > typescript', function () {
-  loadFixture(inputProject, options);
+  loadFixture(inputProject, codemodOptions);
 
   const migrationStrategy = migrationStrategyForComponentClasses(options);
 

--- a/tests/migration/ember-app/app/component-stylesheets/javascript.test.js
+++ b/tests/migration/ember-app/app/component-stylesheets/javascript.test.js
@@ -1,10 +1,13 @@
 import { migrationStrategyForComponentStylesheets } from '../../../../../src/migration/ember-app/app/component-stylesheets.js';
 import { inputProject } from '../../../../fixtures/ember-app/javascript/index.js';
-import { options } from '../../../../helpers/shared-test-setups/ember-app/javascript.js';
+import {
+  codemodOptions,
+  options,
+} from '../../../../helpers/shared-test-setups/ember-app/javascript.js';
 import { assert, loadFixture, test } from '../../../../helpers/testing.js';
 
 test('migration | ember-app | app | component-stylesheets > javascript', function () {
-  loadFixture(inputProject, options);
+  loadFixture(inputProject, codemodOptions);
 
   const migrationStrategy = migrationStrategyForComponentStylesheets(options);
 

--- a/tests/migration/ember-app/app/component-stylesheets/pod-path.test.js
+++ b/tests/migration/ember-app/app/component-stylesheets/pod-path.test.js
@@ -1,10 +1,13 @@
 import { migrationStrategyForComponentStylesheets } from '../../../../../src/migration/ember-app/app/component-stylesheets.js';
 import { inputProject } from '../../../../fixtures/ember-app/pod-path/index.js';
-import { options } from '../../../../helpers/shared-test-setups/ember-app/pod-path.js';
+import {
+  codemodOptions,
+  options,
+} from '../../../../helpers/shared-test-setups/ember-app/pod-path.js';
 import { assert, loadFixture, test } from '../../../../helpers/testing.js';
 
 test('migration | ember-app | app | component-stylesheets > pod path', function () {
-  loadFixture(inputProject, options);
+  loadFixture(inputProject, codemodOptions);
 
   const migrationStrategy = migrationStrategyForComponentStylesheets(options);
 

--- a/tests/migration/ember-app/app/component-stylesheets/sass.test.js
+++ b/tests/migration/ember-app/app/component-stylesheets/sass.test.js
@@ -1,10 +1,13 @@
 import { migrationStrategyForComponentStylesheets } from '../../../../../src/migration/ember-app/app/component-stylesheets.js';
 import { inputProject } from '../../../../fixtures/ember-app/sass/index.js';
-import { options } from '../../../../helpers/shared-test-setups/ember-app/sass.js';
+import {
+  codemodOptions,
+  options,
+} from '../../../../helpers/shared-test-setups/ember-app/sass.js';
 import { assert, loadFixture, test } from '../../../../helpers/testing.js';
 
 test('migration | ember-app | app | component-stylesheets > sass', function () {
-  loadFixture(inputProject, options);
+  loadFixture(inputProject, codemodOptions);
 
   const migrationStrategy = migrationStrategyForComponentStylesheets(options);
 

--- a/tests/migration/ember-app/app/component-stylesheets/typescript.test.js
+++ b/tests/migration/ember-app/app/component-stylesheets/typescript.test.js
@@ -1,10 +1,13 @@
 import { migrationStrategyForComponentStylesheets } from '../../../../../src/migration/ember-app/app/component-stylesheets.js';
 import { inputProject } from '../../../../fixtures/ember-app/typescript/index.js';
-import { options } from '../../../../helpers/shared-test-setups/ember-app/typescript.js';
+import {
+  codemodOptions,
+  options,
+} from '../../../../helpers/shared-test-setups/ember-app/typescript.js';
 import { assert, loadFixture, test } from '../../../../helpers/testing.js';
 
 test('migration | ember-app | app | component-stylesheets > typescript', function () {
-  loadFixture(inputProject, options);
+  loadFixture(inputProject, codemodOptions);
 
   const migrationStrategy = migrationStrategyForComponentStylesheets(options);
 

--- a/tests/migration/ember-app/app/component-templates/javascript.test.js
+++ b/tests/migration/ember-app/app/component-templates/javascript.test.js
@@ -1,10 +1,13 @@
 import { migrationStrategyForComponentTemplates } from '../../../../../src/migration/ember-app/app/component-templates.js';
 import { inputProject } from '../../../../fixtures/ember-app/javascript/index.js';
-import { options } from '../../../../helpers/shared-test-setups/ember-app/javascript.js';
+import {
+  codemodOptions,
+  options,
+} from '../../../../helpers/shared-test-setups/ember-app/javascript.js';
 import { assert, loadFixture, test } from '../../../../helpers/testing.js';
 
 test('migration | ember-app | app | component-templates > javascript', function () {
-  loadFixture(inputProject, options);
+  loadFixture(inputProject, codemodOptions);
 
   const migrationStrategy = migrationStrategyForComponentTemplates(options);
 

--- a/tests/migration/ember-app/app/component-templates/pod-path.test.js
+++ b/tests/migration/ember-app/app/component-templates/pod-path.test.js
@@ -1,10 +1,13 @@
 import { migrationStrategyForComponentTemplates } from '../../../../../src/migration/ember-app/app/component-templates.js';
 import { inputProject } from '../../../../fixtures/ember-app/pod-path/index.js';
-import { options } from '../../../../helpers/shared-test-setups/ember-app/pod-path.js';
+import {
+  codemodOptions,
+  options,
+} from '../../../../helpers/shared-test-setups/ember-app/pod-path.js';
 import { assert, loadFixture, test } from '../../../../helpers/testing.js';
 
 test('migration | ember-app | app | component-templates > pod path', function () {
-  loadFixture(inputProject, options);
+  loadFixture(inputProject, codemodOptions);
 
   const migrationStrategy = migrationStrategyForComponentTemplates(options);
 

--- a/tests/migration/ember-app/app/component-templates/typescript.test.js
+++ b/tests/migration/ember-app/app/component-templates/typescript.test.js
@@ -1,10 +1,13 @@
 import { migrationStrategyForComponentTemplates } from '../../../../../src/migration/ember-app/app/component-templates.js';
 import { inputProject } from '../../../../fixtures/ember-app/typescript/index.js';
-import { options } from '../../../../helpers/shared-test-setups/ember-app/typescript.js';
+import {
+  codemodOptions,
+  options,
+} from '../../../../helpers/shared-test-setups/ember-app/typescript.js';
 import { assert, loadFixture, test } from '../../../../helpers/testing.js';
 
 test('migration | ember-app | app | component-templates > typescript', function () {
-  loadFixture(inputProject, options);
+  loadFixture(inputProject, codemodOptions);
 
   const migrationStrategy = migrationStrategyForComponentTemplates(options);
 

--- a/tests/migration/ember-app/app/route-adapters/javascript.test.js
+++ b/tests/migration/ember-app/app/route-adapters/javascript.test.js
@@ -1,10 +1,13 @@
 import { migrationStrategyForRouteAdapters } from '../../../../../src/migration/ember-app/app/route-adapters.js';
 import { inputProject } from '../../../../fixtures/ember-app/javascript/index.js';
-import { options } from '../../../../helpers/shared-test-setups/ember-app/javascript.js';
+import {
+  codemodOptions,
+  options,
+} from '../../../../helpers/shared-test-setups/ember-app/javascript.js';
 import { assert, loadFixture, test } from '../../../../helpers/testing.js';
 
 test('migration | ember-app | app | route-adapters > javascript', function () {
-  loadFixture(inputProject, options);
+  loadFixture(inputProject, codemodOptions);
 
   const migrationStrategy = migrationStrategyForRouteAdapters(options);
 

--- a/tests/migration/ember-app/app/route-adapters/pod-path.test.js
+++ b/tests/migration/ember-app/app/route-adapters/pod-path.test.js
@@ -1,10 +1,13 @@
 import { migrationStrategyForRouteAdapters } from '../../../../../src/migration/ember-app/app/route-adapters.js';
 import { inputProject } from '../../../../fixtures/ember-app/pod-path/index.js';
-import { options } from '../../../../helpers/shared-test-setups/ember-app/pod-path.js';
+import {
+  codemodOptions,
+  options,
+} from '../../../../helpers/shared-test-setups/ember-app/pod-path.js';
 import { assert, loadFixture, test } from '../../../../helpers/testing.js';
 
 test('migration | ember-app | app | route-adapters > pod path', function () {
-  loadFixture(inputProject, options);
+  loadFixture(inputProject, codemodOptions);
 
   const migrationStrategy = migrationStrategyForRouteAdapters(options);
 

--- a/tests/migration/ember-app/app/route-adapters/typescript.test.js
+++ b/tests/migration/ember-app/app/route-adapters/typescript.test.js
@@ -1,10 +1,13 @@
 import { migrationStrategyForRouteAdapters } from '../../../../../src/migration/ember-app/app/route-adapters.js';
 import { inputProject } from '../../../../fixtures/ember-app/typescript/index.js';
-import { options } from '../../../../helpers/shared-test-setups/ember-app/typescript.js';
+import {
+  codemodOptions,
+  options,
+} from '../../../../helpers/shared-test-setups/ember-app/typescript.js';
 import { assert, loadFixture, test } from '../../../../helpers/testing.js';
 
 test('migration | ember-app | app | route-adapters > typescript', function () {
-  loadFixture(inputProject, options);
+  loadFixture(inputProject, codemodOptions);
 
   const migrationStrategy = migrationStrategyForRouteAdapters(options);
 

--- a/tests/migration/ember-app/app/route-controllers/javascript.test.js
+++ b/tests/migration/ember-app/app/route-controllers/javascript.test.js
@@ -1,10 +1,13 @@
 import { migrationStrategyForRouteControllers } from '../../../../../src/migration/ember-app/app/route-controllers.js';
 import { inputProject } from '../../../../fixtures/ember-app/javascript/index.js';
-import { options } from '../../../../helpers/shared-test-setups/ember-app/javascript.js';
+import {
+  codemodOptions,
+  options,
+} from '../../../../helpers/shared-test-setups/ember-app/javascript.js';
 import { assert, loadFixture, test } from '../../../../helpers/testing.js';
 
 test('migration | ember-app | app | route-controllers > javascript', function () {
-  loadFixture(inputProject, options);
+  loadFixture(inputProject, codemodOptions);
 
   const migrationStrategy = migrationStrategyForRouteControllers(options);
 

--- a/tests/migration/ember-app/app/route-controllers/pod-path.test.js
+++ b/tests/migration/ember-app/app/route-controllers/pod-path.test.js
@@ -1,10 +1,13 @@
 import { migrationStrategyForRouteControllers } from '../../../../../src/migration/ember-app/app/route-controllers.js';
 import { inputProject } from '../../../../fixtures/ember-app/pod-path/index.js';
-import { options } from '../../../../helpers/shared-test-setups/ember-app/pod-path.js';
+import {
+  codemodOptions,
+  options,
+} from '../../../../helpers/shared-test-setups/ember-app/pod-path.js';
 import { assert, loadFixture, test } from '../../../../helpers/testing.js';
 
 test('migration | ember-app | app | route-controllers > pod path', function () {
-  loadFixture(inputProject, options);
+  loadFixture(inputProject, codemodOptions);
 
   const migrationStrategy = migrationStrategyForRouteControllers(options);
 

--- a/tests/migration/ember-app/app/route-controllers/typescript.test.js
+++ b/tests/migration/ember-app/app/route-controllers/typescript.test.js
@@ -1,10 +1,13 @@
 import { migrationStrategyForRouteControllers } from '../../../../../src/migration/ember-app/app/route-controllers.js';
 import { inputProject } from '../../../../fixtures/ember-app/typescript/index.js';
-import { options } from '../../../../helpers/shared-test-setups/ember-app/typescript.js';
+import {
+  codemodOptions,
+  options,
+} from '../../../../helpers/shared-test-setups/ember-app/typescript.js';
 import { assert, loadFixture, test } from '../../../../helpers/testing.js';
 
 test('migration | ember-app | app | route-controllers > typescript', function () {
-  loadFixture(inputProject, options);
+  loadFixture(inputProject, codemodOptions);
 
   const migrationStrategy = migrationStrategyForRouteControllers(options);
 

--- a/tests/migration/ember-app/app/route-models/javascript.test.js
+++ b/tests/migration/ember-app/app/route-models/javascript.test.js
@@ -1,10 +1,13 @@
 import { migrationStrategyForRouteModels } from '../../../../../src/migration/ember-app/app/route-models.js';
 import { inputProject } from '../../../../fixtures/ember-app/javascript/index.js';
-import { options } from '../../../../helpers/shared-test-setups/ember-app/javascript.js';
+import {
+  codemodOptions,
+  options,
+} from '../../../../helpers/shared-test-setups/ember-app/javascript.js';
 import { assert, loadFixture, test } from '../../../../helpers/testing.js';
 
 test('migration | ember-app | app | route-models > javascript', function () {
-  loadFixture(inputProject, options);
+  loadFixture(inputProject, codemodOptions);
 
   const migrationStrategy = migrationStrategyForRouteModels(options);
 

--- a/tests/migration/ember-app/app/route-models/pod-path.test.js
+++ b/tests/migration/ember-app/app/route-models/pod-path.test.js
@@ -1,10 +1,13 @@
 import { migrationStrategyForRouteModels } from '../../../../../src/migration/ember-app/app/route-models.js';
 import { inputProject } from '../../../../fixtures/ember-app/pod-path/index.js';
-import { options } from '../../../../helpers/shared-test-setups/ember-app/pod-path.js';
+import {
+  codemodOptions,
+  options,
+} from '../../../../helpers/shared-test-setups/ember-app/pod-path.js';
 import { assert, loadFixture, test } from '../../../../helpers/testing.js';
 
 test('migration | ember-app | app | route-models > pod path', function () {
-  loadFixture(inputProject, options);
+  loadFixture(inputProject, codemodOptions);
 
   const migrationStrategy = migrationStrategyForRouteModels(options);
 

--- a/tests/migration/ember-app/app/route-models/typescript.test.js
+++ b/tests/migration/ember-app/app/route-models/typescript.test.js
@@ -1,10 +1,13 @@
 import { migrationStrategyForRouteModels } from '../../../../../src/migration/ember-app/app/route-models.js';
 import { inputProject } from '../../../../fixtures/ember-app/typescript/index.js';
-import { options } from '../../../../helpers/shared-test-setups/ember-app/typescript.js';
+import {
+  codemodOptions,
+  options,
+} from '../../../../helpers/shared-test-setups/ember-app/typescript.js';
 import { assert, loadFixture, test } from '../../../../helpers/testing.js';
 
 test('migration | ember-app | app | route-models > typescript', function () {
-  loadFixture(inputProject, options);
+  loadFixture(inputProject, codemodOptions);
 
   const migrationStrategy = migrationStrategyForRouteModels(options);
 

--- a/tests/migration/ember-app/app/route-routes/javascript.test.js
+++ b/tests/migration/ember-app/app/route-routes/javascript.test.js
@@ -1,10 +1,13 @@
 import { migrationStrategyForRouteRoutes } from '../../../../../src/migration/ember-app/app/route-routes.js';
 import { inputProject } from '../../../../fixtures/ember-app/javascript/index.js';
-import { options } from '../../../../helpers/shared-test-setups/ember-app/javascript.js';
+import {
+  codemodOptions,
+  options,
+} from '../../../../helpers/shared-test-setups/ember-app/javascript.js';
 import { assert, loadFixture, test } from '../../../../helpers/testing.js';
 
 test('migration | ember-app | app | route-routes > javascript', function () {
-  loadFixture(inputProject, options);
+  loadFixture(inputProject, codemodOptions);
 
   const migrationStrategy = migrationStrategyForRouteRoutes(options);
 

--- a/tests/migration/ember-app/app/route-routes/pod-path.test.js
+++ b/tests/migration/ember-app/app/route-routes/pod-path.test.js
@@ -1,10 +1,13 @@
 import { migrationStrategyForRouteRoutes } from '../../../../../src/migration/ember-app/app/route-routes.js';
 import { inputProject } from '../../../../fixtures/ember-app/pod-path/index.js';
-import { options } from '../../../../helpers/shared-test-setups/ember-app/pod-path.js';
+import {
+  codemodOptions,
+  options,
+} from '../../../../helpers/shared-test-setups/ember-app/pod-path.js';
 import { assert, loadFixture, test } from '../../../../helpers/testing.js';
 
 test('migration | ember-app | app | route-routes > pod path', function () {
-  loadFixture(inputProject, options);
+  loadFixture(inputProject, codemodOptions);
 
   const migrationStrategy = migrationStrategyForRouteRoutes(options);
 

--- a/tests/migration/ember-app/app/route-routes/typescript.test.js
+++ b/tests/migration/ember-app/app/route-routes/typescript.test.js
@@ -1,10 +1,13 @@
 import { migrationStrategyForRouteRoutes } from '../../../../../src/migration/ember-app/app/route-routes.js';
 import { inputProject } from '../../../../fixtures/ember-app/typescript/index.js';
-import { options } from '../../../../helpers/shared-test-setups/ember-app/typescript.js';
+import {
+  codemodOptions,
+  options,
+} from '../../../../helpers/shared-test-setups/ember-app/typescript.js';
 import { assert, loadFixture, test } from '../../../../helpers/testing.js';
 
 test('migration | ember-app | app | route-routes > typescript', function () {
-  loadFixture(inputProject, options);
+  loadFixture(inputProject, codemodOptions);
 
   const migrationStrategy = migrationStrategyForRouteRoutes(options);
 

--- a/tests/migration/ember-app/app/route-serializers/javascript.test.js
+++ b/tests/migration/ember-app/app/route-serializers/javascript.test.js
@@ -1,10 +1,13 @@
 import { migrationStrategyForRouteSerializers } from '../../../../../src/migration/ember-app/app/route-serializers.js';
 import { inputProject } from '../../../../fixtures/ember-app/javascript/index.js';
-import { options } from '../../../../helpers/shared-test-setups/ember-app/javascript.js';
+import {
+  codemodOptions,
+  options,
+} from '../../../../helpers/shared-test-setups/ember-app/javascript.js';
 import { assert, loadFixture, test } from '../../../../helpers/testing.js';
 
 test('migration | ember-app | app | route-serializers > javascript', function () {
-  loadFixture(inputProject, options);
+  loadFixture(inputProject, codemodOptions);
 
   const migrationStrategy = migrationStrategyForRouteSerializers(options);
 

--- a/tests/migration/ember-app/app/route-serializers/pod-path.test.js
+++ b/tests/migration/ember-app/app/route-serializers/pod-path.test.js
@@ -1,10 +1,13 @@
 import { migrationStrategyForRouteSerializers } from '../../../../../src/migration/ember-app/app/route-serializers.js';
 import { inputProject } from '../../../../fixtures/ember-app/pod-path/index.js';
-import { options } from '../../../../helpers/shared-test-setups/ember-app/pod-path.js';
+import {
+  codemodOptions,
+  options,
+} from '../../../../helpers/shared-test-setups/ember-app/pod-path.js';
 import { assert, loadFixture, test } from '../../../../helpers/testing.js';
 
 test('migration | ember-app | app | route-serializers > pod path', function () {
-  loadFixture(inputProject, options);
+  loadFixture(inputProject, codemodOptions);
 
   const migrationStrategy = migrationStrategyForRouteSerializers(options);
 

--- a/tests/migration/ember-app/app/route-serializers/typescript.test.js
+++ b/tests/migration/ember-app/app/route-serializers/typescript.test.js
@@ -1,10 +1,13 @@
 import { migrationStrategyForRouteSerializers } from '../../../../../src/migration/ember-app/app/route-serializers.js';
 import { inputProject } from '../../../../fixtures/ember-app/typescript/index.js';
-import { options } from '../../../../helpers/shared-test-setups/ember-app/typescript.js';
+import {
+  codemodOptions,
+  options,
+} from '../../../../helpers/shared-test-setups/ember-app/typescript.js';
 import { assert, loadFixture, test } from '../../../../helpers/testing.js';
 
 test('migration | ember-app | app | route-serializers > typescript', function () {
-  loadFixture(inputProject, options);
+  loadFixture(inputProject, codemodOptions);
 
   const migrationStrategy = migrationStrategyForRouteSerializers(options);
 

--- a/tests/migration/ember-app/app/route-stylesheets/javascript.test.js
+++ b/tests/migration/ember-app/app/route-stylesheets/javascript.test.js
@@ -1,10 +1,13 @@
 import { migrationStrategyForRouteStylesheets } from '../../../../../src/migration/ember-app/app/route-stylesheets.js';
 import { inputProject } from '../../../../fixtures/ember-app/javascript/index.js';
-import { options } from '../../../../helpers/shared-test-setups/ember-app/javascript.js';
+import {
+  codemodOptions,
+  options,
+} from '../../../../helpers/shared-test-setups/ember-app/javascript.js';
 import { assert, loadFixture, test } from '../../../../helpers/testing.js';
 
 test('migration | ember-app | app | route-stylesheets > javascript', function () {
-  loadFixture(inputProject, options);
+  loadFixture(inputProject, codemodOptions);
 
   const migrationStrategy = migrationStrategyForRouteStylesheets(options);
 

--- a/tests/migration/ember-app/app/route-stylesheets/pod-path.test.js
+++ b/tests/migration/ember-app/app/route-stylesheets/pod-path.test.js
@@ -1,10 +1,13 @@
 import { migrationStrategyForRouteSerializers } from '../../../../../src/migration/ember-app/app/route-serializers.js';
 import { inputProject } from '../../../../fixtures/ember-app/pod-path/index.js';
-import { options } from '../../../../helpers/shared-test-setups/ember-app/pod-path.js';
+import {
+  codemodOptions,
+  options,
+} from '../../../../helpers/shared-test-setups/ember-app/pod-path.js';
 import { assert, loadFixture, test } from '../../../../helpers/testing.js';
 
 test('migration | ember-app | app | route-serializers > pod path', function () {
-  loadFixture(inputProject, options);
+  loadFixture(inputProject, codemodOptions);
 
   const migrationStrategy = migrationStrategyForRouteSerializers(options);
 

--- a/tests/migration/ember-app/app/route-stylesheets/sass.test.js
+++ b/tests/migration/ember-app/app/route-stylesheets/sass.test.js
@@ -1,10 +1,13 @@
 import { migrationStrategyForRouteStylesheets } from '../../../../../src/migration/ember-app/app/route-stylesheets.js';
 import { inputProject } from '../../../../fixtures/ember-app/sass/index.js';
-import { options } from '../../../../helpers/shared-test-setups/ember-app/sass.js';
+import {
+  codemodOptions,
+  options,
+} from '../../../../helpers/shared-test-setups/ember-app/sass.js';
 import { assert, loadFixture, test } from '../../../../helpers/testing.js';
 
 test('migration | ember-app | app | route-stylesheets > sass', function () {
-  loadFixture(inputProject, options);
+  loadFixture(inputProject, codemodOptions);
 
   const migrationStrategy = migrationStrategyForRouteStylesheets(options);
 

--- a/tests/migration/ember-app/app/route-stylesheets/typescript.test.js
+++ b/tests/migration/ember-app/app/route-stylesheets/typescript.test.js
@@ -1,10 +1,13 @@
 import { migrationStrategyForRouteStylesheets } from '../../../../../src/migration/ember-app/app/route-stylesheets.js';
 import { inputProject } from '../../../../fixtures/ember-app/typescript/index.js';
-import { options } from '../../../../helpers/shared-test-setups/ember-app/typescript.js';
+import {
+  codemodOptions,
+  options,
+} from '../../../../helpers/shared-test-setups/ember-app/typescript.js';
 import { assert, loadFixture, test } from '../../../../helpers/testing.js';
 
 test('migration | ember-app | app | route-stylesheets > typescript', function () {
-  loadFixture(inputProject, options);
+  loadFixture(inputProject, codemodOptions);
 
   const migrationStrategy = migrationStrategyForRouteStylesheets(options);
 

--- a/tests/migration/ember-app/app/route-templates/javascript.test.js
+++ b/tests/migration/ember-app/app/route-templates/javascript.test.js
@@ -1,10 +1,13 @@
 import { migrationStrategyForRouteTemplates } from '../../../../../src/migration/ember-app/app/route-templates.js';
 import { inputProject } from '../../../../fixtures/ember-app/javascript/index.js';
-import { options } from '../../../../helpers/shared-test-setups/ember-app/javascript.js';
+import {
+  codemodOptions,
+  options,
+} from '../../../../helpers/shared-test-setups/ember-app/javascript.js';
 import { assert, loadFixture, test } from '../../../../helpers/testing.js';
 
 test('migration | ember-app | app | route-templates > javascript', function () {
-  loadFixture(inputProject, options);
+  loadFixture(inputProject, codemodOptions);
 
   const migrationStrategy = migrationStrategyForRouteTemplates(options);
 

--- a/tests/migration/ember-app/app/route-templates/pod-path.test.js
+++ b/tests/migration/ember-app/app/route-templates/pod-path.test.js
@@ -1,10 +1,13 @@
 import { migrationStrategyForRouteTemplates } from '../../../../../src/migration/ember-app/app/route-templates.js';
 import { inputProject } from '../../../../fixtures/ember-app/pod-path/index.js';
-import { options } from '../../../../helpers/shared-test-setups/ember-app/pod-path.js';
+import {
+  codemodOptions,
+  options,
+} from '../../../../helpers/shared-test-setups/ember-app/pod-path.js';
 import { assert, loadFixture, test } from '../../../../helpers/testing.js';
 
 test('migration | ember-app | app | route-templates > pod path', function () {
-  loadFixture(inputProject, options);
+  loadFixture(inputProject, codemodOptions);
 
   const migrationStrategy = migrationStrategyForRouteTemplates(options);
 

--- a/tests/migration/ember-app/app/route-templates/typescript.test.js
+++ b/tests/migration/ember-app/app/route-templates/typescript.test.js
@@ -1,10 +1,13 @@
 import { migrationStrategyForRouteTemplates } from '../../../../../src/migration/ember-app/app/route-templates.js';
 import { inputProject } from '../../../../fixtures/ember-app/typescript/index.js';
-import { options } from '../../../../helpers/shared-test-setups/ember-app/typescript.js';
+import {
+  codemodOptions,
+  options,
+} from '../../../../helpers/shared-test-setups/ember-app/typescript.js';
 import { assert, loadFixture, test } from '../../../../helpers/testing.js';
 
 test('migration | ember-app | app | route-templates > typescript', function () {
-  loadFixture(inputProject, options);
+  loadFixture(inputProject, codemodOptions);
 
   const migrationStrategy = migrationStrategyForRouteTemplates(options);
 

--- a/tests/migration/ember-app/app/services/javascript.test.js
+++ b/tests/migration/ember-app/app/services/javascript.test.js
@@ -1,10 +1,13 @@
 import { migrationStrategyForServices } from '../../../../../src/migration/ember-app/app/services.js';
 import { inputProject } from '../../../../fixtures/ember-app/javascript/index.js';
-import { options } from '../../../../helpers/shared-test-setups/ember-app/javascript.js';
+import {
+  codemodOptions,
+  options,
+} from '../../../../helpers/shared-test-setups/ember-app/javascript.js';
 import { assert, loadFixture, test } from '../../../../helpers/testing.js';
 
 test('migration | ember-app | app | services > javascript', function () {
-  loadFixture(inputProject, options);
+  loadFixture(inputProject, codemodOptions);
 
   const migrationStrategy = migrationStrategyForServices(options);
 

--- a/tests/migration/ember-app/app/services/pod-path.test.js
+++ b/tests/migration/ember-app/app/services/pod-path.test.js
@@ -1,10 +1,13 @@
 import { migrationStrategyForServices } from '../../../../../src/migration/ember-app/app/services.js';
 import { inputProject } from '../../../../fixtures/ember-app/pod-path/index.js';
-import { options } from '../../../../helpers/shared-test-setups/ember-app/pod-path.js';
+import {
+  codemodOptions,
+  options,
+} from '../../../../helpers/shared-test-setups/ember-app/pod-path.js';
 import { assert, loadFixture, test } from '../../../../helpers/testing.js';
 
 test('migration | ember-app | app | services > pod path', function () {
-  loadFixture(inputProject, options);
+  loadFixture(inputProject, codemodOptions);
 
   const migrationStrategy = migrationStrategyForServices(options);
 

--- a/tests/migration/ember-app/app/services/typescript.test.js
+++ b/tests/migration/ember-app/app/services/typescript.test.js
@@ -1,10 +1,13 @@
 import { migrationStrategyForServices } from '../../../../../src/migration/ember-app/app/services.js';
 import { inputProject } from '../../../../fixtures/ember-app/typescript/index.js';
-import { options } from '../../../../helpers/shared-test-setups/ember-app/typescript.js';
+import {
+  codemodOptions,
+  options,
+} from '../../../../helpers/shared-test-setups/ember-app/typescript.js';
 import { assert, loadFixture, test } from '../../../../helpers/testing.js';
 
 test('migration | ember-app | app | services > typescript', function () {
-  loadFixture(inputProject, options);
+  loadFixture(inputProject, codemodOptions);
 
   const migrationStrategy = migrationStrategyForServices(options);
 

--- a/tests/migration/ember-app/index/javascript.test.js
+++ b/tests/migration/ember-app/index/javascript.test.js
@@ -3,18 +3,18 @@ import {
   inputProject,
   outputProject,
 } from '../../../fixtures/ember-app/javascript/index.js';
-import { options } from '../../../helpers/shared-test-setups/ember-app/javascript.js';
+import { codemodOptions } from '../../../helpers/shared-test-setups/ember-app/javascript.js';
 import { assertFixture, loadFixture, test } from '../../../helpers/testing.js';
 
 test('migration | ember-app | index > javascript', function () {
-  loadFixture(inputProject, options);
+  loadFixture(inputProject, codemodOptions);
 
-  migrateEmberApp(options);
+  migrateEmberApp(codemodOptions);
 
-  assertFixture(outputProject, options);
+  assertFixture(outputProject, codemodOptions);
 
   // Check idempotence
-  migrateEmberApp(options);
+  migrateEmberApp(codemodOptions);
 
-  assertFixture(outputProject, options);
+  assertFixture(outputProject, codemodOptions);
 });

--- a/tests/migration/ember-app/index/pod-path.test.js
+++ b/tests/migration/ember-app/index/pod-path.test.js
@@ -3,18 +3,18 @@ import {
   inputProject,
   outputProject,
 } from '../../../fixtures/ember-app/pod-path/index.js';
-import { options } from '../../../helpers/shared-test-setups/ember-app/pod-path.js';
+import { codemodOptions } from '../../../helpers/shared-test-setups/ember-app/pod-path.js';
 import { assertFixture, loadFixture, test } from '../../../helpers/testing.js';
 
 test('migration | ember-app | index > pod path', function () {
-  loadFixture(inputProject, options);
+  loadFixture(inputProject, codemodOptions);
 
-  migrateEmberApp(options);
+  migrateEmberApp(codemodOptions);
 
-  assertFixture(outputProject, options);
+  assertFixture(outputProject, codemodOptions);
 
   // Check idempotence
-  migrateEmberApp(options);
+  migrateEmberApp(codemodOptions);
 
-  assertFixture(outputProject, options);
+  assertFixture(outputProject, codemodOptions);
 });

--- a/tests/migration/ember-app/index/sass.test.js
+++ b/tests/migration/ember-app/index/sass.test.js
@@ -3,18 +3,18 @@ import {
   inputProject,
   outputProject,
 } from '../../../fixtures/ember-app/sass/index.js';
-import { options } from '../../../helpers/shared-test-setups/ember-app/sass.js';
+import { codemodOptions } from '../../../helpers/shared-test-setups/ember-app/sass.js';
 import { assertFixture, loadFixture, test } from '../../../helpers/testing.js';
 
 test('migration | ember-app | index > sass', function () {
-  loadFixture(inputProject, options);
+  loadFixture(inputProject, codemodOptions);
 
-  migrateEmberApp(options);
+  migrateEmberApp(codemodOptions);
 
-  assertFixture(outputProject, options);
+  assertFixture(outputProject, codemodOptions);
 
   // Check idempotence
-  migrateEmberApp(options);
+  migrateEmberApp(codemodOptions);
 
-  assertFixture(outputProject, options);
+  assertFixture(outputProject, codemodOptions);
 });

--- a/tests/migration/ember-app/index/typescript.test.js
+++ b/tests/migration/ember-app/index/typescript.test.js
@@ -3,18 +3,18 @@ import {
   inputProject,
   outputProject,
 } from '../../../fixtures/ember-app/typescript/index.js';
-import { options } from '../../../helpers/shared-test-setups/ember-app/typescript.js';
+import { codemodOptions } from '../../../helpers/shared-test-setups/ember-app/typescript.js';
 import { assertFixture, loadFixture, test } from '../../../helpers/testing.js';
 
 test('migration | ember-app | index > typescript', function () {
-  loadFixture(inputProject, options);
+  loadFixture(inputProject, codemodOptions);
 
-  migrateEmberApp(options);
+  migrateEmberApp(codemodOptions);
 
-  assertFixture(outputProject, options);
+  assertFixture(outputProject, codemodOptions);
 
   // Check idempotence
-  migrateEmberApp(options);
+  migrateEmberApp(codemodOptions);
 
-  assertFixture(outputProject, options);
+  assertFixture(outputProject, codemodOptions);
 });

--- a/tests/migration/ember-app/steps/create-options/error-handling-package-json-is-an-empty-file.test.js
+++ b/tests/migration/ember-app/steps/create-options/error-handling-package-json-is-an-empty-file.test.js
@@ -1,0 +1,25 @@
+import { createOptions } from '../../../../../src/migration/ember-app/steps/index.js';
+import { codemodOptions } from '../../../../helpers/shared-test-setups/ember-app/javascript.js';
+import { assert, loadFixture, test } from '../../../../helpers/testing.js';
+
+test('migration | ember-app | steps | create-options > error handling (package.json is an empty file)', function () {
+  const inputProject = {
+    'package.json': '',
+  };
+
+  loadFixture(inputProject, codemodOptions);
+
+  assert.throws(
+    () => {
+      createOptions(codemodOptions);
+    },
+    (error) => {
+      assert.strictEqual(
+        error.message,
+        'ERROR: package.json is missing or is not valid. (Unexpected end of JSON input)\n'
+      );
+
+      return true;
+    }
+  );
+});

--- a/tests/migration/ember-app/steps/create-options/error-handling-package-json-is-not-a-valid-json.test.js
+++ b/tests/migration/ember-app/steps/create-options/error-handling-package-json-is-not-a-valid-json.test.js
@@ -1,0 +1,25 @@
+import { createOptions } from '../../../../../src/migration/ember-app/steps/index.js';
+import { codemodOptions } from '../../../../helpers/shared-test-setups/ember-app/javascript.js';
+import { assert, loadFixture, test } from '../../../../helpers/testing.js';
+
+test('migration | ember-app | steps | create-options > error handling (package.json is not a valid JSON)', function () {
+  const inputProject = {
+    'package.json': '{\n  "name": }',
+  };
+
+  loadFixture(inputProject, codemodOptions);
+
+  assert.throws(
+    () => {
+      createOptions(codemodOptions);
+    },
+    (error) => {
+      assert.strictEqual(
+        error.message,
+        'ERROR: package.json is missing or is not valid. (Unexpected token } in JSON at position 12)\n'
+      );
+
+      return true;
+    }
+  );
+});

--- a/tests/migration/ember-app/steps/create-options/error-handling-package-name-is-missing.test.js
+++ b/tests/migration/ember-app/steps/create-options/error-handling-package-name-is-missing.test.js
@@ -1,0 +1,25 @@
+import { createOptions } from '../../../../../src/migration/ember-app/steps/index.js';
+import { codemodOptions } from '../../../../helpers/shared-test-setups/ember-app/javascript.js';
+import { assert, loadFixture, test } from '../../../../helpers/testing.js';
+
+test('migration | ember-app | steps | create-options > error handling (package name is missing)', function () {
+  const inputProject = {
+    'package.json': '{}',
+  };
+
+  loadFixture(inputProject, codemodOptions);
+
+  assert.throws(
+    () => {
+      createOptions(codemodOptions);
+    },
+    (error) => {
+      assert.strictEqual(
+        error.message,
+        'ERROR: package.json is missing or is not valid. (Package name is missing.)\n'
+      );
+
+      return true;
+    }
+  );
+});

--- a/tests/migration/ember-app/steps/create-options/error-handling-package-name-is-not-valid.test.js
+++ b/tests/migration/ember-app/steps/create-options/error-handling-package-name-is-not-valid.test.js
@@ -1,0 +1,32 @@
+import { createOptions } from '../../../../../src/migration/ember-app/steps/index.js';
+import { codemodOptions } from '../../../../helpers/shared-test-setups/ember-app/javascript.js';
+import { assert, loadFixture, test } from '../../../../helpers/testing.js';
+
+test('migration | ember-app | steps | create-options > error handling (package name is not valid)', function () {
+  const inputProject = {
+    'package.json': JSON.stringify(
+      {
+        name: '@ijlee2/',
+        version: '0.0.0',
+      },
+      null,
+      2
+    ),
+  };
+
+  loadFixture(inputProject, codemodOptions);
+
+  assert.throws(
+    () => {
+      createOptions(codemodOptions);
+    },
+    (error) => {
+      assert.strictEqual(
+        error.message,
+        'ERROR: package.json is missing or is not valid. (Package name is missing.)\n'
+      );
+
+      return true;
+    }
+  );
+});

--- a/tests/migration/ember-app/steps/create-options/javascript.test.js
+++ b/tests/migration/ember-app/steps/create-options/javascript.test.js
@@ -1,0 +1,23 @@
+import { createOptions } from '../../../../../src/migration/ember-app/steps/index.js';
+import {
+  codemodOptions,
+  options,
+} from '../../../../helpers/shared-test-setups/ember-app/javascript.js';
+import { assert, loadFixture, test } from '../../../../helpers/testing.js';
+
+test('migration | ember-app | steps | create-options > javascript', function () {
+  const inputProject = {
+    'package.json': JSON.stringify(
+      {
+        name: '@ijlee2/ember-workshop-app',
+        version: '0.0.0',
+      },
+      null,
+      2
+    ),
+  };
+
+  loadFixture(inputProject, codemodOptions);
+
+  assert.deepEqual(createOptions(codemodOptions), options);
+});

--- a/tests/migration/ember-app/tests/components/javascript.test.js
+++ b/tests/migration/ember-app/tests/components/javascript.test.js
@@ -1,10 +1,13 @@
 import { migrationStrategyForComponents } from '../../../../../src/migration/ember-app/tests/components.js';
 import { inputProject } from '../../../../fixtures/ember-app/javascript/index.js';
-import { options } from '../../../../helpers/shared-test-setups/ember-app/javascript.js';
+import {
+  codemodOptions,
+  options,
+} from '../../../../helpers/shared-test-setups/ember-app/javascript.js';
 import { assert, loadFixture, test } from '../../../../helpers/testing.js';
 
 test('migration | ember-app | tests | components > javascript', function () {
-  loadFixture(inputProject, options);
+  loadFixture(inputProject, codemodOptions);
 
   const migrationStrategy = migrationStrategyForComponents(options);
 

--- a/tests/migration/ember-app/tests/components/pod-path.test.js
+++ b/tests/migration/ember-app/tests/components/pod-path.test.js
@@ -1,10 +1,13 @@
 import { migrationStrategyForComponents } from '../../../../../src/migration/ember-app/tests/components.js';
 import { inputProject } from '../../../../fixtures/ember-app/pod-path/index.js';
-import { options } from '../../../../helpers/shared-test-setups/ember-app/pod-path.js';
+import {
+  codemodOptions,
+  options,
+} from '../../../../helpers/shared-test-setups/ember-app/pod-path.js';
 import { assert, loadFixture, test } from '../../../../helpers/testing.js';
 
 test('migration | ember-app | tests | components > pod path', function () {
-  loadFixture(inputProject, options);
+  loadFixture(inputProject, codemodOptions);
 
   const migrationStrategy = migrationStrategyForComponents(options);
 

--- a/tests/migration/ember-app/tests/components/typescript.test.js
+++ b/tests/migration/ember-app/tests/components/typescript.test.js
@@ -1,10 +1,13 @@
 import { migrationStrategyForComponents } from '../../../../../src/migration/ember-app/tests/components.js';
 import { inputProject } from '../../../../fixtures/ember-app/typescript/index.js';
-import { options } from '../../../../helpers/shared-test-setups/ember-app/typescript.js';
+import {
+  codemodOptions,
+  options,
+} from '../../../../helpers/shared-test-setups/ember-app/typescript.js';
 import { assert, loadFixture, test } from '../../../../helpers/testing.js';
 
 test('migration | ember-app | tests | components > typescript', function () {
-  loadFixture(inputProject, options);
+  loadFixture(inputProject, codemodOptions);
 
   const migrationStrategy = migrationStrategyForComponents(options);
 

--- a/tests/migration/ember-app/tests/route-controllers/javascript.test.js
+++ b/tests/migration/ember-app/tests/route-controllers/javascript.test.js
@@ -1,10 +1,13 @@
 import { migrationStrategyForRouteControllers } from '../../../../../src/migration/ember-app/tests/route-controllers.js';
 import { inputProject } from '../../../../fixtures/ember-app/javascript/index.js';
-import { options } from '../../../../helpers/shared-test-setups/ember-app/javascript.js';
+import {
+  codemodOptions,
+  options,
+} from '../../../../helpers/shared-test-setups/ember-app/javascript.js';
 import { assert, loadFixture, test } from '../../../../helpers/testing.js';
 
 test('migration | ember-app | tests | route-controllers > javascript', function () {
-  loadFixture(inputProject, options);
+  loadFixture(inputProject, codemodOptions);
 
   const migrationStrategy = migrationStrategyForRouteControllers(options);
 

--- a/tests/migration/ember-app/tests/route-controllers/pod-path.test.js
+++ b/tests/migration/ember-app/tests/route-controllers/pod-path.test.js
@@ -1,10 +1,13 @@
 import { migrationStrategyForRouteControllers } from '../../../../../src/migration/ember-app/tests/route-controllers.js';
 import { inputProject } from '../../../../fixtures/ember-app/pod-path/index.js';
-import { options } from '../../../../helpers/shared-test-setups/ember-app/pod-path.js';
+import {
+  codemodOptions,
+  options,
+} from '../../../../helpers/shared-test-setups/ember-app/pod-path.js';
 import { assert, loadFixture, test } from '../../../../helpers/testing.js';
 
 test('migration | ember-app | tests | route-controllers > pod path', function () {
-  loadFixture(inputProject, options);
+  loadFixture(inputProject, codemodOptions);
 
   const migrationStrategy = migrationStrategyForRouteControllers(options);
 

--- a/tests/migration/ember-app/tests/route-controllers/typescript.test.js
+++ b/tests/migration/ember-app/tests/route-controllers/typescript.test.js
@@ -1,10 +1,13 @@
 import { migrationStrategyForRouteControllers } from '../../../../../src/migration/ember-app/tests/route-controllers.js';
 import { inputProject } from '../../../../fixtures/ember-app/typescript/index.js';
-import { options } from '../../../../helpers/shared-test-setups/ember-app/typescript.js';
+import {
+  codemodOptions,
+  options,
+} from '../../../../helpers/shared-test-setups/ember-app/typescript.js';
 import { assert, loadFixture, test } from '../../../../helpers/testing.js';
 
 test('migration | ember-app | tests | route-controllers > typescript', function () {
-  loadFixture(inputProject, options);
+  loadFixture(inputProject, codemodOptions);
 
   const migrationStrategy = migrationStrategyForRouteControllers(options);
 

--- a/tests/migration/ember-app/tests/route-routes/javascript.test.js
+++ b/tests/migration/ember-app/tests/route-routes/javascript.test.js
@@ -1,10 +1,13 @@
 import { migrationStrategyForRouteRoutes } from '../../../../../src/migration/ember-app/tests/route-routes.js';
 import { inputProject } from '../../../../fixtures/ember-app/javascript/index.js';
-import { options } from '../../../../helpers/shared-test-setups/ember-app/javascript.js';
+import {
+  codemodOptions,
+  options,
+} from '../../../../helpers/shared-test-setups/ember-app/javascript.js';
 import { assert, loadFixture, test } from '../../../../helpers/testing.js';
 
 test('migration | ember-app | tests | route-routes > javascript', function () {
-  loadFixture(inputProject, options);
+  loadFixture(inputProject, codemodOptions);
 
   const migrationStrategy = migrationStrategyForRouteRoutes(options);
 

--- a/tests/migration/ember-app/tests/route-routes/pod-path.test.js
+++ b/tests/migration/ember-app/tests/route-routes/pod-path.test.js
@@ -1,10 +1,13 @@
 import { migrationStrategyForRouteRoutes } from '../../../../../src/migration/ember-app/tests/route-routes.js';
 import { inputProject } from '../../../../fixtures/ember-app/pod-path/index.js';
-import { options } from '../../../../helpers/shared-test-setups/ember-app/pod-path.js';
+import {
+  codemodOptions,
+  options,
+} from '../../../../helpers/shared-test-setups/ember-app/pod-path.js';
 import { assert, loadFixture, test } from '../../../../helpers/testing.js';
 
 test('migration | ember-app | tests | route-routes > pod path', function () {
-  loadFixture(inputProject, options);
+  loadFixture(inputProject, codemodOptions);
 
   const migrationStrategy = migrationStrategyForRouteRoutes(options);
 

--- a/tests/migration/ember-app/tests/route-routes/typescript.test.js
+++ b/tests/migration/ember-app/tests/route-routes/typescript.test.js
@@ -1,10 +1,13 @@
 import { migrationStrategyForRouteRoutes } from '../../../../../src/migration/ember-app/tests/route-routes.js';
 import { inputProject } from '../../../../fixtures/ember-app/typescript/index.js';
-import { options } from '../../../../helpers/shared-test-setups/ember-app/typescript.js';
+import {
+  codemodOptions,
+  options,
+} from '../../../../helpers/shared-test-setups/ember-app/typescript.js';
 import { assert, loadFixture, test } from '../../../../helpers/testing.js';
 
 test('migration | ember-app | tests | route-routes > typescript', function () {
-  loadFixture(inputProject, options);
+  loadFixture(inputProject, codemodOptions);
 
   const migrationStrategy = migrationStrategyForRouteRoutes(options);
 

--- a/tests/migration/ember-app/tests/services/javascript.test.js
+++ b/tests/migration/ember-app/tests/services/javascript.test.js
@@ -1,10 +1,13 @@
 import { migrationStrategyForServices } from '../../../../../src/migration/ember-app/tests/services.js';
 import { inputProject } from '../../../../fixtures/ember-app/javascript/index.js';
-import { options } from '../../../../helpers/shared-test-setups/ember-app/javascript.js';
+import {
+  codemodOptions,
+  options,
+} from '../../../../helpers/shared-test-setups/ember-app/javascript.js';
 import { assert, loadFixture, test } from '../../../../helpers/testing.js';
 
 test('migration | ember-app | tests | services > javascript', function () {
-  loadFixture(inputProject, options);
+  loadFixture(inputProject, codemodOptions);
 
   const migrationStrategy = migrationStrategyForServices(options);
 

--- a/tests/migration/ember-app/tests/services/pod-path.test.js
+++ b/tests/migration/ember-app/tests/services/pod-path.test.js
@@ -1,10 +1,13 @@
 import { migrationStrategyForServices } from '../../../../../src/migration/ember-app/tests/services.js';
 import { inputProject } from '../../../../fixtures/ember-app/pod-path/index.js';
-import { options } from '../../../../helpers/shared-test-setups/ember-app/pod-path.js';
+import {
+  codemodOptions,
+  options,
+} from '../../../../helpers/shared-test-setups/ember-app/pod-path.js';
 import { assert, loadFixture, test } from '../../../../helpers/testing.js';
 
 test('migration | ember-app | tests | services > pod path', function () {
-  loadFixture(inputProject, options);
+  loadFixture(inputProject, codemodOptions);
 
   const migrationStrategy = migrationStrategyForServices(options);
 

--- a/tests/migration/ember-app/tests/services/typescript.test.js
+++ b/tests/migration/ember-app/tests/services/typescript.test.js
@@ -1,10 +1,13 @@
 import { migrationStrategyForServices } from '../../../../../src/migration/ember-app/tests/services.js';
 import { inputProject } from '../../../../fixtures/ember-app/typescript/index.js';
-import { options } from '../../../../helpers/shared-test-setups/ember-app/typescript.js';
+import {
+  codemodOptions,
+  options,
+} from '../../../../helpers/shared-test-setups/ember-app/typescript.js';
 import { assert, loadFixture, test } from '../../../../helpers/testing.js';
 
 test('migration | ember-app | tests | services > typescript', function () {
-  loadFixture(inputProject, options);
+  loadFixture(inputProject, codemodOptions);
 
   const migrationStrategy = migrationStrategyForServices(options);
 

--- a/tests/migration/ember-engine/addon/component-classes/javascript.test.js
+++ b/tests/migration/ember-engine/addon/component-classes/javascript.test.js
@@ -1,10 +1,13 @@
 import { migrationStrategyForComponentClasses } from '../../../../../src/migration/ember-engine/addon/component-classes.js';
 import { inputProject } from '../../../../fixtures/ember-engine/javascript/index.js';
-import { options } from '../../../../helpers/shared-test-setups/ember-engine/javascript.js';
+import {
+  codemodOptions,
+  options,
+} from '../../../../helpers/shared-test-setups/ember-engine/javascript.js';
 import { assert, loadFixture, test } from '../../../../helpers/testing.js';
 
 test('migration | ember-engine | addon | component-classes > javascript', function () {
-  loadFixture(inputProject, options);
+  loadFixture(inputProject, codemodOptions);
 
   const migrationStrategy = migrationStrategyForComponentClasses(options);
 

--- a/tests/migration/ember-engine/addon/component-classes/typescript.test.js
+++ b/tests/migration/ember-engine/addon/component-classes/typescript.test.js
@@ -1,10 +1,13 @@
 import { migrationStrategyForComponentClasses } from '../../../../../src/migration/ember-engine/addon/component-classes.js';
 import { inputProject } from '../../../../fixtures/ember-engine/typescript/index.js';
-import { options } from '../../../../helpers/shared-test-setups/ember-engine/typescript.js';
+import {
+  codemodOptions,
+  options,
+} from '../../../../helpers/shared-test-setups/ember-engine/typescript.js';
 import { assert, loadFixture, test } from '../../../../helpers/testing.js';
 
 test('migration | ember-engine | addon | component-classes > typescript', function () {
-  loadFixture(inputProject, options);
+  loadFixture(inputProject, codemodOptions);
 
   const migrationStrategy = migrationStrategyForComponentClasses(options);
 

--- a/tests/migration/ember-engine/addon/component-stylesheets/javascript.test.js
+++ b/tests/migration/ember-engine/addon/component-stylesheets/javascript.test.js
@@ -1,10 +1,13 @@
 import { migrationStrategyForComponentStylesheets } from '../../../../../src/migration/ember-engine/addon/component-stylesheets.js';
 import { inputProject } from '../../../../fixtures/ember-engine/javascript/index.js';
-import { options } from '../../../../helpers/shared-test-setups/ember-engine/javascript.js';
+import {
+  codemodOptions,
+  options,
+} from '../../../../helpers/shared-test-setups/ember-engine/javascript.js';
 import { assert, loadFixture, test } from '../../../../helpers/testing.js';
 
 test('migration | ember-engine | addon | component-stylesheets > javascript', function () {
-  loadFixture(inputProject, options);
+  loadFixture(inputProject, codemodOptions);
 
   const migrationStrategy = migrationStrategyForComponentStylesheets(options);
 

--- a/tests/migration/ember-engine/addon/component-stylesheets/sass.test.js
+++ b/tests/migration/ember-engine/addon/component-stylesheets/sass.test.js
@@ -1,10 +1,13 @@
 import { migrationStrategyForComponentStylesheets } from '../../../../../src/migration/ember-engine/addon/component-stylesheets.js';
 import { inputProject } from '../../../../fixtures/ember-engine/sass/index.js';
-import { options } from '../../../../helpers/shared-test-setups/ember-engine/sass.js';
+import {
+  codemodOptions,
+  options,
+} from '../../../../helpers/shared-test-setups/ember-engine/sass.js';
 import { assert, loadFixture, test } from '../../../../helpers/testing.js';
 
 test('migration | ember-engine | addon | component-stylesheets > sass', function () {
-  loadFixture(inputProject, options);
+  loadFixture(inputProject, codemodOptions);
 
   const migrationStrategy = migrationStrategyForComponentStylesheets(options);
 

--- a/tests/migration/ember-engine/addon/component-stylesheets/typescript.test.js
+++ b/tests/migration/ember-engine/addon/component-stylesheets/typescript.test.js
@@ -1,10 +1,13 @@
 import { migrationStrategyForComponentStylesheets } from '../../../../../src/migration/ember-engine/addon/component-stylesheets.js';
 import { inputProject } from '../../../../fixtures/ember-engine/typescript/index.js';
-import { options } from '../../../../helpers/shared-test-setups/ember-engine/typescript.js';
+import {
+  codemodOptions,
+  options,
+} from '../../../../helpers/shared-test-setups/ember-engine/typescript.js';
 import { assert, loadFixture, test } from '../../../../helpers/testing.js';
 
 test('migration | ember-engine | addon | component-stylesheets > typescript', function () {
-  loadFixture(inputProject, options);
+  loadFixture(inputProject, codemodOptions);
 
   const migrationStrategy = migrationStrategyForComponentStylesheets(options);
 

--- a/tests/migration/ember-engine/addon/component-templates/javascript.test.js
+++ b/tests/migration/ember-engine/addon/component-templates/javascript.test.js
@@ -1,10 +1,13 @@
 import { migrationStrategyForComponentTemplates } from '../../../../../src/migration/ember-engine/addon/component-templates.js';
 import { inputProject } from '../../../../fixtures/ember-engine/javascript/index.js';
-import { options } from '../../../../helpers/shared-test-setups/ember-engine/javascript.js';
+import {
+  codemodOptions,
+  options,
+} from '../../../../helpers/shared-test-setups/ember-engine/javascript.js';
 import { assert, loadFixture, test } from '../../../../helpers/testing.js';
 
 test('migration | ember-engine | addon | component-templates > javascript', function () {
-  loadFixture(inputProject, options);
+  loadFixture(inputProject, codemodOptions);
 
   const migrationStrategy = migrationStrategyForComponentTemplates(options);
 

--- a/tests/migration/ember-engine/addon/component-templates/typescript.test.js
+++ b/tests/migration/ember-engine/addon/component-templates/typescript.test.js
@@ -1,10 +1,13 @@
 import { migrationStrategyForComponentTemplates } from '../../../../../src/migration/ember-engine/addon/component-templates.js';
 import { inputProject } from '../../../../fixtures/ember-engine/typescript/index.js';
-import { options } from '../../../../helpers/shared-test-setups/ember-engine/typescript.js';
+import {
+  codemodOptions,
+  options,
+} from '../../../../helpers/shared-test-setups/ember-engine/typescript.js';
 import { assert, loadFixture, test } from '../../../../helpers/testing.js';
 
 test('migration | ember-engine | addon | component-templates > typescript', function () {
-  loadFixture(inputProject, options);
+  loadFixture(inputProject, codemodOptions);
 
   const migrationStrategy = migrationStrategyForComponentTemplates(options);
 

--- a/tests/migration/ember-engine/addon/route-controllers/javascript.test.js
+++ b/tests/migration/ember-engine/addon/route-controllers/javascript.test.js
@@ -1,10 +1,13 @@
 import { migrationStrategyForRouteControllers } from '../../../../../src/migration/ember-engine/addon/route-controllers.js';
 import { inputProject } from '../../../../fixtures/ember-engine/javascript/index.js';
-import { options } from '../../../../helpers/shared-test-setups/ember-engine/javascript.js';
+import {
+  codemodOptions,
+  options,
+} from '../../../../helpers/shared-test-setups/ember-engine/javascript.js';
 import { assert, loadFixture, test } from '../../../../helpers/testing.js';
 
 test('migration | ember-engine | addon | route-controllers > javascript', function () {
-  loadFixture(inputProject, options);
+  loadFixture(inputProject, codemodOptions);
 
   const migrationStrategy = migrationStrategyForRouteControllers(options);
 

--- a/tests/migration/ember-engine/addon/route-controllers/typescript.test.js
+++ b/tests/migration/ember-engine/addon/route-controllers/typescript.test.js
@@ -1,10 +1,13 @@
 import { migrationStrategyForRouteControllers } from '../../../../../src/migration/ember-engine/addon/route-controllers.js';
 import { inputProject } from '../../../../fixtures/ember-engine/typescript/index.js';
-import { options } from '../../../../helpers/shared-test-setups/ember-engine/typescript.js';
+import {
+  codemodOptions,
+  options,
+} from '../../../../helpers/shared-test-setups/ember-engine/typescript.js';
 import { assert, loadFixture, test } from '../../../../helpers/testing.js';
 
 test('migration | ember-engine | addon | route-controllers > typescript', function () {
-  loadFixture(inputProject, options);
+  loadFixture(inputProject, codemodOptions);
 
   const migrationStrategy = migrationStrategyForRouteControllers(options);
 

--- a/tests/migration/ember-engine/addon/route-routes/javascript.test.js
+++ b/tests/migration/ember-engine/addon/route-routes/javascript.test.js
@@ -1,10 +1,13 @@
 import { migrationStrategyForRouteRoutes } from '../../../../../src/migration/ember-engine/addon/route-routes.js';
 import { inputProject } from '../../../../fixtures/ember-engine/javascript/index.js';
-import { options } from '../../../../helpers/shared-test-setups/ember-engine/javascript.js';
+import {
+  codemodOptions,
+  options,
+} from '../../../../helpers/shared-test-setups/ember-engine/javascript.js';
 import { assert, loadFixture, test } from '../../../../helpers/testing.js';
 
 test('migration | ember-engine | addon | route-routes > javascript', function () {
-  loadFixture(inputProject, options);
+  loadFixture(inputProject, codemodOptions);
 
   const migrationStrategy = migrationStrategyForRouteRoutes(options);
 

--- a/tests/migration/ember-engine/addon/route-routes/typescript.test.js
+++ b/tests/migration/ember-engine/addon/route-routes/typescript.test.js
@@ -1,10 +1,13 @@
 import { migrationStrategyForRouteRoutes } from '../../../../../src/migration/ember-engine/addon/route-routes.js';
 import { inputProject } from '../../../../fixtures/ember-engine/typescript/index.js';
-import { options } from '../../../../helpers/shared-test-setups/ember-engine/typescript.js';
+import {
+  codemodOptions,
+  options,
+} from '../../../../helpers/shared-test-setups/ember-engine/typescript.js';
 import { assert, loadFixture, test } from '../../../../helpers/testing.js';
 
 test('migration | ember-engine | addon | route-routes > typescript', function () {
-  loadFixture(inputProject, options);
+  loadFixture(inputProject, codemodOptions);
 
   const migrationStrategy = migrationStrategyForRouteRoutes(options);
 

--- a/tests/migration/ember-engine/addon/route-stylesheets/javascript.test.js
+++ b/tests/migration/ember-engine/addon/route-stylesheets/javascript.test.js
@@ -1,10 +1,13 @@
 import { migrationStrategyForRouteStylesheets } from '../../../../../src/migration/ember-engine/addon/route-stylesheets.js';
 import { inputProject } from '../../../../fixtures/ember-engine/javascript/index.js';
-import { options } from '../../../../helpers/shared-test-setups/ember-engine/javascript.js';
+import {
+  codemodOptions,
+  options,
+} from '../../../../helpers/shared-test-setups/ember-engine/javascript.js';
 import { assert, loadFixture, test } from '../../../../helpers/testing.js';
 
 test('migration | ember-engine | addon | route-stylesheets > javascript', function () {
-  loadFixture(inputProject, options);
+  loadFixture(inputProject, codemodOptions);
 
   const migrationStrategy = migrationStrategyForRouteStylesheets(options);
 

--- a/tests/migration/ember-engine/addon/route-stylesheets/sass.test.js
+++ b/tests/migration/ember-engine/addon/route-stylesheets/sass.test.js
@@ -1,10 +1,13 @@
 import { migrationStrategyForRouteStylesheets } from '../../../../../src/migration/ember-engine/addon/route-stylesheets.js';
 import { inputProject } from '../../../../fixtures/ember-engine/sass/index.js';
-import { options } from '../../../../helpers/shared-test-setups/ember-engine/sass.js';
+import {
+  codemodOptions,
+  options,
+} from '../../../../helpers/shared-test-setups/ember-engine/sass.js';
 import { assert, loadFixture, test } from '../../../../helpers/testing.js';
 
 test('migration | ember-engine | addon | route-stylesheets > sass', function () {
-  loadFixture(inputProject, options);
+  loadFixture(inputProject, codemodOptions);
 
   const migrationStrategy = migrationStrategyForRouteStylesheets(options);
 

--- a/tests/migration/ember-engine/addon/route-stylesheets/typescript.test.js
+++ b/tests/migration/ember-engine/addon/route-stylesheets/typescript.test.js
@@ -1,10 +1,13 @@
 import { migrationStrategyForRouteStylesheets } from '../../../../../src/migration/ember-engine/addon/route-stylesheets.js';
 import { inputProject } from '../../../../fixtures/ember-engine/typescript/index.js';
-import { options } from '../../../../helpers/shared-test-setups/ember-engine/typescript.js';
+import {
+  codemodOptions,
+  options,
+} from '../../../../helpers/shared-test-setups/ember-engine/typescript.js';
 import { assert, loadFixture, test } from '../../../../helpers/testing.js';
 
 test('migration | ember-engine | addon | route-stylesheets > typescript', function () {
-  loadFixture(inputProject, options);
+  loadFixture(inputProject, codemodOptions);
 
   const migrationStrategy = migrationStrategyForRouteStylesheets(options);
 

--- a/tests/migration/ember-engine/addon/route-templates/javascript.test.js
+++ b/tests/migration/ember-engine/addon/route-templates/javascript.test.js
@@ -1,10 +1,13 @@
 import { migrationStrategyForRouteTemplates } from '../../../../../src/migration/ember-engine/addon/route-templates.js';
 import { inputProject } from '../../../../fixtures/ember-engine/javascript/index.js';
-import { options } from '../../../../helpers/shared-test-setups/ember-engine/javascript.js';
+import {
+  codemodOptions,
+  options,
+} from '../../../../helpers/shared-test-setups/ember-engine/javascript.js';
 import { assert, loadFixture, test } from '../../../../helpers/testing.js';
 
 test('migration | ember-engine | addon | route-templates > javascript', function () {
-  loadFixture(inputProject, options);
+  loadFixture(inputProject, codemodOptions);
 
   const migrationStrategy = migrationStrategyForRouteTemplates(options);
 

--- a/tests/migration/ember-engine/addon/route-templates/typescript.test.js
+++ b/tests/migration/ember-engine/addon/route-templates/typescript.test.js
@@ -1,10 +1,13 @@
 import { migrationStrategyForRouteTemplates } from '../../../../../src/migration/ember-engine/addon/route-templates.js';
 import { inputProject } from '../../../../fixtures/ember-engine/typescript/index.js';
-import { options } from '../../../../helpers/shared-test-setups/ember-engine/typescript.js';
+import {
+  codemodOptions,
+  options,
+} from '../../../../helpers/shared-test-setups/ember-engine/typescript.js';
 import { assert, loadFixture, test } from '../../../../helpers/testing.js';
 
 test('migration | ember-engine | addon | route-templates > typescript', function () {
-  loadFixture(inputProject, options);
+  loadFixture(inputProject, codemodOptions);
 
   const migrationStrategy = migrationStrategyForRouteTemplates(options);
 

--- a/tests/migration/ember-engine/index/javascript.test.js
+++ b/tests/migration/ember-engine/index/javascript.test.js
@@ -3,18 +3,18 @@ import {
   inputProject,
   outputProject,
 } from '../../../fixtures/ember-engine/javascript/index.js';
-import { options } from '../../../helpers/shared-test-setups/ember-engine/javascript.js';
+import { codemodOptions } from '../../../helpers/shared-test-setups/ember-engine/javascript.js';
 import { assertFixture, loadFixture, test } from '../../../helpers/testing.js';
 
 test('migration | ember-engine | index > javascript', function () {
-  loadFixture(inputProject, options);
+  loadFixture(inputProject, codemodOptions);
 
-  migrateEmberEngine(options);
+  migrateEmberEngine(codemodOptions);
 
-  assertFixture(outputProject, options);
+  assertFixture(outputProject, codemodOptions);
 
   // Check idempotence
-  migrateEmberEngine(options);
+  migrateEmberEngine(codemodOptions);
 
-  assertFixture(outputProject, options);
+  assertFixture(outputProject, codemodOptions);
 });

--- a/tests/migration/ember-engine/index/sass.test.js
+++ b/tests/migration/ember-engine/index/sass.test.js
@@ -3,18 +3,18 @@ import {
   inputProject,
   outputProject,
 } from '../../../fixtures/ember-engine/sass/index.js';
-import { options } from '../../../helpers/shared-test-setups/ember-engine/sass.js';
+import { codemodOptions } from '../../../helpers/shared-test-setups/ember-engine/sass.js';
 import { assertFixture, loadFixture, test } from '../../../helpers/testing.js';
 
 test('migration | ember-engine | index > sass', function () {
-  loadFixture(inputProject, options);
+  loadFixture(inputProject, codemodOptions);
 
-  migrateEmberEngine(options);
+  migrateEmberEngine(codemodOptions);
 
-  assertFixture(outputProject, options);
+  assertFixture(outputProject, codemodOptions);
 
   // Check idempotence
-  migrateEmberEngine(options);
+  migrateEmberEngine(codemodOptions);
 
-  assertFixture(outputProject, options);
+  assertFixture(outputProject, codemodOptions);
 });

--- a/tests/migration/ember-engine/index/typescript.test.js
+++ b/tests/migration/ember-engine/index/typescript.test.js
@@ -3,18 +3,18 @@ import {
   inputProject,
   outputProject,
 } from '../../../fixtures/ember-engine/typescript/index.js';
-import { options } from '../../../helpers/shared-test-setups/ember-engine/typescript.js';
+import { codemodOptions } from '../../../helpers/shared-test-setups/ember-engine/typescript.js';
 import { assertFixture, loadFixture, test } from '../../../helpers/testing.js';
 
 test('migration | ember-engine | index > typescript', function () {
-  loadFixture(inputProject, options);
+  loadFixture(inputProject, codemodOptions);
 
-  migrateEmberEngine(options);
+  migrateEmberEngine(codemodOptions);
 
-  assertFixture(outputProject, options);
+  assertFixture(outputProject, codemodOptions);
 
   // Check idempotence
-  migrateEmberEngine(options);
+  migrateEmberEngine(codemodOptions);
 
-  assertFixture(outputProject, options);
+  assertFixture(outputProject, codemodOptions);
 });

--- a/tests/migration/ember-engine/steps/create-options/error-handling-package-json-is-an-empty-file.test.js
+++ b/tests/migration/ember-engine/steps/create-options/error-handling-package-json-is-an-empty-file.test.js
@@ -1,0 +1,25 @@
+import { createOptions } from '../../../../../src/migration/ember-engine/steps/index.js';
+import { codemodOptions } from '../../../../helpers/shared-test-setups/ember-engine/javascript.js';
+import { assert, loadFixture, test } from '../../../../helpers/testing.js';
+
+test('migration | ember-engine | steps | create-options > error handling (package.json is an empty file)', function () {
+  const inputProject = {
+    'package.json': '',
+  };
+
+  loadFixture(inputProject, codemodOptions);
+
+  assert.throws(
+    () => {
+      createOptions(codemodOptions);
+    },
+    (error) => {
+      assert.strictEqual(
+        error.message,
+        'ERROR: package.json is missing or is not valid. (Unexpected end of JSON input)\n'
+      );
+
+      return true;
+    }
+  );
+});

--- a/tests/migration/ember-engine/steps/create-options/error-handling-package-json-is-not-a-valid-json.test.js
+++ b/tests/migration/ember-engine/steps/create-options/error-handling-package-json-is-not-a-valid-json.test.js
@@ -1,0 +1,25 @@
+import { createOptions } from '../../../../../src/migration/ember-engine/steps/index.js';
+import { codemodOptions } from '../../../../helpers/shared-test-setups/ember-engine/javascript.js';
+import { assert, loadFixture, test } from '../../../../helpers/testing.js';
+
+test('migration | ember-engine | steps | create-options > error handling (package.json is not a valid JSON)', function () {
+  const inputProject = {
+    'package.json': '{\n  "name": }',
+  };
+
+  loadFixture(inputProject, codemodOptions);
+
+  assert.throws(
+    () => {
+      createOptions(codemodOptions);
+    },
+    (error) => {
+      assert.strictEqual(
+        error.message,
+        'ERROR: package.json is missing or is not valid. (Unexpected token } in JSON at position 12)\n'
+      );
+
+      return true;
+    }
+  );
+});

--- a/tests/migration/ember-engine/steps/create-options/error-handling-package-name-is-missing.test.js
+++ b/tests/migration/ember-engine/steps/create-options/error-handling-package-name-is-missing.test.js
@@ -1,0 +1,25 @@
+import { createOptions } from '../../../../../src/migration/ember-engine/steps/index.js';
+import { codemodOptions } from '../../../../helpers/shared-test-setups/ember-engine/javascript.js';
+import { assert, loadFixture, test } from '../../../../helpers/testing.js';
+
+test('migration | ember-engine | steps | create-options > error handling (package name is missing)', function () {
+  const inputProject = {
+    'package.json': '{}',
+  };
+
+  loadFixture(inputProject, codemodOptions);
+
+  assert.throws(
+    () => {
+      createOptions(codemodOptions);
+    },
+    (error) => {
+      assert.strictEqual(
+        error.message,
+        'ERROR: package.json is missing or is not valid. (Package name is missing.)\n'
+      );
+
+      return true;
+    }
+  );
+});

--- a/tests/migration/ember-engine/steps/create-options/error-handling-package-name-is-not-valid.test.js
+++ b/tests/migration/ember-engine/steps/create-options/error-handling-package-name-is-not-valid.test.js
@@ -1,0 +1,32 @@
+import { createOptions } from '../../../../../src/migration/ember-engine/steps/index.js';
+import { codemodOptions } from '../../../../helpers/shared-test-setups/ember-engine/javascript.js';
+import { assert, loadFixture, test } from '../../../../helpers/testing.js';
+
+test('migration | ember-engine | steps | create-options > error handling (package name is not valid)', function () {
+  const inputProject = {
+    'package.json': JSON.stringify(
+      {
+        name: '@ijlee2/',
+        version: '0.0.0',
+      },
+      null,
+      2
+    ),
+  };
+
+  loadFixture(inputProject, codemodOptions);
+
+  assert.throws(
+    () => {
+      createOptions(codemodOptions);
+    },
+    (error) => {
+      assert.strictEqual(
+        error.message,
+        'ERROR: package.json is missing or is not valid. (Package name is missing.)\n'
+      );
+
+      return true;
+    }
+  );
+});

--- a/tests/migration/ember-engine/steps/create-options/javascript.test.js
+++ b/tests/migration/ember-engine/steps/create-options/javascript.test.js
@@ -1,0 +1,23 @@
+import { createOptions } from '../../../../../src/migration/ember-engine/steps/index.js';
+import {
+  codemodOptions,
+  options,
+} from '../../../../helpers/shared-test-setups/ember-engine/javascript.js';
+import { assert, loadFixture, test } from '../../../../helpers/testing.js';
+
+test('migration | ember-engine | steps | create-options > javascript', function () {
+  const inputProject = {
+    'package.json': JSON.stringify(
+      {
+        name: '@ijlee2/ember-workshop-engine',
+        version: '0.0.0',
+      },
+      null,
+      2
+    ),
+  };
+
+  loadFixture(inputProject, codemodOptions);
+
+  assert.deepEqual(createOptions(codemodOptions), options);
+});

--- a/tests/migration/ember-engine/tests/components/javascript.test.js
+++ b/tests/migration/ember-engine/tests/components/javascript.test.js
@@ -1,10 +1,13 @@
 import { migrationStrategyForComponents } from '../../../../../src/migration/ember-engine/tests/components.js';
 import { inputProject } from '../../../../fixtures/ember-engine/javascript/index.js';
-import { options } from '../../../../helpers/shared-test-setups/ember-engine/javascript.js';
+import {
+  codemodOptions,
+  options,
+} from '../../../../helpers/shared-test-setups/ember-engine/javascript.js';
 import { assert, loadFixture, test } from '../../../../helpers/testing.js';
 
 test('migration | ember-engine | tests | components > javascript', function () {
-  loadFixture(inputProject, options);
+  loadFixture(inputProject, codemodOptions);
 
   const migrationStrategy = migrationStrategyForComponents(options);
 

--- a/tests/migration/ember-engine/tests/components/typescript.test.js
+++ b/tests/migration/ember-engine/tests/components/typescript.test.js
@@ -1,10 +1,13 @@
 import { migrationStrategyForComponents } from '../../../../../src/migration/ember-engine/tests/components.js';
 import { inputProject } from '../../../../fixtures/ember-engine/typescript/index.js';
-import { options } from '../../../../helpers/shared-test-setups/ember-engine/typescript.js';
+import {
+  codemodOptions,
+  options,
+} from '../../../../helpers/shared-test-setups/ember-engine/typescript.js';
 import { assert, loadFixture, test } from '../../../../helpers/testing.js';
 
 test('migration | ember-engine | tests | components > typescript', function () {
-  loadFixture(inputProject, options);
+  loadFixture(inputProject, codemodOptions);
 
   const migrationStrategy = migrationStrategyForComponents(options);
 

--- a/tests/migration/ember-engine/tests/route-controllers/javascript.test.js
+++ b/tests/migration/ember-engine/tests/route-controllers/javascript.test.js
@@ -1,10 +1,13 @@
 import { migrationStrategyForRouteControllers } from '../../../../../src/migration/ember-engine/tests/route-controllers.js';
 import { inputProject } from '../../../../fixtures/ember-engine/javascript/index.js';
-import { options } from '../../../../helpers/shared-test-setups/ember-engine/javascript.js';
+import {
+  codemodOptions,
+  options,
+} from '../../../../helpers/shared-test-setups/ember-engine/javascript.js';
 import { assert, loadFixture, test } from '../../../../helpers/testing.js';
 
 test('migration | ember-engine | tests | route-controllers > javascript', function () {
-  loadFixture(inputProject, options);
+  loadFixture(inputProject, codemodOptions);
 
   const migrationStrategy = migrationStrategyForRouteControllers(options);
 

--- a/tests/migration/ember-engine/tests/route-controllers/typescript.test.js
+++ b/tests/migration/ember-engine/tests/route-controllers/typescript.test.js
@@ -1,10 +1,13 @@
 import { migrationStrategyForRouteControllers } from '../../../../../src/migration/ember-engine/tests/route-controllers.js';
 import { inputProject } from '../../../../fixtures/ember-engine/typescript/index.js';
-import { options } from '../../../../helpers/shared-test-setups/ember-engine/typescript.js';
+import {
+  codemodOptions,
+  options,
+} from '../../../../helpers/shared-test-setups/ember-engine/typescript.js';
 import { assert, loadFixture, test } from '../../../../helpers/testing.js';
 
 test('migration | ember-engine | tests | route-controllers > typescript', function () {
-  loadFixture(inputProject, options);
+  loadFixture(inputProject, codemodOptions);
 
   const migrationStrategy = migrationStrategyForRouteControllers(options);
 

--- a/tests/migration/ember-engine/tests/route-routes/javascript.test.js
+++ b/tests/migration/ember-engine/tests/route-routes/javascript.test.js
@@ -1,10 +1,13 @@
 import { migrationStrategyForRouteRoutes } from '../../../../../src/migration/ember-engine/tests/route-routes.js';
 import { inputProject } from '../../../../fixtures/ember-engine/javascript/index.js';
-import { options } from '../../../../helpers/shared-test-setups/ember-engine/javascript.js';
+import {
+  codemodOptions,
+  options,
+} from '../../../../helpers/shared-test-setups/ember-engine/javascript.js';
 import { assert, loadFixture, test } from '../../../../helpers/testing.js';
 
 test('migration | ember-engine | tests | route-routes > javascript', function () {
-  loadFixture(inputProject, options);
+  loadFixture(inputProject, codemodOptions);
 
   const migrationStrategy = migrationStrategyForRouteRoutes(options);
 

--- a/tests/migration/ember-engine/tests/route-routes/typescript.test.js
+++ b/tests/migration/ember-engine/tests/route-routes/typescript.test.js
@@ -1,10 +1,13 @@
 import { migrationStrategyForRouteRoutes } from '../../../../../src/migration/ember-engine/tests/route-routes.js';
 import { inputProject } from '../../../../fixtures/ember-engine/typescript/index.js';
-import { options } from '../../../../helpers/shared-test-setups/ember-engine/typescript.js';
+import {
+  codemodOptions,
+  options,
+} from '../../../../helpers/shared-test-setups/ember-engine/typescript.js';
 import { assert, loadFixture, test } from '../../../../helpers/testing.js';
 
 test('migration | ember-engine | tests | route-routes > typescript', function () {
-  loadFixture(inputProject, options);
+  loadFixture(inputProject, codemodOptions);
 
   const migrationStrategy = migrationStrategyForRouteRoutes(options);
 

--- a/tests/utils/ember-addon/app/components.test.js
+++ b/tests/utils/ember-addon/app/components.test.js
@@ -1,6 +1,9 @@
 import { updatePaths } from '../../../../src/utils/ember-addon/app/components.js';
 import { moveFiles } from '../../../../src/utils/files.js';
-import { options } from '../../../helpers/shared-test-setups/ember-addon/javascript.js';
+import {
+  codemodOptions,
+  options,
+} from '../../../helpers/shared-test-setups/ember-addon/javascript.js';
 import { assertFixture, loadFixture, test } from '../../../helpers/testing.js';
 
 test('utils | ember-addon | app | components', function () {
@@ -32,7 +35,7 @@ test('utils | ember-addon | app | components', function () {
     },
   };
 
-  loadFixture(inputProject, options);
+  loadFixture(inputProject, codemodOptions);
 
   const migrationStrategy = new Map([
     [
@@ -45,5 +48,5 @@ test('utils | ember-addon | app | components', function () {
 
   updatePaths(migrationStrategy, options);
 
-  assertFixture(outputProject, options);
+  assertFixture(outputProject, codemodOptions);
 });

--- a/tests/utils/files/move-files.test.js
+++ b/tests/utils/files/move-files.test.js
@@ -1,5 +1,8 @@
 import { moveFiles } from '../../../src/utils/files.js';
-import { options } from '../../helpers/shared-test-setups/ember-addon/typescript.js';
+import {
+  codemodOptions,
+  options,
+} from '../../helpers/shared-test-setups/ember-addon/typescript.js';
 import { assertFixture, loadFixture, test } from '../../helpers/testing.js';
 
 test('utils | files | move-files', function () {
@@ -35,7 +38,7 @@ test('utils | files | move-files', function () {
     },
   };
 
-  loadFixture(inputProject, options);
+  loadFixture(inputProject, codemodOptions);
 
   const migrationStrategy = new Map([
     [
@@ -50,5 +53,5 @@ test('utils | files | move-files', function () {
 
   moveFiles(migrationStrategy, options);
 
-  assertFixture(outputProject, options);
+  assertFixture(outputProject, codemodOptions);
 });

--- a/tests/utils/files/remove-directory-if-empty.test.js
+++ b/tests/utils/files/remove-directory-if-empty.test.js
@@ -1,5 +1,8 @@
 import { removeDirectoryIfEmpty } from '../../../src/utils/files.js';
-import { options } from '../../helpers/shared-test-setups/ember-addon/typescript.js';
+import {
+  codemodOptions,
+  options,
+} from '../../helpers/shared-test-setups/ember-addon/typescript.js';
 import { assertFixture, loadFixture, test } from '../../helpers/testing.js';
 
 test('utils | files | remove-directory-if-empty > parent directories are empty', function () {
@@ -17,14 +20,14 @@ test('utils | files | remove-directory-if-empty > parent directories are empty',
 
   const outputProject = {};
 
-  loadFixture(inputProject, options);
+  loadFixture(inputProject, codemodOptions);
 
   removeDirectoryIfEmpty({
     oldPath: 'addon/components/ui/form/checkbox/component.ts',
     projectRoot: options.projectRoot,
   });
 
-  assertFixture(outputProject, options);
+  assertFixture(outputProject, codemodOptions);
 });
 
 test('utils | files | remove-directory-if-empty > a parent directory is not empty', function () {
@@ -56,12 +59,12 @@ test('utils | files | remove-directory-if-empty > a parent directory is not empt
     },
   };
 
-  loadFixture(inputProject, options);
+  loadFixture(inputProject, codemodOptions);
 
   removeDirectoryIfEmpty({
     oldPath: 'addon/components/ui/form/checkbox/component.ts',
     projectRoot: options.projectRoot,
   });
 
-  assertFixture(outputProject, options);
+  assertFixture(outputProject, codemodOptions);
 });


### PR DESCRIPTION
## Description

When developing [`ember-codemod-v1-to-v2`](https://github.com/ijlee2/ember-codemod-v1-to-v2), I realized that it is important to separate the options that the end-developer provides from the options that we (maintainers) provide for the migration steps.


## References

- https://github.com/ijlee2/ember-codemod-v1-to-v2/pull/9