### PR TITLE
Updated paths after migration (ember-engine)

### DIFF
--- a/codemod-test-fixtures.sh
+++ b/codemod-test-fixtures.sh
@@ -19,6 +19,8 @@
 ./codemod-test-fixture.sh -t "app" -p "pods" ember-app/pod-path
 ./codemod-test-fixture.sh -t "app" ember-app/sass
 ./codemod-test-fixture.sh -t "app" ember-app/typescript
+./codemod-test-fixture.sh -t "engine" ember-engine/absolute-imports
 ./codemod-test-fixture.sh -t "engine" ember-engine/javascript
+./codemod-test-fixture.sh -t "engine" ember-engine/relative-imports
 ./codemod-test-fixture.sh -t "engine" ember-engine/sass
 ./codemod-test-fixture.sh -t "engine" ember-engine/typescript

--- a/src/migration/ember-addon/index.js
+++ b/src/migration/ember-addon/index.js
@@ -1,4 +1,4 @@
-import { updatePaths } from '../../utils/ember-addon/app/components.js';
+import { updatePathsInAppFolder } from '../../utils/ember-addon/app/components.js';
 import { moveFiles } from '../../utils/files.js';
 import { migrationStrategyForAddonFolder } from './addon/index.js';
 import { migrationStrategyForAppFolder } from './app/index.js';
@@ -26,5 +26,5 @@ export function migrateEmberAddon(codemodOptions) {
   moveFiles(migrationStrategyApp, options);
   moveFiles(migrationStrategyTests, options);
 
-  updatePaths(migrationStrategyApp, options);
+  updatePathsInAppFolder(migrationStrategyApp, options);
 }

--- a/src/migration/ember-engine/index.js
+++ b/src/migration/ember-engine/index.js
@@ -1,6 +1,11 @@
 import { moveFiles } from '../../utils/files.js';
 import { migrationStrategyForAddonFolder } from './addon/index.js';
-import { createOptions } from './steps/index.js';
+import {
+  createOptions,
+  updateAbsolutePaths,
+  useAbsolutePaths,
+  useRelativePaths,
+} from './steps/index.js';
 import { migrationStrategyForTestsFolder } from './tests/index.js';
 
 export function migrateEmberEngine(codemodOptions) {
@@ -18,6 +23,14 @@ export function migrateEmberEngine(codemodOptions) {
     return;
   }
 
+  // Prepare for migration
+  useAbsolutePaths(options);
+
+  // Preserve code
   moveFiles(migrationStrategyAddon, options);
   moveFiles(migrationStrategyTests, options);
+
+  // Update import paths
+  updateAbsolutePaths(options);
+  useRelativePaths(options);
 }

--- a/src/migration/ember-engine/index.js
+++ b/src/migration/ember-engine/index.js
@@ -14,11 +14,13 @@ export function migrateEmberEngine(codemodOptions) {
   const migrationStrategyAddon = migrationStrategyForAddonFolder(options);
   const migrationStrategyTests = migrationStrategyForTestsFolder(options);
 
+  const migrationStrategy = new Map([
+    ...migrationStrategyAddon,
+    ...migrationStrategyTests,
+  ]);
+
   if (options.testRun) {
-    console.log({
-      migrationStrategyAddon,
-      migrationStrategyTests,
-    });
+    console.log(migrationStrategy);
 
     return;
   }
@@ -31,6 +33,6 @@ export function migrateEmberEngine(codemodOptions) {
   moveFiles(migrationStrategyTests, options);
 
   // Update import paths
-  updateAbsolutePaths(options);
+  updateAbsolutePaths(migrationStrategy, options);
   useRelativePaths(options);
 }

--- a/src/migration/ember-engine/steps/index.js
+++ b/src/migration/ember-engine/steps/index.js
@@ -1,1 +1,4 @@
 export * from './create-options.js';
+export * from './update-absolute-paths.js';
+export * from './use-absolute-paths.js';
+export * from './use-relative-paths.js';

--- a/src/migration/ember-engine/steps/update-absolute-paths.js
+++ b/src/migration/ember-engine/steps/update-absolute-paths.js
@@ -1,0 +1,3 @@
+export function updateAbsolutePaths(options) {
+  // ...
+}

--- a/src/migration/ember-engine/steps/update-absolute-paths.js
+++ b/src/migration/ember-engine/steps/update-absolute-paths.js
@@ -1,3 +1,104 @@
-export function updateAbsolutePaths(options) {
-  // ...
+import { readFileSync, writeFileSync } from 'node:fs';
+import { join, parse } from 'node:path';
+
+import glob from 'glob';
+
+function removeFileExtension(path) {
+  const { dir, name } = parse(path);
+
+  return `${dir}/${name}`;
+}
+
+function createMapping(migrationStrategy) {
+  return new Map(
+    [...migrationStrategy].map(([oldPath, newPath]) => {
+      const before = removeFileExtension(oldPath);
+      const after = removeFileExtension(newPath);
+
+      return [before, after];
+    })
+  );
+}
+
+function updatePathsToAddonFiles(oldFile, { mapping, projectName }) {
+  const regex = new RegExp(`(?:'|")(${projectName}/(.*))(?:'|")`, 'g');
+  const matchResults = [...oldFile.matchAll(regex)];
+
+  let newFile = oldFile;
+
+  matchResults.forEach((matchResult) => {
+    // eslint-disable-next-line no-unused-vars
+    const [_, oldPath, remainingPath] = matchResult;
+    const before = join('addon', remainingPath);
+
+    if (!mapping.has(before)) {
+      return;
+    }
+
+    const after = mapping.get(before).replace(new RegExp('^addon/'), '');
+    const newPath = join(projectName, after);
+
+    newFile = newFile.replace(oldPath, newPath);
+  });
+
+  return newFile;
+}
+
+function updatePathsToTestFiles(oldFile, { mapping, projectName }) {
+  const regex = new RegExp(`(?:'|")(${projectName}/(.*))(?:'|")`, 'g');
+  const matchResults = [...oldFile.matchAll(regex)];
+
+  let newFile = oldFile;
+
+  matchResults.forEach((matchResult) => {
+    // eslint-disable-next-line no-unused-vars
+    const [_, oldPath, remainingPath] = matchResult;
+    const before = remainingPath;
+
+    if (!mapping.has(before)) {
+      return;
+    }
+
+    const after = mapping.get(before);
+    const newPath = join(projectName, after);
+
+    newFile = newFile.replace(oldPath, newPath);
+  });
+
+  return newFile;
+}
+
+function updatePaths(mapping, options) {
+  const { projectName, projectRoot } = options;
+
+  // File extensions had been specified, partly to encode assumptions
+  // about Ember, and partly to avoid corrupting non-text files
+  const filePaths = glob.sync('{addon,tests}/**/*.{d.ts,js,ts}', {
+    cwd: projectRoot,
+    dot: true,
+    nodir: true,
+  });
+
+  filePaths.forEach((filePath) => {
+    const oldPath = join(projectRoot, filePath);
+    const oldFile = readFileSync(oldPath, 'utf8');
+
+    let newFile = updatePathsToAddonFiles(oldFile, {
+      mapping,
+      projectName,
+    });
+
+    newFile = updatePathsToTestFiles(newFile, {
+      mapping,
+      projectName: 'dummy',
+    });
+
+    writeFileSync(oldPath, newFile, 'utf8');
+  });
+}
+
+export function updateAbsolutePaths(migrationStrategy, options) {
+  const mapping = createMapping(migrationStrategy);
+
+  updatePaths(mapping, options);
 }

--- a/src/migration/ember-engine/steps/use-absolute-paths.js
+++ b/src/migration/ember-engine/steps/use-absolute-paths.js
@@ -1,3 +1,60 @@
+import { readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join, relative, resolve } from 'node:path';
+
+import glob from 'glob';
+
+function removeRelativePaths(oldFile, { filePath, projectName, projectRoot }) {
+  const regex = new RegExp(`(?:'|")(.{1,2}/(.*))(?:'|")`, 'g');
+  const matchResults = [...oldFile.matchAll(regex)];
+
+  let newFile = oldFile;
+
+  matchResults.forEach((matchResult) => {
+    // eslint-disable-next-line no-unused-vars
+    const [_, oldPath, remainingPath] = matchResult;
+
+    let newPath = relative(
+      projectRoot,
+      resolve(projectRoot, dirname(filePath), oldPath)
+    );
+
+    if (newPath.startsWith('addon')) {
+      newPath = join(projectName, newPath.replace(new RegExp('^addon/'), ''));
+    } else if (newPath.startsWith('tests')) {
+      newPath = join('dummy', newPath);
+    }
+
+    newFile = newFile.replace(oldPath, newPath);
+  });
+
+  return newFile;
+}
+
+function updatePaths(options) {
+  const { projectName, projectRoot } = options;
+
+  // File extensions had been specified, partly to encode assumptions
+  // about Ember, and partly to avoid corrupting non-text files
+  const filePaths = glob.sync('{addon,tests}/**/*.{d.ts,js,ts}', {
+    cwd: projectRoot,
+    dot: true,
+    nodir: true,
+  });
+
+  filePaths.forEach((filePath) => {
+    const oldPath = join(projectRoot, filePath);
+    const oldFile = readFileSync(oldPath, 'utf8');
+
+    const newFile = removeRelativePaths(oldFile, {
+      filePath,
+      projectName,
+      projectRoot,
+    });
+
+    writeFileSync(oldPath, newFile, 'utf8');
+  });
+}
+
 export function useAbsolutePaths(options) {
-  // ...
+  updatePaths(options);
 }

--- a/src/migration/ember-engine/steps/use-absolute-paths.js
+++ b/src/migration/ember-engine/steps/use-absolute-paths.js
@@ -1,0 +1,3 @@
+export function useAbsolutePaths(options) {
+  // ...
+}

--- a/src/migration/ember-engine/steps/use-relative-paths.js
+++ b/src/migration/ember-engine/steps/use-relative-paths.js
@@ -1,3 +1,116 @@
+import { readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join, relative } from 'node:path';
+
+import glob from 'glob';
+
+function normalizeRelativePath(relativePath) {
+  if (relativePath.startsWith('..')) {
+    return relativePath;
+  }
+
+  return `./${relativePath}`;
+}
+
+function updateFile(oldFile, { filePath, projectName, projectRoot }) {
+  const regex = new RegExp(`(?:'|")(${projectName}/(.*/)*(.*))(?:'|")`, 'g');
+  const matchResults = [...oldFile.matchAll(regex)];
+
+  let newFile = oldFile;
+
+  matchResults.forEach((matchResult) => {
+    // eslint-disable-next-line no-unused-vars
+    const [_, oldPath, remainingDirectories, fileName] = matchResult;
+
+    const from = dirname(filePath);
+    const to = join(projectRoot, remainingDirectories);
+
+    const relativePath = join(relative(from, to), fileName);
+    const newPath = normalizeRelativePath(relativePath);
+
+    newFile = newFile.replace(oldPath, newPath);
+  });
+
+  return newFile;
+}
+
+function useRelativePathInAddonFolder(options) {
+  const { projectName, projectRoot } = options;
+
+  // File extensions had been specified, partly to encode assumptions
+  // about Ember, and partly to avoid corrupting non-text files
+  const filePaths = glob.sync('addon/**/*.{d.ts,js,ts}', {
+    cwd: projectRoot,
+    dot: true,
+    nodir: true,
+  });
+
+  filePaths.forEach((filePath) => {
+    const oldPath = join(projectRoot, filePath);
+    const oldFile = readFileSync(oldPath, 'utf8');
+
+    const newFile = updateFile(oldFile, {
+      filePath,
+      projectName,
+      projectRoot: 'addon',
+    });
+
+    writeFileSync(oldPath, newFile, 'utf8');
+  });
+}
+
+function useRelativePathInTestsFolder(options) {
+  const { projectRoot } = options;
+
+  // File extensions had been specified, partly to encode assumptions
+  // about Ember, and partly to avoid corrupting non-text files
+  const filePaths = glob.sync('tests/**/*.{d.ts,js,ts}', {
+    cwd: projectRoot,
+    dot: true,
+    ignore: 'tests/dummy/**/*',
+    nodir: true,
+  });
+
+  filePaths.forEach((filePath) => {
+    const oldPath = join(projectRoot, filePath);
+    const oldFile = readFileSync(oldPath, 'utf8');
+
+    const newFile = updateFile(oldFile, {
+      filePath,
+      projectName: 'dummy',
+      projectRoot: '',
+    });
+
+    writeFileSync(oldPath, newFile, 'utf8');
+  });
+}
+
+function useRelativePathInTestsDummyFolder(options) {
+  const { projectRoot } = options;
+
+  // File extensions had been specified, partly to encode assumptions
+  // about Ember, and partly to avoid corrupting non-text files
+  const filePaths = glob.sync('tests/dummy/**/*.{d.ts,js,ts}', {
+    cwd: projectRoot,
+    dot: true,
+    nodir: true,
+  });
+
+  filePaths.forEach((filePath) => {
+    const oldPath = join(projectRoot, filePath);
+    const oldFile = readFileSync(oldPath, 'utf8');
+
+    const newFile = updateFile(oldFile, {
+      filePath,
+      projectName: 'dummy',
+      projectRoot: 'tests/dummy/app',
+    });
+
+    writeFileSync(oldPath, newFile, 'utf8');
+  });
+}
+
 export function useRelativePaths(options) {
-  // ...
+  useRelativePathInAddonFolder(options);
+  useRelativePathInTestsFolder(options);
+  useRelativePathInTestsDummyFolder(options);
 }

--- a/src/migration/ember-engine/steps/use-relative-paths.js
+++ b/src/migration/ember-engine/steps/use-relative-paths.js
@@ -1,0 +1,3 @@
+export function useRelativePaths(options) {
+  // ...
+}

--- a/src/utils/ember-addon/app/components.js
+++ b/src/utils/ember-addon/app/components.js
@@ -1,7 +1,7 @@
 import { readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
-export function updatePaths(migrationStrategy, options) {
+export function updatePathsInAppFolder(migrationStrategy, options) {
   const { projectRoot } = options;
 
   migrationStrategy.forEach((newPath, oldPath) => {

--- a/tests/fixtures/ember-engine/absolute-imports/index.js
+++ b/tests/fixtures/ember-engine/absolute-imports/index.js
@@ -1,0 +1,6 @@
+import { convertFixtureToJson } from '../../../helpers/testing.js';
+
+const inputProject = convertFixtureToJson('ember-engine/absolute-imports/input');
+const outputProject = convertFixtureToJson('ember-engine/absolute-imports/output');
+
+export { inputProject, outputProject };

--- a/tests/fixtures/ember-engine/absolute-imports/input/addon/authenticated/controller.ts
+++ b/tests/fixtures/ember-engine/absolute-imports/input/addon/authenticated/controller.ts
@@ -1,0 +1,3 @@
+import Controller from '@ember/controller';
+
+export default class AuthenticatedController extends Controller {}

--- a/tests/fixtures/ember-engine/absolute-imports/input/addon/components/ui/password-reset-form/component.ts
+++ b/tests/fixtures/ember-engine/absolute-imports/input/addon/components/ui/password-reset-form/component.ts
@@ -1,0 +1,11 @@
+import Component from '@glimmer/component';
+
+export type PasswordResetFormModel = {};
+
+export default class UiPasswordResetFormComponent extends Component {
+  get model(): PasswordResetFormModel {
+    return {
+      // ...
+    };
+  }
+}

--- a/tests/fixtures/ember-engine/absolute-imports/input/addon/components/ui/password-reset-page/component.ts
+++ b/tests/fixtures/ember-engine/absolute-imports/input/addon/components/ui/password-reset-page/component.ts
@@ -1,0 +1,8 @@
+import { inject as service } from '@ember/service';
+import Component from '@glimmer/component';
+import type { PasswordResetFormModel } from '@namespace/package-name/components/ui/password-reset-form/component';
+import type FormService from '@namespace/package-name/services/form';
+
+export default class UiPasswordResetPageComponent extends Component {
+  @service declare form: FormService;
+}

--- a/tests/fixtures/ember-engine/absolute-imports/input/addon/index/route.ts
+++ b/tests/fixtures/ember-engine/absolute-imports/input/addon/index/route.ts
@@ -1,0 +1,7 @@
+import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
+import ApiService from '@namespace/package-name/services/api';
+
+export default class IndexRoute extends Route {
+  @service declare api: ApiService;
+}

--- a/tests/fixtures/ember-engine/absolute-imports/input/addon/password-reset/controller.ts
+++ b/tests/fixtures/ember-engine/absolute-imports/input/addon/password-reset/controller.ts
@@ -1,0 +1,3 @@
+import AuthenticatedController from '@namespace/package-name/authenticated/controller';
+
+export default class PasswordResetController extends AuthenticatedController {}

--- a/tests/fixtures/ember-engine/absolute-imports/input/addon/services/api.ts
+++ b/tests/fixtures/ember-engine/absolute-imports/input/addon/services/api.ts
@@ -1,0 +1,3 @@
+import Service from '@ember/service';
+
+export default class ApiService extends Service {}

--- a/tests/fixtures/ember-engine/absolute-imports/input/addon/services/form.ts
+++ b/tests/fixtures/ember-engine/absolute-imports/input/addon/services/form.ts
@@ -1,0 +1,6 @@
+import Service, { inject as service } from '@ember/service';
+import ApiService from '@namespace/package-name/services/api';
+
+export default class FormService extends Service {
+  @service declare api: ApiService;
+}

--- a/tests/fixtures/ember-engine/absolute-imports/input/package.json
+++ b/tests/fixtures/ember-engine/absolute-imports/input/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@namespace/package-name",
+  "version": "0.0.0"
+}

--- a/tests/fixtures/ember-engine/absolute-imports/input/tests/dummy/app/components/new-password-reset-page/component.ts
+++ b/tests/fixtures/ember-engine/absolute-imports/input/tests/dummy/app/components/new-password-reset-page/component.ts
@@ -1,0 +1,8 @@
+import { inject as service } from '@ember/service';
+import Component from '@glimmer/component';
+import type { PasswordResetFormModel } from '@namespace/package-name/components/ui/password-reset-form/component';
+import type FormService from '@namespace/package-name/services/form';
+
+export default class NewPasswordResetPageComponent extends Component {
+  @service declare form: FormService;
+}

--- a/tests/fixtures/ember-engine/absolute-imports/input/tests/integration/components/ui/password-reset-form/component-test.ts
+++ b/tests/fixtures/ember-engine/absolute-imports/input/tests/integration/components/ui/password-reset-form/component-test.ts
@@ -1,0 +1,3 @@
+import type { PasswordResetFormModel } from '@namespace/package-name/components/ui/password-reset-form/component';
+
+export type CustomType = string | unknown;

--- a/tests/fixtures/ember-engine/absolute-imports/input/tests/integration/components/ui/password-reset-page/component-test.ts
+++ b/tests/fixtures/ember-engine/absolute-imports/input/tests/integration/components/ui/password-reset-page/component-test.ts
@@ -1,0 +1,2 @@
+import type { PasswordResetFormModel } from '@namespace/package-name/components/ui/password-reset-form/component';
+import type { CustomType } from 'dummy/tests/integration/components/ui/password-reset-form/component-test';

--- a/tests/fixtures/ember-engine/absolute-imports/input/tests/unit/authenticated/controller-test.ts
+++ b/tests/fixtures/ember-engine/absolute-imports/input/tests/unit/authenticated/controller-test.ts
@@ -1,0 +1,1 @@
+import type AuthenticatedController from '@namespace/package-name/authenticated/controller';

--- a/tests/fixtures/ember-engine/absolute-imports/input/tests/unit/controllers/password-reset-test.ts
+++ b/tests/fixtures/ember-engine/absolute-imports/input/tests/unit/controllers/password-reset-test.ts
@@ -1,0 +1,1 @@
+import type PasswordResetController from '@namespace/package-name/password-reset/controller';

--- a/tests/fixtures/ember-engine/absolute-imports/input/tests/unit/index/route-test.ts
+++ b/tests/fixtures/ember-engine/absolute-imports/input/tests/unit/index/route-test.ts
@@ -1,0 +1,1 @@
+import type IndexRoute from '@namespace/package-name/index/route';

--- a/tests/fixtures/ember-engine/absolute-imports/input/tests/unit/services/api-test.ts
+++ b/tests/fixtures/ember-engine/absolute-imports/input/tests/unit/services/api-test.ts
@@ -1,0 +1,1 @@
+import type ApiService from '@namespace/package-name/services/api';

--- a/tests/fixtures/ember-engine/absolute-imports/input/tests/unit/services/form-test.ts
+++ b/tests/fixtures/ember-engine/absolute-imports/input/tests/unit/services/form-test.ts
@@ -1,0 +1,1 @@
+import type FormService from '@namespace/package-name/services/form';

--- a/tests/fixtures/ember-engine/absolute-imports/output/addon/components/ui/password-reset-form.ts
+++ b/tests/fixtures/ember-engine/absolute-imports/output/addon/components/ui/password-reset-form.ts
@@ -1,0 +1,11 @@
+import Component from '@glimmer/component';
+
+export type PasswordResetFormModel = {};
+
+export default class UiPasswordResetFormComponent extends Component {
+  get model(): PasswordResetFormModel {
+    return {
+      // ...
+    };
+  }
+}

--- a/tests/fixtures/ember-engine/absolute-imports/output/addon/components/ui/password-reset-page.ts
+++ b/tests/fixtures/ember-engine/absolute-imports/output/addon/components/ui/password-reset-page.ts
@@ -1,0 +1,8 @@
+import { inject as service } from '@ember/service';
+import Component from '@glimmer/component';
+import type { PasswordResetFormModel } from './password-reset-form';
+import type FormService from '../../services/form';
+
+export default class UiPasswordResetPageComponent extends Component {
+  @service declare form: FormService;
+}

--- a/tests/fixtures/ember-engine/absolute-imports/output/addon/controllers/authenticated.ts
+++ b/tests/fixtures/ember-engine/absolute-imports/output/addon/controllers/authenticated.ts
@@ -1,0 +1,3 @@
+import Controller from '@ember/controller';
+
+export default class AuthenticatedController extends Controller {}

--- a/tests/fixtures/ember-engine/absolute-imports/output/addon/controllers/password-reset.ts
+++ b/tests/fixtures/ember-engine/absolute-imports/output/addon/controllers/password-reset.ts
@@ -1,0 +1,3 @@
+import AuthenticatedController from './authenticated';
+
+export default class PasswordResetController extends AuthenticatedController {}

--- a/tests/fixtures/ember-engine/absolute-imports/output/addon/routes/index.ts
+++ b/tests/fixtures/ember-engine/absolute-imports/output/addon/routes/index.ts
@@ -1,0 +1,7 @@
+import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
+import ApiService from '../services/api';
+
+export default class IndexRoute extends Route {
+  @service declare api: ApiService;
+}

--- a/tests/fixtures/ember-engine/absolute-imports/output/addon/services/api.ts
+++ b/tests/fixtures/ember-engine/absolute-imports/output/addon/services/api.ts
@@ -1,0 +1,3 @@
+import Service from '@ember/service';
+
+export default class ApiService extends Service {}

--- a/tests/fixtures/ember-engine/absolute-imports/output/addon/services/form.ts
+++ b/tests/fixtures/ember-engine/absolute-imports/output/addon/services/form.ts
@@ -1,0 +1,6 @@
+import Service, { inject as service } from '@ember/service';
+import ApiService from './api';
+
+export default class FormService extends Service {
+  @service declare api: ApiService;
+}

--- a/tests/fixtures/ember-engine/absolute-imports/output/package.json
+++ b/tests/fixtures/ember-engine/absolute-imports/output/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@namespace/package-name",
+  "version": "0.0.0"
+}

--- a/tests/fixtures/ember-engine/absolute-imports/output/tests/dummy/app/components/new-password-reset-page/component.ts
+++ b/tests/fixtures/ember-engine/absolute-imports/output/tests/dummy/app/components/new-password-reset-page/component.ts
@@ -1,0 +1,8 @@
+import { inject as service } from '@ember/service';
+import Component from '@glimmer/component';
+import type { PasswordResetFormModel } from '@namespace/package-name/components/ui/password-reset-form';
+import type FormService from '@namespace/package-name/services/form';
+
+export default class NewPasswordResetPageComponent extends Component {
+  @service declare form: FormService;
+}

--- a/tests/fixtures/ember-engine/absolute-imports/output/tests/integration/components/ui/password-reset-form-test.ts
+++ b/tests/fixtures/ember-engine/absolute-imports/output/tests/integration/components/ui/password-reset-form-test.ts
@@ -1,0 +1,3 @@
+import type { PasswordResetFormModel } from '@namespace/package-name/components/ui/password-reset-form';
+
+export type CustomType = string | unknown;

--- a/tests/fixtures/ember-engine/absolute-imports/output/tests/integration/components/ui/password-reset-page-test.ts
+++ b/tests/fixtures/ember-engine/absolute-imports/output/tests/integration/components/ui/password-reset-page-test.ts
@@ -1,0 +1,2 @@
+import type { PasswordResetFormModel } from '@namespace/package-name/components/ui/password-reset-form';
+import type { CustomType } from './password-reset-form-test';

--- a/tests/fixtures/ember-engine/absolute-imports/output/tests/unit/controllers/authenticated-test.ts
+++ b/tests/fixtures/ember-engine/absolute-imports/output/tests/unit/controllers/authenticated-test.ts
@@ -1,0 +1,1 @@
+import type AuthenticatedController from '@namespace/package-name/controllers/authenticated';

--- a/tests/fixtures/ember-engine/absolute-imports/output/tests/unit/controllers/password-reset-test.ts
+++ b/tests/fixtures/ember-engine/absolute-imports/output/tests/unit/controllers/password-reset-test.ts
@@ -1,0 +1,1 @@
+import type PasswordResetController from '@namespace/package-name/controllers/password-reset';

--- a/tests/fixtures/ember-engine/absolute-imports/output/tests/unit/routes/index-test.ts
+++ b/tests/fixtures/ember-engine/absolute-imports/output/tests/unit/routes/index-test.ts
@@ -1,0 +1,1 @@
+import type IndexRoute from '@namespace/package-name/routes/index';

--- a/tests/fixtures/ember-engine/absolute-imports/output/tests/unit/services/api-test.ts
+++ b/tests/fixtures/ember-engine/absolute-imports/output/tests/unit/services/api-test.ts
@@ -1,0 +1,1 @@
+import type ApiService from '@namespace/package-name/services/api';

--- a/tests/fixtures/ember-engine/absolute-imports/output/tests/unit/services/form-test.ts
+++ b/tests/fixtures/ember-engine/absolute-imports/output/tests/unit/services/form-test.ts
@@ -1,0 +1,1 @@
+import type FormService from '@namespace/package-name/services/form';

--- a/tests/fixtures/ember-engine/relative-imports/index.js
+++ b/tests/fixtures/ember-engine/relative-imports/index.js
@@ -1,0 +1,6 @@
+import { convertFixtureToJson } from '../../../helpers/testing.js';
+
+const inputProject = convertFixtureToJson('ember-engine/relative-imports/input');
+const outputProject = convertFixtureToJson('ember-engine/relative-imports/output');
+
+export { inputProject, outputProject };

--- a/tests/fixtures/ember-engine/relative-imports/input/addon/authenticated/controller.ts
+++ b/tests/fixtures/ember-engine/relative-imports/input/addon/authenticated/controller.ts
@@ -1,0 +1,3 @@
+import Controller from '@ember/controller';
+
+export default class AuthenticatedController extends Controller {}

--- a/tests/fixtures/ember-engine/relative-imports/input/addon/components/ui/password-reset-form/component.ts
+++ b/tests/fixtures/ember-engine/relative-imports/input/addon/components/ui/password-reset-form/component.ts
@@ -1,0 +1,11 @@
+import Component from '@glimmer/component';
+
+export type PasswordResetFormModel = {};
+
+export default class UiPasswordResetFormComponent extends Component {
+  get model(): PasswordResetFormModel {
+    return {
+      // ...
+    };
+  }
+}

--- a/tests/fixtures/ember-engine/relative-imports/input/addon/components/ui/password-reset-page/component.ts
+++ b/tests/fixtures/ember-engine/relative-imports/input/addon/components/ui/password-reset-page/component.ts
@@ -1,0 +1,9 @@
+import { inject as service } from '@ember/service';
+import Component from '@glimmer/component';
+
+import type FormService from '../../../services/form';
+import type { PasswordResetFormModel } from '../password-reset-form/component';
+
+export default class UiPasswordResetPageComponent extends Component {
+  @service declare form: FormService;
+}

--- a/tests/fixtures/ember-engine/relative-imports/input/addon/index/route.ts
+++ b/tests/fixtures/ember-engine/relative-imports/input/addon/index/route.ts
@@ -1,0 +1,8 @@
+import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
+
+import ApiService from '../services/api';
+
+export default class IndexRoute extends Route {
+  @service declare api: ApiService;
+}

--- a/tests/fixtures/ember-engine/relative-imports/input/addon/password-reset/controller.ts
+++ b/tests/fixtures/ember-engine/relative-imports/input/addon/password-reset/controller.ts
@@ -1,0 +1,3 @@
+import AuthenticatedController from '../authenticated/controller';
+
+export default class PasswordResetController extends AuthenticatedController {}

--- a/tests/fixtures/ember-engine/relative-imports/input/addon/services/api.ts
+++ b/tests/fixtures/ember-engine/relative-imports/input/addon/services/api.ts
@@ -1,0 +1,3 @@
+import Service from '@ember/service';
+
+export default class ApiService extends Service {}

--- a/tests/fixtures/ember-engine/relative-imports/input/addon/services/form.ts
+++ b/tests/fixtures/ember-engine/relative-imports/input/addon/services/form.ts
@@ -1,0 +1,7 @@
+import Service, { inject as service } from '@ember/service';
+
+import ApiService from '../services/api';
+
+export default class FormService extends Service {
+  @service declare api: ApiService;
+}

--- a/tests/fixtures/ember-engine/relative-imports/input/package.json
+++ b/tests/fixtures/ember-engine/relative-imports/input/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@namespace/package-name",
+  "version": "0.0.0"
+}

--- a/tests/fixtures/ember-engine/relative-imports/input/tests/dummy/app/components/new-password-reset-page/component.ts
+++ b/tests/fixtures/ember-engine/relative-imports/input/tests/dummy/app/components/new-password-reset-page/component.ts
@@ -1,0 +1,8 @@
+import { inject as service } from '@ember/service';
+import Component from '@glimmer/component';
+import type { PasswordResetFormModel } from '@namespace/package-name/components/ui/password-reset-form/component';
+import type FormService from '@namespace/package-name/services/form';
+
+export default class NewPasswordResetPageComponent extends Component {
+  @service declare form: FormService;
+}

--- a/tests/fixtures/ember-engine/relative-imports/input/tests/integration/components/ui/password-reset-form/component-test.ts
+++ b/tests/fixtures/ember-engine/relative-imports/input/tests/integration/components/ui/password-reset-form/component-test.ts
@@ -1,0 +1,3 @@
+import type { PasswordResetFormModel } from '@namespace/package-name/components/ui/password-reset-form/component';
+
+export type CustomType = string | unknown;

--- a/tests/fixtures/ember-engine/relative-imports/input/tests/integration/components/ui/password-reset-page/component-test.ts
+++ b/tests/fixtures/ember-engine/relative-imports/input/tests/integration/components/ui/password-reset-page/component-test.ts
@@ -1,0 +1,3 @@
+import type { PasswordResetFormModel } from '@namespace/package-name/components/ui/password-reset-form/component';
+
+import type { CustomType } from '../password-reset-form/component-test';

--- a/tests/fixtures/ember-engine/relative-imports/input/tests/unit/authenticated/controller-test.ts
+++ b/tests/fixtures/ember-engine/relative-imports/input/tests/unit/authenticated/controller-test.ts
@@ -1,0 +1,1 @@
+import type AuthenticatedController from '@namespace/package-name/authenticated/controller';

--- a/tests/fixtures/ember-engine/relative-imports/input/tests/unit/controllers/password-reset-test.ts
+++ b/tests/fixtures/ember-engine/relative-imports/input/tests/unit/controllers/password-reset-test.ts
@@ -1,0 +1,1 @@
+import type PasswordResetController from '@namespace/package-name/password-reset/controller';

--- a/tests/fixtures/ember-engine/relative-imports/input/tests/unit/index/route-test.ts
+++ b/tests/fixtures/ember-engine/relative-imports/input/tests/unit/index/route-test.ts
@@ -1,0 +1,1 @@
+import type IndexRoute from '@namespace/package-name/index/route';

--- a/tests/fixtures/ember-engine/relative-imports/input/tests/unit/services/api-test.ts
+++ b/tests/fixtures/ember-engine/relative-imports/input/tests/unit/services/api-test.ts
@@ -1,0 +1,1 @@
+import type ApiService from '@namespace/package-name/services/api';

--- a/tests/fixtures/ember-engine/relative-imports/input/tests/unit/services/form-test.ts
+++ b/tests/fixtures/ember-engine/relative-imports/input/tests/unit/services/form-test.ts
@@ -1,0 +1,1 @@
+import type FormService from '@namespace/package-name/services/form';

--- a/tests/fixtures/ember-engine/relative-imports/output/addon/components/ui/password-reset-form.ts
+++ b/tests/fixtures/ember-engine/relative-imports/output/addon/components/ui/password-reset-form.ts
@@ -1,0 +1,11 @@
+import Component from '@glimmer/component';
+
+export type PasswordResetFormModel = {};
+
+export default class UiPasswordResetFormComponent extends Component {
+  get model(): PasswordResetFormModel {
+    return {
+      // ...
+    };
+  }
+}

--- a/tests/fixtures/ember-engine/relative-imports/output/addon/components/ui/password-reset-page.ts
+++ b/tests/fixtures/ember-engine/relative-imports/output/addon/components/ui/password-reset-page.ts
@@ -1,0 +1,9 @@
+import { inject as service } from '@ember/service';
+import Component from '@glimmer/component';
+
+import type FormService from '../../services/form';
+import type { PasswordResetFormModel } from './password-reset-form';
+
+export default class UiPasswordResetPageComponent extends Component {
+  @service declare form: FormService;
+}

--- a/tests/fixtures/ember-engine/relative-imports/output/addon/controllers/authenticated.ts
+++ b/tests/fixtures/ember-engine/relative-imports/output/addon/controllers/authenticated.ts
@@ -1,0 +1,3 @@
+import Controller from '@ember/controller';
+
+export default class AuthenticatedController extends Controller {}

--- a/tests/fixtures/ember-engine/relative-imports/output/addon/controllers/password-reset.ts
+++ b/tests/fixtures/ember-engine/relative-imports/output/addon/controllers/password-reset.ts
@@ -1,0 +1,3 @@
+import AuthenticatedController from './authenticated';
+
+export default class PasswordResetController extends AuthenticatedController {}

--- a/tests/fixtures/ember-engine/relative-imports/output/addon/routes/index.ts
+++ b/tests/fixtures/ember-engine/relative-imports/output/addon/routes/index.ts
@@ -1,0 +1,8 @@
+import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
+
+import ApiService from '../services/api';
+
+export default class IndexRoute extends Route {
+  @service declare api: ApiService;
+}

--- a/tests/fixtures/ember-engine/relative-imports/output/addon/services/api.ts
+++ b/tests/fixtures/ember-engine/relative-imports/output/addon/services/api.ts
@@ -1,0 +1,3 @@
+import Service from '@ember/service';
+
+export default class ApiService extends Service {}

--- a/tests/fixtures/ember-engine/relative-imports/output/addon/services/form.ts
+++ b/tests/fixtures/ember-engine/relative-imports/output/addon/services/form.ts
@@ -1,0 +1,7 @@
+import Service, { inject as service } from '@ember/service';
+
+import ApiService from './api';
+
+export default class FormService extends Service {
+  @service declare api: ApiService;
+}

--- a/tests/fixtures/ember-engine/relative-imports/output/package.json
+++ b/tests/fixtures/ember-engine/relative-imports/output/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@namespace/package-name",
+  "version": "0.0.0"
+}

--- a/tests/fixtures/ember-engine/relative-imports/output/tests/dummy/app/components/new-password-reset-page/component.ts
+++ b/tests/fixtures/ember-engine/relative-imports/output/tests/dummy/app/components/new-password-reset-page/component.ts
@@ -1,0 +1,8 @@
+import { inject as service } from '@ember/service';
+import Component from '@glimmer/component';
+import type { PasswordResetFormModel } from '@namespace/package-name/components/ui/password-reset-form';
+import type FormService from '@namespace/package-name/services/form';
+
+export default class NewPasswordResetPageComponent extends Component {
+  @service declare form: FormService;
+}

--- a/tests/fixtures/ember-engine/relative-imports/output/tests/integration/components/ui/password-reset-form-test.ts
+++ b/tests/fixtures/ember-engine/relative-imports/output/tests/integration/components/ui/password-reset-form-test.ts
@@ -1,0 +1,3 @@
+import type { PasswordResetFormModel } from '@namespace/package-name/components/ui/password-reset-form';
+
+export type CustomType = string | unknown;

--- a/tests/fixtures/ember-engine/relative-imports/output/tests/integration/components/ui/password-reset-page-test.ts
+++ b/tests/fixtures/ember-engine/relative-imports/output/tests/integration/components/ui/password-reset-page-test.ts
@@ -1,0 +1,3 @@
+import type { PasswordResetFormModel } from '@namespace/package-name/components/ui/password-reset-form';
+
+import type { CustomType } from './password-reset-form-test';

--- a/tests/fixtures/ember-engine/relative-imports/output/tests/unit/controllers/authenticated-test.ts
+++ b/tests/fixtures/ember-engine/relative-imports/output/tests/unit/controllers/authenticated-test.ts
@@ -1,0 +1,1 @@
+import type AuthenticatedController from '@namespace/package-name/controllers/authenticated';

--- a/tests/fixtures/ember-engine/relative-imports/output/tests/unit/controllers/password-reset-test.ts
+++ b/tests/fixtures/ember-engine/relative-imports/output/tests/unit/controllers/password-reset-test.ts
@@ -1,0 +1,1 @@
+import type PasswordResetController from '@namespace/package-name/controllers/password-reset';

--- a/tests/fixtures/ember-engine/relative-imports/output/tests/unit/routes/index-test.ts
+++ b/tests/fixtures/ember-engine/relative-imports/output/tests/unit/routes/index-test.ts
@@ -1,0 +1,1 @@
+import type IndexRoute from '@namespace/package-name/routes/index';

--- a/tests/fixtures/ember-engine/relative-imports/output/tests/unit/services/api-test.ts
+++ b/tests/fixtures/ember-engine/relative-imports/output/tests/unit/services/api-test.ts
@@ -1,0 +1,1 @@
+import type ApiService from '@namespace/package-name/services/api';

--- a/tests/fixtures/ember-engine/relative-imports/output/tests/unit/services/form-test.ts
+++ b/tests/fixtures/ember-engine/relative-imports/output/tests/unit/services/form-test.ts
@@ -1,0 +1,1 @@
+import type FormService from '@namespace/package-name/services/form';

--- a/tests/fixtures/ember-engine/steps/update-absolute-paths/absolute-imports/input/addon/components/ui/password-reset-form.ts
+++ b/tests/fixtures/ember-engine/steps/update-absolute-paths/absolute-imports/input/addon/components/ui/password-reset-form.ts
@@ -1,0 +1,11 @@
+import Component from '@glimmer/component';
+
+export type PasswordResetFormModel = {};
+
+export default class UiPasswordResetFormComponent extends Component {
+  get model(): PasswordResetFormModel {
+    return {
+      // ...
+    };
+  }
+}

--- a/tests/fixtures/ember-engine/steps/update-absolute-paths/absolute-imports/input/addon/components/ui/password-reset-page.ts
+++ b/tests/fixtures/ember-engine/steps/update-absolute-paths/absolute-imports/input/addon/components/ui/password-reset-page.ts
@@ -1,0 +1,8 @@
+import { inject as service } from '@ember/service';
+import Component from '@glimmer/component';
+import type { PasswordResetFormModel } from '@namespace/package-name/components/ui/password-reset-form/component';
+import type FormService from '@namespace/package-name/services/form';
+
+export default class UiPasswordResetPageComponent extends Component {
+  @service declare form: FormService;
+}

--- a/tests/fixtures/ember-engine/steps/update-absolute-paths/absolute-imports/input/addon/controllers/authenticated.ts
+++ b/tests/fixtures/ember-engine/steps/update-absolute-paths/absolute-imports/input/addon/controllers/authenticated.ts
@@ -1,0 +1,3 @@
+import Controller from '@ember/controller';
+
+export default class AuthenticatedController extends Controller {}

--- a/tests/fixtures/ember-engine/steps/update-absolute-paths/absolute-imports/input/addon/controllers/password-reset.ts
+++ b/tests/fixtures/ember-engine/steps/update-absolute-paths/absolute-imports/input/addon/controllers/password-reset.ts
@@ -1,0 +1,3 @@
+import AuthenticatedController from '@namespace/package-name/authenticated/controller';
+
+export default class PasswordResetController extends AuthenticatedController {}

--- a/tests/fixtures/ember-engine/steps/update-absolute-paths/absolute-imports/input/addon/routes/index.ts
+++ b/tests/fixtures/ember-engine/steps/update-absolute-paths/absolute-imports/input/addon/routes/index.ts
@@ -1,0 +1,7 @@
+import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
+import ApiService from '@namespace/package-name/services/api';
+
+export default class IndexRoute extends Route {
+  @service declare api: ApiService;
+}

--- a/tests/fixtures/ember-engine/steps/update-absolute-paths/absolute-imports/input/addon/services/api.ts
+++ b/tests/fixtures/ember-engine/steps/update-absolute-paths/absolute-imports/input/addon/services/api.ts
@@ -1,0 +1,3 @@
+import Service from '@ember/service';
+
+export default class ApiService extends Service {}

--- a/tests/fixtures/ember-engine/steps/update-absolute-paths/absolute-imports/input/addon/services/form.ts
+++ b/tests/fixtures/ember-engine/steps/update-absolute-paths/absolute-imports/input/addon/services/form.ts
@@ -1,0 +1,6 @@
+import Service, { inject as service } from '@ember/service';
+import ApiService from '@namespace/package-name/services/api';
+
+export default class FormService extends Service {
+  @service declare api: ApiService;
+}

--- a/tests/fixtures/ember-engine/steps/update-absolute-paths/absolute-imports/input/package.json
+++ b/tests/fixtures/ember-engine/steps/update-absolute-paths/absolute-imports/input/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@namespace/package-name",
+  "version": "0.0.0"
+}

--- a/tests/fixtures/ember-engine/steps/update-absolute-paths/absolute-imports/input/tests/dummy/app/components/new-password-reset-page/component.ts
+++ b/tests/fixtures/ember-engine/steps/update-absolute-paths/absolute-imports/input/tests/dummy/app/components/new-password-reset-page/component.ts
@@ -1,0 +1,8 @@
+import { inject as service } from '@ember/service';
+import Component from '@glimmer/component';
+import type { PasswordResetFormModel } from '@namespace/package-name/components/ui/password-reset-form/component';
+import type FormService from '@namespace/package-name/services/form';
+
+export default class NewPasswordResetPageComponent extends Component {
+  @service declare form: FormService;
+}

--- a/tests/fixtures/ember-engine/steps/update-absolute-paths/absolute-imports/input/tests/integration/components/ui/password-reset-form-test.ts
+++ b/tests/fixtures/ember-engine/steps/update-absolute-paths/absolute-imports/input/tests/integration/components/ui/password-reset-form-test.ts
@@ -1,0 +1,3 @@
+import type { PasswordResetFormModel } from '@namespace/package-name/components/ui/password-reset-form/component';
+
+export type CustomType = string | unknown;

--- a/tests/fixtures/ember-engine/steps/update-absolute-paths/absolute-imports/input/tests/integration/components/ui/password-reset-page-test.ts
+++ b/tests/fixtures/ember-engine/steps/update-absolute-paths/absolute-imports/input/tests/integration/components/ui/password-reset-page-test.ts
@@ -1,0 +1,2 @@
+import type { PasswordResetFormModel } from '@namespace/package-name/components/ui/password-reset-form/component';
+import type { CustomType } from 'dummy/tests/integration/components/ui/password-reset-form/component-test';

--- a/tests/fixtures/ember-engine/steps/update-absolute-paths/absolute-imports/input/tests/unit/controllers/authenticated-test.ts
+++ b/tests/fixtures/ember-engine/steps/update-absolute-paths/absolute-imports/input/tests/unit/controllers/authenticated-test.ts
@@ -1,0 +1,1 @@
+import type AuthenticatedController from '@namespace/package-name/authenticated/controller';

--- a/tests/fixtures/ember-engine/steps/update-absolute-paths/absolute-imports/input/tests/unit/controllers/password-reset-test.ts
+++ b/tests/fixtures/ember-engine/steps/update-absolute-paths/absolute-imports/input/tests/unit/controllers/password-reset-test.ts
@@ -1,0 +1,1 @@
+import type PasswordResetController from '@namespace/package-name/password-reset/controller';

--- a/tests/fixtures/ember-engine/steps/update-absolute-paths/absolute-imports/input/tests/unit/routes/index-test.ts
+++ b/tests/fixtures/ember-engine/steps/update-absolute-paths/absolute-imports/input/tests/unit/routes/index-test.ts
@@ -1,0 +1,1 @@
+import type IndexRoute from '@namespace/package-name/index/route';

--- a/tests/fixtures/ember-engine/steps/update-absolute-paths/absolute-imports/input/tests/unit/services/api-test.ts
+++ b/tests/fixtures/ember-engine/steps/update-absolute-paths/absolute-imports/input/tests/unit/services/api-test.ts
@@ -1,0 +1,1 @@
+import type ApiService from '@namespace/package-name/services/api';

--- a/tests/fixtures/ember-engine/steps/update-absolute-paths/absolute-imports/input/tests/unit/services/form-test.ts
+++ b/tests/fixtures/ember-engine/steps/update-absolute-paths/absolute-imports/input/tests/unit/services/form-test.ts
@@ -1,0 +1,1 @@
+import type FormService from '@namespace/package-name/services/form';

--- a/tests/fixtures/ember-engine/steps/update-absolute-paths/absolute-imports/output/addon/components/ui/password-reset-form.ts
+++ b/tests/fixtures/ember-engine/steps/update-absolute-paths/absolute-imports/output/addon/components/ui/password-reset-form.ts
@@ -1,0 +1,11 @@
+import Component from '@glimmer/component';
+
+export type PasswordResetFormModel = {};
+
+export default class UiPasswordResetFormComponent extends Component {
+  get model(): PasswordResetFormModel {
+    return {
+      // ...
+    };
+  }
+}

--- a/tests/fixtures/ember-engine/steps/update-absolute-paths/absolute-imports/output/addon/components/ui/password-reset-page.ts
+++ b/tests/fixtures/ember-engine/steps/update-absolute-paths/absolute-imports/output/addon/components/ui/password-reset-page.ts
@@ -1,0 +1,8 @@
+import { inject as service } from '@ember/service';
+import Component from '@glimmer/component';
+import type { PasswordResetFormModel } from '@namespace/package-name/components/ui/password-reset-form';
+import type FormService from '@namespace/package-name/services/form';
+
+export default class UiPasswordResetPageComponent extends Component {
+  @service declare form: FormService;
+}

--- a/tests/fixtures/ember-engine/steps/update-absolute-paths/absolute-imports/output/addon/controllers/authenticated.ts
+++ b/tests/fixtures/ember-engine/steps/update-absolute-paths/absolute-imports/output/addon/controllers/authenticated.ts
@@ -1,0 +1,3 @@
+import Controller from '@ember/controller';
+
+export default class AuthenticatedController extends Controller {}

--- a/tests/fixtures/ember-engine/steps/update-absolute-paths/absolute-imports/output/addon/controllers/password-reset.ts
+++ b/tests/fixtures/ember-engine/steps/update-absolute-paths/absolute-imports/output/addon/controllers/password-reset.ts
@@ -1,0 +1,3 @@
+import AuthenticatedController from '@namespace/package-name/controllers/authenticated';
+
+export default class PasswordResetController extends AuthenticatedController {}

--- a/tests/fixtures/ember-engine/steps/update-absolute-paths/absolute-imports/output/addon/routes/index.ts
+++ b/tests/fixtures/ember-engine/steps/update-absolute-paths/absolute-imports/output/addon/routes/index.ts
@@ -1,0 +1,7 @@
+import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
+import ApiService from '@namespace/package-name/services/api';
+
+export default class IndexRoute extends Route {
+  @service declare api: ApiService;
+}

--- a/tests/fixtures/ember-engine/steps/update-absolute-paths/absolute-imports/output/addon/services/api.ts
+++ b/tests/fixtures/ember-engine/steps/update-absolute-paths/absolute-imports/output/addon/services/api.ts
@@ -1,0 +1,3 @@
+import Service from '@ember/service';
+
+export default class ApiService extends Service {}

--- a/tests/fixtures/ember-engine/steps/update-absolute-paths/absolute-imports/output/addon/services/form.ts
+++ b/tests/fixtures/ember-engine/steps/update-absolute-paths/absolute-imports/output/addon/services/form.ts
@@ -1,0 +1,6 @@
+import Service, { inject as service } from '@ember/service';
+import ApiService from '@namespace/package-name/services/api';
+
+export default class FormService extends Service {
+  @service declare api: ApiService;
+}

--- a/tests/fixtures/ember-engine/steps/update-absolute-paths/absolute-imports/output/package.json
+++ b/tests/fixtures/ember-engine/steps/update-absolute-paths/absolute-imports/output/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@namespace/package-name",
+  "version": "0.0.0"
+}

--- a/tests/fixtures/ember-engine/steps/update-absolute-paths/absolute-imports/output/tests/dummy/app/components/new-password-reset-page/component.ts
+++ b/tests/fixtures/ember-engine/steps/update-absolute-paths/absolute-imports/output/tests/dummy/app/components/new-password-reset-page/component.ts
@@ -1,0 +1,8 @@
+import { inject as service } from '@ember/service';
+import Component from '@glimmer/component';
+import type { PasswordResetFormModel } from '@namespace/package-name/components/ui/password-reset-form';
+import type FormService from '@namespace/package-name/services/form';
+
+export default class NewPasswordResetPageComponent extends Component {
+  @service declare form: FormService;
+}

--- a/tests/fixtures/ember-engine/steps/update-absolute-paths/absolute-imports/output/tests/integration/components/ui/password-reset-form-test.ts
+++ b/tests/fixtures/ember-engine/steps/update-absolute-paths/absolute-imports/output/tests/integration/components/ui/password-reset-form-test.ts
@@ -1,0 +1,3 @@
+import type { PasswordResetFormModel } from '@namespace/package-name/components/ui/password-reset-form';
+
+export type CustomType = string | unknown;

--- a/tests/fixtures/ember-engine/steps/update-absolute-paths/absolute-imports/output/tests/integration/components/ui/password-reset-page-test.ts
+++ b/tests/fixtures/ember-engine/steps/update-absolute-paths/absolute-imports/output/tests/integration/components/ui/password-reset-page-test.ts
@@ -1,0 +1,2 @@
+import type { PasswordResetFormModel } from '@namespace/package-name/components/ui/password-reset-form';
+import type { CustomType } from 'dummy/tests/integration/components/ui/password-reset-form-test';

--- a/tests/fixtures/ember-engine/steps/update-absolute-paths/absolute-imports/output/tests/unit/controllers/authenticated-test.ts
+++ b/tests/fixtures/ember-engine/steps/update-absolute-paths/absolute-imports/output/tests/unit/controllers/authenticated-test.ts
@@ -1,0 +1,1 @@
+import type AuthenticatedController from '@namespace/package-name/controllers/authenticated';

--- a/tests/fixtures/ember-engine/steps/update-absolute-paths/absolute-imports/output/tests/unit/controllers/password-reset-test.ts
+++ b/tests/fixtures/ember-engine/steps/update-absolute-paths/absolute-imports/output/tests/unit/controllers/password-reset-test.ts
@@ -1,0 +1,1 @@
+import type PasswordResetController from '@namespace/package-name/controllers/password-reset';

--- a/tests/fixtures/ember-engine/steps/update-absolute-paths/absolute-imports/output/tests/unit/routes/index-test.ts
+++ b/tests/fixtures/ember-engine/steps/update-absolute-paths/absolute-imports/output/tests/unit/routes/index-test.ts
@@ -1,0 +1,1 @@
+import type IndexRoute from '@namespace/package-name/routes/index';

--- a/tests/fixtures/ember-engine/steps/update-absolute-paths/absolute-imports/output/tests/unit/services/api-test.ts
+++ b/tests/fixtures/ember-engine/steps/update-absolute-paths/absolute-imports/output/tests/unit/services/api-test.ts
@@ -1,0 +1,1 @@
+import type ApiService from '@namespace/package-name/services/api';

--- a/tests/fixtures/ember-engine/steps/update-absolute-paths/absolute-imports/output/tests/unit/services/form-test.ts
+++ b/tests/fixtures/ember-engine/steps/update-absolute-paths/absolute-imports/output/tests/unit/services/form-test.ts
@@ -1,0 +1,1 @@
+import type FormService from '@namespace/package-name/services/form';

--- a/tests/fixtures/ember-engine/steps/update-absolute-paths/relative-imports/input/addon/components/ui/password-reset-form.ts
+++ b/tests/fixtures/ember-engine/steps/update-absolute-paths/relative-imports/input/addon/components/ui/password-reset-form.ts
@@ -1,0 +1,11 @@
+import Component from '@glimmer/component';
+
+export type PasswordResetFormModel = {};
+
+export default class UiPasswordResetFormComponent extends Component {
+  get model(): PasswordResetFormModel {
+    return {
+      // ...
+    };
+  }
+}

--- a/tests/fixtures/ember-engine/steps/update-absolute-paths/relative-imports/input/addon/components/ui/password-reset-page.ts
+++ b/tests/fixtures/ember-engine/steps/update-absolute-paths/relative-imports/input/addon/components/ui/password-reset-page.ts
@@ -1,0 +1,9 @@
+import { inject as service } from '@ember/service';
+import Component from '@glimmer/component';
+
+import type FormService from '@namespace/package-name/services/form';
+import type { PasswordResetFormModel } from '@namespace/package-name/components/ui/password-reset-form/component';
+
+export default class UiPasswordResetPageComponent extends Component {
+  @service declare form: FormService;
+}

--- a/tests/fixtures/ember-engine/steps/update-absolute-paths/relative-imports/input/addon/controllers/authenticated.ts
+++ b/tests/fixtures/ember-engine/steps/update-absolute-paths/relative-imports/input/addon/controllers/authenticated.ts
@@ -1,0 +1,3 @@
+import Controller from '@ember/controller';
+
+export default class AuthenticatedController extends Controller {}

--- a/tests/fixtures/ember-engine/steps/update-absolute-paths/relative-imports/input/addon/controllers/password-reset.ts
+++ b/tests/fixtures/ember-engine/steps/update-absolute-paths/relative-imports/input/addon/controllers/password-reset.ts
@@ -1,0 +1,3 @@
+import AuthenticatedController from '@namespace/package-name/authenticated/controller';
+
+export default class PasswordResetController extends AuthenticatedController {}

--- a/tests/fixtures/ember-engine/steps/update-absolute-paths/relative-imports/input/addon/routes/index.ts
+++ b/tests/fixtures/ember-engine/steps/update-absolute-paths/relative-imports/input/addon/routes/index.ts
@@ -1,0 +1,8 @@
+import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
+
+import ApiService from '@namespace/package-name/services/api';
+
+export default class IndexRoute extends Route {
+  @service declare api: ApiService;
+}

--- a/tests/fixtures/ember-engine/steps/update-absolute-paths/relative-imports/input/addon/services/api.ts
+++ b/tests/fixtures/ember-engine/steps/update-absolute-paths/relative-imports/input/addon/services/api.ts
@@ -1,0 +1,3 @@
+import Service from '@ember/service';
+
+export default class ApiService extends Service {}

--- a/tests/fixtures/ember-engine/steps/update-absolute-paths/relative-imports/input/addon/services/form.ts
+++ b/tests/fixtures/ember-engine/steps/update-absolute-paths/relative-imports/input/addon/services/form.ts
@@ -1,0 +1,7 @@
+import Service, { inject as service } from '@ember/service';
+
+import ApiService from '@namespace/package-name/services/api';
+
+export default class FormService extends Service {
+  @service declare api: ApiService;
+}

--- a/tests/fixtures/ember-engine/steps/update-absolute-paths/relative-imports/input/package.json
+++ b/tests/fixtures/ember-engine/steps/update-absolute-paths/relative-imports/input/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@namespace/package-name",
+  "version": "0.0.0"
+}

--- a/tests/fixtures/ember-engine/steps/update-absolute-paths/relative-imports/input/tests/dummy/app/components/new-password-reset-page/component.ts
+++ b/tests/fixtures/ember-engine/steps/update-absolute-paths/relative-imports/input/tests/dummy/app/components/new-password-reset-page/component.ts
@@ -1,0 +1,8 @@
+import { inject as service } from '@ember/service';
+import Component from '@glimmer/component';
+import type { PasswordResetFormModel } from '@namespace/package-name/components/ui/password-reset-form/component';
+import type FormService from '@namespace/package-name/services/form';
+
+export default class NewPasswordResetPageComponent extends Component {
+  @service declare form: FormService;
+}

--- a/tests/fixtures/ember-engine/steps/update-absolute-paths/relative-imports/input/tests/integration/components/ui/password-reset-form-test.ts
+++ b/tests/fixtures/ember-engine/steps/update-absolute-paths/relative-imports/input/tests/integration/components/ui/password-reset-form-test.ts
@@ -1,0 +1,3 @@
+import type { PasswordResetFormModel } from '@namespace/package-name/components/ui/password-reset-form/component';
+
+export type CustomType = string | unknown;

--- a/tests/fixtures/ember-engine/steps/update-absolute-paths/relative-imports/input/tests/integration/components/ui/password-reset-page-test.ts
+++ b/tests/fixtures/ember-engine/steps/update-absolute-paths/relative-imports/input/tests/integration/components/ui/password-reset-page-test.ts
@@ -1,0 +1,3 @@
+import type { PasswordResetFormModel } from '@namespace/package-name/components/ui/password-reset-form/component';
+
+import type { CustomType } from 'dummy/tests/integration/components/ui/password-reset-form/component-test';

--- a/tests/fixtures/ember-engine/steps/update-absolute-paths/relative-imports/input/tests/unit/controllers/authenticated-test.ts
+++ b/tests/fixtures/ember-engine/steps/update-absolute-paths/relative-imports/input/tests/unit/controllers/authenticated-test.ts
@@ -1,0 +1,1 @@
+import type AuthenticatedController from '@namespace/package-name/authenticated/controller';

--- a/tests/fixtures/ember-engine/steps/update-absolute-paths/relative-imports/input/tests/unit/controllers/password-reset-test.ts
+++ b/tests/fixtures/ember-engine/steps/update-absolute-paths/relative-imports/input/tests/unit/controllers/password-reset-test.ts
@@ -1,0 +1,1 @@
+import type PasswordResetController from '@namespace/package-name/password-reset/controller';

--- a/tests/fixtures/ember-engine/steps/update-absolute-paths/relative-imports/input/tests/unit/routes/index-test.ts
+++ b/tests/fixtures/ember-engine/steps/update-absolute-paths/relative-imports/input/tests/unit/routes/index-test.ts
@@ -1,0 +1,1 @@
+import type IndexRoute from '@namespace/package-name/index/route';

--- a/tests/fixtures/ember-engine/steps/update-absolute-paths/relative-imports/input/tests/unit/services/api-test.ts
+++ b/tests/fixtures/ember-engine/steps/update-absolute-paths/relative-imports/input/tests/unit/services/api-test.ts
@@ -1,0 +1,1 @@
+import type ApiService from '@namespace/package-name/services/api';

--- a/tests/fixtures/ember-engine/steps/update-absolute-paths/relative-imports/input/tests/unit/services/form-test.ts
+++ b/tests/fixtures/ember-engine/steps/update-absolute-paths/relative-imports/input/tests/unit/services/form-test.ts
@@ -1,0 +1,1 @@
+import type FormService from '@namespace/package-name/services/form';

--- a/tests/fixtures/ember-engine/steps/update-absolute-paths/relative-imports/output/addon/components/ui/password-reset-form.ts
+++ b/tests/fixtures/ember-engine/steps/update-absolute-paths/relative-imports/output/addon/components/ui/password-reset-form.ts
@@ -1,0 +1,11 @@
+import Component from '@glimmer/component';
+
+export type PasswordResetFormModel = {};
+
+export default class UiPasswordResetFormComponent extends Component {
+  get model(): PasswordResetFormModel {
+    return {
+      // ...
+    };
+  }
+}

--- a/tests/fixtures/ember-engine/steps/update-absolute-paths/relative-imports/output/addon/components/ui/password-reset-page.ts
+++ b/tests/fixtures/ember-engine/steps/update-absolute-paths/relative-imports/output/addon/components/ui/password-reset-page.ts
@@ -1,0 +1,9 @@
+import { inject as service } from '@ember/service';
+import Component from '@glimmer/component';
+
+import type FormService from '@namespace/package-name/services/form';
+import type { PasswordResetFormModel } from '@namespace/package-name/components/ui/password-reset-form';
+
+export default class UiPasswordResetPageComponent extends Component {
+  @service declare form: FormService;
+}

--- a/tests/fixtures/ember-engine/steps/update-absolute-paths/relative-imports/output/addon/controllers/authenticated.ts
+++ b/tests/fixtures/ember-engine/steps/update-absolute-paths/relative-imports/output/addon/controllers/authenticated.ts
@@ -1,0 +1,3 @@
+import Controller from '@ember/controller';
+
+export default class AuthenticatedController extends Controller {}

--- a/tests/fixtures/ember-engine/steps/update-absolute-paths/relative-imports/output/addon/controllers/password-reset.ts
+++ b/tests/fixtures/ember-engine/steps/update-absolute-paths/relative-imports/output/addon/controllers/password-reset.ts
@@ -1,0 +1,3 @@
+import AuthenticatedController from '@namespace/package-name/controllers/authenticated';
+
+export default class PasswordResetController extends AuthenticatedController {}

--- a/tests/fixtures/ember-engine/steps/update-absolute-paths/relative-imports/output/addon/routes/index.ts
+++ b/tests/fixtures/ember-engine/steps/update-absolute-paths/relative-imports/output/addon/routes/index.ts
@@ -1,0 +1,8 @@
+import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
+
+import ApiService from '@namespace/package-name/services/api';
+
+export default class IndexRoute extends Route {
+  @service declare api: ApiService;
+}

--- a/tests/fixtures/ember-engine/steps/update-absolute-paths/relative-imports/output/addon/services/api.ts
+++ b/tests/fixtures/ember-engine/steps/update-absolute-paths/relative-imports/output/addon/services/api.ts
@@ -1,0 +1,3 @@
+import Service from '@ember/service';
+
+export default class ApiService extends Service {}

--- a/tests/fixtures/ember-engine/steps/update-absolute-paths/relative-imports/output/addon/services/form.ts
+++ b/tests/fixtures/ember-engine/steps/update-absolute-paths/relative-imports/output/addon/services/form.ts
@@ -1,0 +1,7 @@
+import Service, { inject as service } from '@ember/service';
+
+import ApiService from '@namespace/package-name/services/api';
+
+export default class FormService extends Service {
+  @service declare api: ApiService;
+}

--- a/tests/fixtures/ember-engine/steps/update-absolute-paths/relative-imports/output/package.json
+++ b/tests/fixtures/ember-engine/steps/update-absolute-paths/relative-imports/output/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@namespace/package-name",
+  "version": "0.0.0"
+}

--- a/tests/fixtures/ember-engine/steps/update-absolute-paths/relative-imports/output/tests/dummy/app/components/new-password-reset-page/component.ts
+++ b/tests/fixtures/ember-engine/steps/update-absolute-paths/relative-imports/output/tests/dummy/app/components/new-password-reset-page/component.ts
@@ -1,0 +1,8 @@
+import { inject as service } from '@ember/service';
+import Component from '@glimmer/component';
+import type { PasswordResetFormModel } from '@namespace/package-name/components/ui/password-reset-form';
+import type FormService from '@namespace/package-name/services/form';
+
+export default class NewPasswordResetPageComponent extends Component {
+  @service declare form: FormService;
+}

--- a/tests/fixtures/ember-engine/steps/update-absolute-paths/relative-imports/output/tests/integration/components/ui/password-reset-form-test.ts
+++ b/tests/fixtures/ember-engine/steps/update-absolute-paths/relative-imports/output/tests/integration/components/ui/password-reset-form-test.ts
@@ -1,0 +1,3 @@
+import type { PasswordResetFormModel } from '@namespace/package-name/components/ui/password-reset-form';
+
+export type CustomType = string | unknown;

--- a/tests/fixtures/ember-engine/steps/update-absolute-paths/relative-imports/output/tests/integration/components/ui/password-reset-page-test.ts
+++ b/tests/fixtures/ember-engine/steps/update-absolute-paths/relative-imports/output/tests/integration/components/ui/password-reset-page-test.ts
@@ -1,0 +1,3 @@
+import type { PasswordResetFormModel } from '@namespace/package-name/components/ui/password-reset-form';
+
+import type { CustomType } from 'dummy/tests/integration/components/ui/password-reset-form-test';

--- a/tests/fixtures/ember-engine/steps/update-absolute-paths/relative-imports/output/tests/unit/controllers/authenticated-test.ts
+++ b/tests/fixtures/ember-engine/steps/update-absolute-paths/relative-imports/output/tests/unit/controllers/authenticated-test.ts
@@ -1,0 +1,1 @@
+import type AuthenticatedController from '@namespace/package-name/controllers/authenticated';

--- a/tests/fixtures/ember-engine/steps/update-absolute-paths/relative-imports/output/tests/unit/controllers/password-reset-test.ts
+++ b/tests/fixtures/ember-engine/steps/update-absolute-paths/relative-imports/output/tests/unit/controllers/password-reset-test.ts
@@ -1,0 +1,1 @@
+import type PasswordResetController from '@namespace/package-name/controllers/password-reset';

--- a/tests/fixtures/ember-engine/steps/update-absolute-paths/relative-imports/output/tests/unit/routes/index-test.ts
+++ b/tests/fixtures/ember-engine/steps/update-absolute-paths/relative-imports/output/tests/unit/routes/index-test.ts
@@ -1,0 +1,1 @@
+import type IndexRoute from '@namespace/package-name/routes/index';

--- a/tests/fixtures/ember-engine/steps/update-absolute-paths/relative-imports/output/tests/unit/services/api-test.ts
+++ b/tests/fixtures/ember-engine/steps/update-absolute-paths/relative-imports/output/tests/unit/services/api-test.ts
@@ -1,0 +1,1 @@
+import type ApiService from '@namespace/package-name/services/api';

--- a/tests/fixtures/ember-engine/steps/update-absolute-paths/relative-imports/output/tests/unit/services/form-test.ts
+++ b/tests/fixtures/ember-engine/steps/update-absolute-paths/relative-imports/output/tests/unit/services/form-test.ts
@@ -1,0 +1,1 @@
+import type FormService from '@namespace/package-name/services/form';

--- a/tests/fixtures/ember-engine/steps/use-absolute-paths/absolute-imports/input/addon/authenticated/controller.ts
+++ b/tests/fixtures/ember-engine/steps/use-absolute-paths/absolute-imports/input/addon/authenticated/controller.ts
@@ -1,0 +1,3 @@
+import Controller from '@ember/controller';
+
+export default class AuthenticatedController extends Controller {}

--- a/tests/fixtures/ember-engine/steps/use-absolute-paths/absolute-imports/input/addon/components/ui/password-reset-form/component.ts
+++ b/tests/fixtures/ember-engine/steps/use-absolute-paths/absolute-imports/input/addon/components/ui/password-reset-form/component.ts
@@ -1,0 +1,11 @@
+import Component from '@glimmer/component';
+
+export type PasswordResetFormModel = {};
+
+export default class UiPasswordResetFormComponent extends Component {
+  get model(): PasswordResetFormModel {
+    return {
+      // ...
+    };
+  }
+}

--- a/tests/fixtures/ember-engine/steps/use-absolute-paths/absolute-imports/input/addon/components/ui/password-reset-page/component.ts
+++ b/tests/fixtures/ember-engine/steps/use-absolute-paths/absolute-imports/input/addon/components/ui/password-reset-page/component.ts
@@ -1,0 +1,8 @@
+import { inject as service } from '@ember/service';
+import Component from '@glimmer/component';
+import type { PasswordResetFormModel } from '@namespace/package-name/components/ui/password-reset-form/component';
+import type FormService from '@namespace/package-name/services/form';
+
+export default class UiPasswordResetPageComponent extends Component {
+  @service declare form: FormService;
+}

--- a/tests/fixtures/ember-engine/steps/use-absolute-paths/absolute-imports/input/addon/index/route.ts
+++ b/tests/fixtures/ember-engine/steps/use-absolute-paths/absolute-imports/input/addon/index/route.ts
@@ -1,0 +1,7 @@
+import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
+import ApiService from '@namespace/package-name/services/api';
+
+export default class IndexRoute extends Route {
+  @service declare api: ApiService;
+}

--- a/tests/fixtures/ember-engine/steps/use-absolute-paths/absolute-imports/input/addon/password-reset/controller.ts
+++ b/tests/fixtures/ember-engine/steps/use-absolute-paths/absolute-imports/input/addon/password-reset/controller.ts
@@ -1,0 +1,3 @@
+import AuthenticatedController from '@namespace/package-name/authenticated/controller';
+
+export default class PasswordResetController extends AuthenticatedController {}

--- a/tests/fixtures/ember-engine/steps/use-absolute-paths/absolute-imports/input/addon/services/api.ts
+++ b/tests/fixtures/ember-engine/steps/use-absolute-paths/absolute-imports/input/addon/services/api.ts
@@ -1,0 +1,3 @@
+import Service from '@ember/service';
+
+export default class ApiService extends Service {}

--- a/tests/fixtures/ember-engine/steps/use-absolute-paths/absolute-imports/input/addon/services/form.ts
+++ b/tests/fixtures/ember-engine/steps/use-absolute-paths/absolute-imports/input/addon/services/form.ts
@@ -1,0 +1,6 @@
+import Service, { inject as service } from '@ember/service';
+import ApiService from '@namespace/package-name/services/api';
+
+export default class FormService extends Service {
+  @service declare api: ApiService;
+}

--- a/tests/fixtures/ember-engine/steps/use-absolute-paths/absolute-imports/input/package.json
+++ b/tests/fixtures/ember-engine/steps/use-absolute-paths/absolute-imports/input/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@namespace/package-name",
+  "version": "0.0.0"
+}

--- a/tests/fixtures/ember-engine/steps/use-absolute-paths/absolute-imports/input/tests/dummy/app/components/new-password-reset-page/component.ts
+++ b/tests/fixtures/ember-engine/steps/use-absolute-paths/absolute-imports/input/tests/dummy/app/components/new-password-reset-page/component.ts
@@ -1,0 +1,8 @@
+import { inject as service } from '@ember/service';
+import Component from '@glimmer/component';
+import type { PasswordResetFormModel } from '@namespace/package-name/components/ui/password-reset-form/component';
+import type FormService from '@namespace/package-name/services/form';
+
+export default class NewPasswordResetPageComponent extends Component {
+  @service declare form: FormService;
+}

--- a/tests/fixtures/ember-engine/steps/use-absolute-paths/absolute-imports/input/tests/integration/components/ui/password-reset-form/component-test.ts
+++ b/tests/fixtures/ember-engine/steps/use-absolute-paths/absolute-imports/input/tests/integration/components/ui/password-reset-form/component-test.ts
@@ -1,0 +1,3 @@
+import type { PasswordResetFormModel } from '@namespace/package-name/components/ui/password-reset-form/component';
+
+export type CustomType = string | unknown;

--- a/tests/fixtures/ember-engine/steps/use-absolute-paths/absolute-imports/input/tests/integration/components/ui/password-reset-page/component-test.ts
+++ b/tests/fixtures/ember-engine/steps/use-absolute-paths/absolute-imports/input/tests/integration/components/ui/password-reset-page/component-test.ts
@@ -1,0 +1,2 @@
+import type { PasswordResetFormModel } from '@namespace/package-name/components/ui/password-reset-form/component';
+import type { CustomType } from 'dummy/tests/integration/components/ui/password-reset-form/component-test';

--- a/tests/fixtures/ember-engine/steps/use-absolute-paths/absolute-imports/input/tests/unit/authenticated/controller-test.ts
+++ b/tests/fixtures/ember-engine/steps/use-absolute-paths/absolute-imports/input/tests/unit/authenticated/controller-test.ts
@@ -1,0 +1,1 @@
+import type AuthenticatedController from '@namespace/package-name/authenticated/controller';

--- a/tests/fixtures/ember-engine/steps/use-absolute-paths/absolute-imports/input/tests/unit/controllers/password-reset-test.ts
+++ b/tests/fixtures/ember-engine/steps/use-absolute-paths/absolute-imports/input/tests/unit/controllers/password-reset-test.ts
@@ -1,0 +1,1 @@
+import type PasswordResetController from '@namespace/package-name/password-reset/controller';

--- a/tests/fixtures/ember-engine/steps/use-absolute-paths/absolute-imports/input/tests/unit/index/route-test.ts
+++ b/tests/fixtures/ember-engine/steps/use-absolute-paths/absolute-imports/input/tests/unit/index/route-test.ts
@@ -1,0 +1,1 @@
+import type IndexRoute from '@namespace/package-name/index/route';

--- a/tests/fixtures/ember-engine/steps/use-absolute-paths/absolute-imports/input/tests/unit/services/api-test.ts
+++ b/tests/fixtures/ember-engine/steps/use-absolute-paths/absolute-imports/input/tests/unit/services/api-test.ts
@@ -1,0 +1,1 @@
+import type ApiService from '@namespace/package-name/services/api';

--- a/tests/fixtures/ember-engine/steps/use-absolute-paths/absolute-imports/input/tests/unit/services/form-test.ts
+++ b/tests/fixtures/ember-engine/steps/use-absolute-paths/absolute-imports/input/tests/unit/services/form-test.ts
@@ -1,0 +1,1 @@
+import type FormService from '@namespace/package-name/services/form';

--- a/tests/fixtures/ember-engine/steps/use-absolute-paths/absolute-imports/output/addon/authenticated/controller.ts
+++ b/tests/fixtures/ember-engine/steps/use-absolute-paths/absolute-imports/output/addon/authenticated/controller.ts
@@ -1,0 +1,3 @@
+import Controller from '@ember/controller';
+
+export default class AuthenticatedController extends Controller {}

--- a/tests/fixtures/ember-engine/steps/use-absolute-paths/absolute-imports/output/addon/components/ui/password-reset-form/component.ts
+++ b/tests/fixtures/ember-engine/steps/use-absolute-paths/absolute-imports/output/addon/components/ui/password-reset-form/component.ts
@@ -1,0 +1,11 @@
+import Component from '@glimmer/component';
+
+export type PasswordResetFormModel = {};
+
+export default class UiPasswordResetFormComponent extends Component {
+  get model(): PasswordResetFormModel {
+    return {
+      // ...
+    };
+  }
+}

--- a/tests/fixtures/ember-engine/steps/use-absolute-paths/absolute-imports/output/addon/components/ui/password-reset-page/component.ts
+++ b/tests/fixtures/ember-engine/steps/use-absolute-paths/absolute-imports/output/addon/components/ui/password-reset-page/component.ts
@@ -1,0 +1,8 @@
+import { inject as service } from '@ember/service';
+import Component from '@glimmer/component';
+import type { PasswordResetFormModel } from '@namespace/package-name/components/ui/password-reset-form/component';
+import type FormService from '@namespace/package-name/services/form';
+
+export default class UiPasswordResetPageComponent extends Component {
+  @service declare form: FormService;
+}

--- a/tests/fixtures/ember-engine/steps/use-absolute-paths/absolute-imports/output/addon/index/route.ts
+++ b/tests/fixtures/ember-engine/steps/use-absolute-paths/absolute-imports/output/addon/index/route.ts
@@ -1,0 +1,7 @@
+import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
+import ApiService from '@namespace/package-name/services/api';
+
+export default class IndexRoute extends Route {
+  @service declare api: ApiService;
+}

--- a/tests/fixtures/ember-engine/steps/use-absolute-paths/absolute-imports/output/addon/password-reset/controller.ts
+++ b/tests/fixtures/ember-engine/steps/use-absolute-paths/absolute-imports/output/addon/password-reset/controller.ts
@@ -1,0 +1,3 @@
+import AuthenticatedController from '@namespace/package-name/authenticated/controller';
+
+export default class PasswordResetController extends AuthenticatedController {}

--- a/tests/fixtures/ember-engine/steps/use-absolute-paths/absolute-imports/output/addon/services/api.ts
+++ b/tests/fixtures/ember-engine/steps/use-absolute-paths/absolute-imports/output/addon/services/api.ts
@@ -1,0 +1,3 @@
+import Service from '@ember/service';
+
+export default class ApiService extends Service {}

--- a/tests/fixtures/ember-engine/steps/use-absolute-paths/absolute-imports/output/addon/services/form.ts
+++ b/tests/fixtures/ember-engine/steps/use-absolute-paths/absolute-imports/output/addon/services/form.ts
@@ -1,0 +1,6 @@
+import Service, { inject as service } from '@ember/service';
+import ApiService from '@namespace/package-name/services/api';
+
+export default class FormService extends Service {
+  @service declare api: ApiService;
+}

--- a/tests/fixtures/ember-engine/steps/use-absolute-paths/absolute-imports/output/package.json
+++ b/tests/fixtures/ember-engine/steps/use-absolute-paths/absolute-imports/output/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@namespace/package-name",
+  "version": "0.0.0"
+}

--- a/tests/fixtures/ember-engine/steps/use-absolute-paths/absolute-imports/output/tests/dummy/app/components/new-password-reset-page/component.ts
+++ b/tests/fixtures/ember-engine/steps/use-absolute-paths/absolute-imports/output/tests/dummy/app/components/new-password-reset-page/component.ts
@@ -1,0 +1,8 @@
+import { inject as service } from '@ember/service';
+import Component from '@glimmer/component';
+import type { PasswordResetFormModel } from '@namespace/package-name/components/ui/password-reset-form/component';
+import type FormService from '@namespace/package-name/services/form';
+
+export default class NewPasswordResetPageComponent extends Component {
+  @service declare form: FormService;
+}

--- a/tests/fixtures/ember-engine/steps/use-absolute-paths/absolute-imports/output/tests/integration/components/ui/password-reset-form/component-test.ts
+++ b/tests/fixtures/ember-engine/steps/use-absolute-paths/absolute-imports/output/tests/integration/components/ui/password-reset-form/component-test.ts
@@ -1,0 +1,3 @@
+import type { PasswordResetFormModel } from '@namespace/package-name/components/ui/password-reset-form/component';
+
+export type CustomType = string | unknown;

--- a/tests/fixtures/ember-engine/steps/use-absolute-paths/absolute-imports/output/tests/integration/components/ui/password-reset-page/component-test.ts
+++ b/tests/fixtures/ember-engine/steps/use-absolute-paths/absolute-imports/output/tests/integration/components/ui/password-reset-page/component-test.ts
@@ -1,0 +1,2 @@
+import type { PasswordResetFormModel } from '@namespace/package-name/components/ui/password-reset-form/component';
+import type { CustomType } from 'dummy/tests/integration/components/ui/password-reset-form/component-test';

--- a/tests/fixtures/ember-engine/steps/use-absolute-paths/absolute-imports/output/tests/unit/authenticated/controller-test.ts
+++ b/tests/fixtures/ember-engine/steps/use-absolute-paths/absolute-imports/output/tests/unit/authenticated/controller-test.ts
@@ -1,0 +1,1 @@
+import type AuthenticatedController from '@namespace/package-name/authenticated/controller';

--- a/tests/fixtures/ember-engine/steps/use-absolute-paths/absolute-imports/output/tests/unit/controllers/password-reset-test.ts
+++ b/tests/fixtures/ember-engine/steps/use-absolute-paths/absolute-imports/output/tests/unit/controllers/password-reset-test.ts
@@ -1,0 +1,1 @@
+import type PasswordResetController from '@namespace/package-name/password-reset/controller';

--- a/tests/fixtures/ember-engine/steps/use-absolute-paths/absolute-imports/output/tests/unit/index/route-test.ts
+++ b/tests/fixtures/ember-engine/steps/use-absolute-paths/absolute-imports/output/tests/unit/index/route-test.ts
@@ -1,0 +1,1 @@
+import type IndexRoute from '@namespace/package-name/index/route';

--- a/tests/fixtures/ember-engine/steps/use-absolute-paths/absolute-imports/output/tests/unit/services/api-test.ts
+++ b/tests/fixtures/ember-engine/steps/use-absolute-paths/absolute-imports/output/tests/unit/services/api-test.ts
@@ -1,0 +1,1 @@
+import type ApiService from '@namespace/package-name/services/api';

--- a/tests/fixtures/ember-engine/steps/use-absolute-paths/absolute-imports/output/tests/unit/services/form-test.ts
+++ b/tests/fixtures/ember-engine/steps/use-absolute-paths/absolute-imports/output/tests/unit/services/form-test.ts
@@ -1,0 +1,1 @@
+import type FormService from '@namespace/package-name/services/form';

--- a/tests/fixtures/ember-engine/steps/use-absolute-paths/relative-imports/input/addon/authenticated/controller.ts
+++ b/tests/fixtures/ember-engine/steps/use-absolute-paths/relative-imports/input/addon/authenticated/controller.ts
@@ -1,0 +1,3 @@
+import Controller from '@ember/controller';
+
+export default class AuthenticatedController extends Controller {}

--- a/tests/fixtures/ember-engine/steps/use-absolute-paths/relative-imports/input/addon/components/ui/password-reset-form/component.ts
+++ b/tests/fixtures/ember-engine/steps/use-absolute-paths/relative-imports/input/addon/components/ui/password-reset-form/component.ts
@@ -1,0 +1,11 @@
+import Component from '@glimmer/component';
+
+export type PasswordResetFormModel = {};
+
+export default class UiPasswordResetFormComponent extends Component {
+  get model(): PasswordResetFormModel {
+    return {
+      // ...
+    };
+  }
+}

--- a/tests/fixtures/ember-engine/steps/use-absolute-paths/relative-imports/input/addon/components/ui/password-reset-page/component.ts
+++ b/tests/fixtures/ember-engine/steps/use-absolute-paths/relative-imports/input/addon/components/ui/password-reset-page/component.ts
@@ -1,0 +1,9 @@
+import { inject as service } from '@ember/service';
+import Component from '@glimmer/component';
+
+import type FormService from '../../../services/form';
+import type { PasswordResetFormModel } from '../password-reset-form/component';
+
+export default class UiPasswordResetPageComponent extends Component {
+  @service declare form: FormService;
+}

--- a/tests/fixtures/ember-engine/steps/use-absolute-paths/relative-imports/input/addon/index/route.ts
+++ b/tests/fixtures/ember-engine/steps/use-absolute-paths/relative-imports/input/addon/index/route.ts
@@ -1,0 +1,8 @@
+import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
+
+import ApiService from '../services/api';
+
+export default class IndexRoute extends Route {
+  @service declare api: ApiService;
+}

--- a/tests/fixtures/ember-engine/steps/use-absolute-paths/relative-imports/input/addon/password-reset/controller.ts
+++ b/tests/fixtures/ember-engine/steps/use-absolute-paths/relative-imports/input/addon/password-reset/controller.ts
@@ -1,0 +1,3 @@
+import AuthenticatedController from '../authenticated/controller';
+
+export default class PasswordResetController extends AuthenticatedController {}

--- a/tests/fixtures/ember-engine/steps/use-absolute-paths/relative-imports/input/addon/services/api.ts
+++ b/tests/fixtures/ember-engine/steps/use-absolute-paths/relative-imports/input/addon/services/api.ts
@@ -1,0 +1,3 @@
+import Service from '@ember/service';
+
+export default class ApiService extends Service {}

--- a/tests/fixtures/ember-engine/steps/use-absolute-paths/relative-imports/input/addon/services/form.ts
+++ b/tests/fixtures/ember-engine/steps/use-absolute-paths/relative-imports/input/addon/services/form.ts
@@ -1,0 +1,7 @@
+import Service, { inject as service } from '@ember/service';
+
+import ApiService from '../services/api';
+
+export default class FormService extends Service {
+  @service declare api: ApiService;
+}

--- a/tests/fixtures/ember-engine/steps/use-absolute-paths/relative-imports/input/package.json
+++ b/tests/fixtures/ember-engine/steps/use-absolute-paths/relative-imports/input/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@namespace/package-name",
+  "version": "0.0.0"
+}

--- a/tests/fixtures/ember-engine/steps/use-absolute-paths/relative-imports/input/tests/dummy/app/components/new-password-reset-page/component.ts
+++ b/tests/fixtures/ember-engine/steps/use-absolute-paths/relative-imports/input/tests/dummy/app/components/new-password-reset-page/component.ts
@@ -1,0 +1,8 @@
+import { inject as service } from '@ember/service';
+import Component from '@glimmer/component';
+import type { PasswordResetFormModel } from '@namespace/package-name/components/ui/password-reset-form/component';
+import type FormService from '@namespace/package-name/services/form';
+
+export default class NewPasswordResetPageComponent extends Component {
+  @service declare form: FormService;
+}

--- a/tests/fixtures/ember-engine/steps/use-absolute-paths/relative-imports/input/tests/integration/components/ui/password-reset-form/component-test.ts
+++ b/tests/fixtures/ember-engine/steps/use-absolute-paths/relative-imports/input/tests/integration/components/ui/password-reset-form/component-test.ts
@@ -1,0 +1,3 @@
+import type { PasswordResetFormModel } from '@namespace/package-name/components/ui/password-reset-form/component';
+
+export type CustomType = string | unknown;

--- a/tests/fixtures/ember-engine/steps/use-absolute-paths/relative-imports/input/tests/integration/components/ui/password-reset-page/component-test.ts
+++ b/tests/fixtures/ember-engine/steps/use-absolute-paths/relative-imports/input/tests/integration/components/ui/password-reset-page/component-test.ts
@@ -1,0 +1,3 @@
+import type { PasswordResetFormModel } from '@namespace/package-name/components/ui/password-reset-form/component';
+
+import type { CustomType } from '../password-reset-form/component-test';

--- a/tests/fixtures/ember-engine/steps/use-absolute-paths/relative-imports/input/tests/unit/authenticated/controller-test.ts
+++ b/tests/fixtures/ember-engine/steps/use-absolute-paths/relative-imports/input/tests/unit/authenticated/controller-test.ts
@@ -1,0 +1,1 @@
+import type AuthenticatedController from '@namespace/package-name/authenticated/controller';

--- a/tests/fixtures/ember-engine/steps/use-absolute-paths/relative-imports/input/tests/unit/controllers/password-reset-test.ts
+++ b/tests/fixtures/ember-engine/steps/use-absolute-paths/relative-imports/input/tests/unit/controllers/password-reset-test.ts
@@ -1,0 +1,1 @@
+import type PasswordResetController from '@namespace/package-name/password-reset/controller';

--- a/tests/fixtures/ember-engine/steps/use-absolute-paths/relative-imports/input/tests/unit/index/route-test.ts
+++ b/tests/fixtures/ember-engine/steps/use-absolute-paths/relative-imports/input/tests/unit/index/route-test.ts
@@ -1,0 +1,1 @@
+import type IndexRoute from '@namespace/package-name/index/route';

--- a/tests/fixtures/ember-engine/steps/use-absolute-paths/relative-imports/input/tests/unit/services/api-test.ts
+++ b/tests/fixtures/ember-engine/steps/use-absolute-paths/relative-imports/input/tests/unit/services/api-test.ts
@@ -1,0 +1,1 @@
+import type ApiService from '@namespace/package-name/services/api';

--- a/tests/fixtures/ember-engine/steps/use-absolute-paths/relative-imports/input/tests/unit/services/form-test.ts
+++ b/tests/fixtures/ember-engine/steps/use-absolute-paths/relative-imports/input/tests/unit/services/form-test.ts
@@ -1,0 +1,1 @@
+import type FormService from '@namespace/package-name/services/form';

--- a/tests/fixtures/ember-engine/steps/use-absolute-paths/relative-imports/output/addon/authenticated/controller.ts
+++ b/tests/fixtures/ember-engine/steps/use-absolute-paths/relative-imports/output/addon/authenticated/controller.ts
@@ -1,0 +1,3 @@
+import Controller from '@ember/controller';
+
+export default class AuthenticatedController extends Controller {}

--- a/tests/fixtures/ember-engine/steps/use-absolute-paths/relative-imports/output/addon/components/ui/password-reset-form/component.ts
+++ b/tests/fixtures/ember-engine/steps/use-absolute-paths/relative-imports/output/addon/components/ui/password-reset-form/component.ts
@@ -1,0 +1,11 @@
+import Component from '@glimmer/component';
+
+export type PasswordResetFormModel = {};
+
+export default class UiPasswordResetFormComponent extends Component {
+  get model(): PasswordResetFormModel {
+    return {
+      // ...
+    };
+  }
+}

--- a/tests/fixtures/ember-engine/steps/use-absolute-paths/relative-imports/output/addon/components/ui/password-reset-page/component.ts
+++ b/tests/fixtures/ember-engine/steps/use-absolute-paths/relative-imports/output/addon/components/ui/password-reset-page/component.ts
@@ -1,0 +1,9 @@
+import { inject as service } from '@ember/service';
+import Component from '@glimmer/component';
+
+import type FormService from '@namespace/package-name/services/form';
+import type { PasswordResetFormModel } from '@namespace/package-name/components/ui/password-reset-form/component';
+
+export default class UiPasswordResetPageComponent extends Component {
+  @service declare form: FormService;
+}

--- a/tests/fixtures/ember-engine/steps/use-absolute-paths/relative-imports/output/addon/index/route.ts
+++ b/tests/fixtures/ember-engine/steps/use-absolute-paths/relative-imports/output/addon/index/route.ts
@@ -1,0 +1,8 @@
+import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
+
+import ApiService from '@namespace/package-name/services/api';
+
+export default class IndexRoute extends Route {
+  @service declare api: ApiService;
+}

--- a/tests/fixtures/ember-engine/steps/use-absolute-paths/relative-imports/output/addon/password-reset/controller.ts
+++ b/tests/fixtures/ember-engine/steps/use-absolute-paths/relative-imports/output/addon/password-reset/controller.ts
@@ -1,0 +1,3 @@
+import AuthenticatedController from '@namespace/package-name/authenticated/controller';
+
+export default class PasswordResetController extends AuthenticatedController {}

--- a/tests/fixtures/ember-engine/steps/use-absolute-paths/relative-imports/output/addon/services/api.ts
+++ b/tests/fixtures/ember-engine/steps/use-absolute-paths/relative-imports/output/addon/services/api.ts
@@ -1,0 +1,3 @@
+import Service from '@ember/service';
+
+export default class ApiService extends Service {}

--- a/tests/fixtures/ember-engine/steps/use-absolute-paths/relative-imports/output/addon/services/form.ts
+++ b/tests/fixtures/ember-engine/steps/use-absolute-paths/relative-imports/output/addon/services/form.ts
@@ -1,0 +1,7 @@
+import Service, { inject as service } from '@ember/service';
+
+import ApiService from '@namespace/package-name/services/api';
+
+export default class FormService extends Service {
+  @service declare api: ApiService;
+}

--- a/tests/fixtures/ember-engine/steps/use-absolute-paths/relative-imports/output/package.json
+++ b/tests/fixtures/ember-engine/steps/use-absolute-paths/relative-imports/output/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@namespace/package-name",
+  "version": "0.0.0"
+}

--- a/tests/fixtures/ember-engine/steps/use-absolute-paths/relative-imports/output/tests/dummy/app/components/new-password-reset-page/component.ts
+++ b/tests/fixtures/ember-engine/steps/use-absolute-paths/relative-imports/output/tests/dummy/app/components/new-password-reset-page/component.ts
@@ -1,0 +1,8 @@
+import { inject as service } from '@ember/service';
+import Component from '@glimmer/component';
+import type { PasswordResetFormModel } from '@namespace/package-name/components/ui/password-reset-form/component';
+import type FormService from '@namespace/package-name/services/form';
+
+export default class NewPasswordResetPageComponent extends Component {
+  @service declare form: FormService;
+}

--- a/tests/fixtures/ember-engine/steps/use-absolute-paths/relative-imports/output/tests/integration/components/ui/password-reset-form/component-test.ts
+++ b/tests/fixtures/ember-engine/steps/use-absolute-paths/relative-imports/output/tests/integration/components/ui/password-reset-form/component-test.ts
@@ -1,0 +1,3 @@
+import type { PasswordResetFormModel } from '@namespace/package-name/components/ui/password-reset-form/component';
+
+export type CustomType = string | unknown;

--- a/tests/fixtures/ember-engine/steps/use-absolute-paths/relative-imports/output/tests/integration/components/ui/password-reset-page/component-test.ts
+++ b/tests/fixtures/ember-engine/steps/use-absolute-paths/relative-imports/output/tests/integration/components/ui/password-reset-page/component-test.ts
@@ -1,0 +1,3 @@
+import type { PasswordResetFormModel } from '@namespace/package-name/components/ui/password-reset-form/component';
+
+import type { CustomType } from 'dummy/tests/integration/components/ui/password-reset-form/component-test';

--- a/tests/fixtures/ember-engine/steps/use-absolute-paths/relative-imports/output/tests/unit/authenticated/controller-test.ts
+++ b/tests/fixtures/ember-engine/steps/use-absolute-paths/relative-imports/output/tests/unit/authenticated/controller-test.ts
@@ -1,0 +1,1 @@
+import type AuthenticatedController from '@namespace/package-name/authenticated/controller';

--- a/tests/fixtures/ember-engine/steps/use-absolute-paths/relative-imports/output/tests/unit/controllers/password-reset-test.ts
+++ b/tests/fixtures/ember-engine/steps/use-absolute-paths/relative-imports/output/tests/unit/controllers/password-reset-test.ts
@@ -1,0 +1,1 @@
+import type PasswordResetController from '@namespace/package-name/password-reset/controller';

--- a/tests/fixtures/ember-engine/steps/use-absolute-paths/relative-imports/output/tests/unit/index/route-test.ts
+++ b/tests/fixtures/ember-engine/steps/use-absolute-paths/relative-imports/output/tests/unit/index/route-test.ts
@@ -1,0 +1,1 @@
+import type IndexRoute from '@namespace/package-name/index/route';

--- a/tests/fixtures/ember-engine/steps/use-absolute-paths/relative-imports/output/tests/unit/services/api-test.ts
+++ b/tests/fixtures/ember-engine/steps/use-absolute-paths/relative-imports/output/tests/unit/services/api-test.ts
@@ -1,0 +1,1 @@
+import type ApiService from '@namespace/package-name/services/api';

--- a/tests/fixtures/ember-engine/steps/use-absolute-paths/relative-imports/output/tests/unit/services/form-test.ts
+++ b/tests/fixtures/ember-engine/steps/use-absolute-paths/relative-imports/output/tests/unit/services/form-test.ts
@@ -1,0 +1,1 @@
+import type FormService from '@namespace/package-name/services/form';

--- a/tests/fixtures/ember-engine/steps/use-relative-paths/absolute-imports/input/addon/components/ui/password-reset-form.ts
+++ b/tests/fixtures/ember-engine/steps/use-relative-paths/absolute-imports/input/addon/components/ui/password-reset-form.ts
@@ -1,0 +1,11 @@
+import Component from '@glimmer/component';
+
+export type PasswordResetFormModel = {};
+
+export default class UiPasswordResetFormComponent extends Component {
+  get model(): PasswordResetFormModel {
+    return {
+      // ...
+    };
+  }
+}

--- a/tests/fixtures/ember-engine/steps/use-relative-paths/absolute-imports/input/addon/components/ui/password-reset-page.ts
+++ b/tests/fixtures/ember-engine/steps/use-relative-paths/absolute-imports/input/addon/components/ui/password-reset-page.ts
@@ -1,0 +1,8 @@
+import { inject as service } from '@ember/service';
+import Component from '@glimmer/component';
+import type { PasswordResetFormModel } from '@namespace/package-name/components/ui/password-reset-form';
+import type FormService from '@namespace/package-name/services/form';
+
+export default class UiPasswordResetPageComponent extends Component {
+  @service declare form: FormService;
+}

--- a/tests/fixtures/ember-engine/steps/use-relative-paths/absolute-imports/input/addon/controllers/authenticated.ts
+++ b/tests/fixtures/ember-engine/steps/use-relative-paths/absolute-imports/input/addon/controllers/authenticated.ts
@@ -1,0 +1,3 @@
+import Controller from '@ember/controller';
+
+export default class AuthenticatedController extends Controller {}

--- a/tests/fixtures/ember-engine/steps/use-relative-paths/absolute-imports/input/addon/controllers/password-reset.ts
+++ b/tests/fixtures/ember-engine/steps/use-relative-paths/absolute-imports/input/addon/controllers/password-reset.ts
@@ -1,0 +1,3 @@
+import AuthenticatedController from '@namespace/package-name/controllers/authenticated';
+
+export default class PasswordResetController extends AuthenticatedController {}

--- a/tests/fixtures/ember-engine/steps/use-relative-paths/absolute-imports/input/addon/routes/index.ts
+++ b/tests/fixtures/ember-engine/steps/use-relative-paths/absolute-imports/input/addon/routes/index.ts
@@ -1,0 +1,7 @@
+import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
+import ApiService from '@namespace/package-name/services/api';
+
+export default class IndexRoute extends Route {
+  @service declare api: ApiService;
+}

--- a/tests/fixtures/ember-engine/steps/use-relative-paths/absolute-imports/input/addon/services/api.ts
+++ b/tests/fixtures/ember-engine/steps/use-relative-paths/absolute-imports/input/addon/services/api.ts
@@ -1,0 +1,3 @@
+import Service from '@ember/service';
+
+export default class ApiService extends Service {}

--- a/tests/fixtures/ember-engine/steps/use-relative-paths/absolute-imports/input/addon/services/form.ts
+++ b/tests/fixtures/ember-engine/steps/use-relative-paths/absolute-imports/input/addon/services/form.ts
@@ -1,0 +1,6 @@
+import Service, { inject as service } from '@ember/service';
+import ApiService from '@namespace/package-name/services/api';
+
+export default class FormService extends Service {
+  @service declare api: ApiService;
+}

--- a/tests/fixtures/ember-engine/steps/use-relative-paths/absolute-imports/input/package.json
+++ b/tests/fixtures/ember-engine/steps/use-relative-paths/absolute-imports/input/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@namespace/package-name",
+  "version": "0.0.0"
+}

--- a/tests/fixtures/ember-engine/steps/use-relative-paths/absolute-imports/input/tests/dummy/app/components/new-password-reset-page/component.ts
+++ b/tests/fixtures/ember-engine/steps/use-relative-paths/absolute-imports/input/tests/dummy/app/components/new-password-reset-page/component.ts
@@ -1,0 +1,8 @@
+import { inject as service } from '@ember/service';
+import Component from '@glimmer/component';
+import type { PasswordResetFormModel } from '@namespace/package-name/components/ui/password-reset-form';
+import type FormService from '@namespace/package-name/services/form';
+
+export default class NewPasswordResetPageComponent extends Component {
+  @service declare form: FormService;
+}

--- a/tests/fixtures/ember-engine/steps/use-relative-paths/absolute-imports/input/tests/integration/components/ui/password-reset-form-test.ts
+++ b/tests/fixtures/ember-engine/steps/use-relative-paths/absolute-imports/input/tests/integration/components/ui/password-reset-form-test.ts
@@ -1,0 +1,3 @@
+import type { PasswordResetFormModel } from '@namespace/package-name/components/ui/password-reset-form';
+
+export type CustomType = string | unknown;

--- a/tests/fixtures/ember-engine/steps/use-relative-paths/absolute-imports/input/tests/integration/components/ui/password-reset-page-test.ts
+++ b/tests/fixtures/ember-engine/steps/use-relative-paths/absolute-imports/input/tests/integration/components/ui/password-reset-page-test.ts
@@ -1,0 +1,2 @@
+import type { PasswordResetFormModel } from '@namespace/package-name/components/ui/password-reset-form';
+import type { CustomType } from 'dummy/tests/integration/components/ui/password-reset-form-test';

--- a/tests/fixtures/ember-engine/steps/use-relative-paths/absolute-imports/input/tests/unit/controllers/authenticated-test.ts
+++ b/tests/fixtures/ember-engine/steps/use-relative-paths/absolute-imports/input/tests/unit/controllers/authenticated-test.ts
@@ -1,0 +1,1 @@
+import type AuthenticatedController from '@namespace/package-name/controllers/authenticated';

--- a/tests/fixtures/ember-engine/steps/use-relative-paths/absolute-imports/input/tests/unit/controllers/password-reset-test.ts
+++ b/tests/fixtures/ember-engine/steps/use-relative-paths/absolute-imports/input/tests/unit/controllers/password-reset-test.ts
@@ -1,0 +1,1 @@
+import type PasswordResetController from '@namespace/package-name/controllers/password-reset';

--- a/tests/fixtures/ember-engine/steps/use-relative-paths/absolute-imports/input/tests/unit/routes/index-test.ts
+++ b/tests/fixtures/ember-engine/steps/use-relative-paths/absolute-imports/input/tests/unit/routes/index-test.ts
@@ -1,0 +1,1 @@
+import type IndexRoute from '@namespace/package-name/routes/index';

--- a/tests/fixtures/ember-engine/steps/use-relative-paths/absolute-imports/input/tests/unit/services/api-test.ts
+++ b/tests/fixtures/ember-engine/steps/use-relative-paths/absolute-imports/input/tests/unit/services/api-test.ts
@@ -1,0 +1,1 @@
+import type ApiService from '@namespace/package-name/services/api';

--- a/tests/fixtures/ember-engine/steps/use-relative-paths/absolute-imports/input/tests/unit/services/form-test.ts
+++ b/tests/fixtures/ember-engine/steps/use-relative-paths/absolute-imports/input/tests/unit/services/form-test.ts
@@ -1,0 +1,1 @@
+import type FormService from '@namespace/package-name/services/form';

--- a/tests/fixtures/ember-engine/steps/use-relative-paths/absolute-imports/output/addon/components/ui/password-reset-form.ts
+++ b/tests/fixtures/ember-engine/steps/use-relative-paths/absolute-imports/output/addon/components/ui/password-reset-form.ts
@@ -1,0 +1,11 @@
+import Component from '@glimmer/component';
+
+export type PasswordResetFormModel = {};
+
+export default class UiPasswordResetFormComponent extends Component {
+  get model(): PasswordResetFormModel {
+    return {
+      // ...
+    };
+  }
+}

--- a/tests/fixtures/ember-engine/steps/use-relative-paths/absolute-imports/output/addon/components/ui/password-reset-page.ts
+++ b/tests/fixtures/ember-engine/steps/use-relative-paths/absolute-imports/output/addon/components/ui/password-reset-page.ts
@@ -1,0 +1,8 @@
+import { inject as service } from '@ember/service';
+import Component from '@glimmer/component';
+import type { PasswordResetFormModel } from './password-reset-form';
+import type FormService from '../../services/form';
+
+export default class UiPasswordResetPageComponent extends Component {
+  @service declare form: FormService;
+}

--- a/tests/fixtures/ember-engine/steps/use-relative-paths/absolute-imports/output/addon/controllers/authenticated.ts
+++ b/tests/fixtures/ember-engine/steps/use-relative-paths/absolute-imports/output/addon/controllers/authenticated.ts
@@ -1,0 +1,3 @@
+import Controller from '@ember/controller';
+
+export default class AuthenticatedController extends Controller {}

--- a/tests/fixtures/ember-engine/steps/use-relative-paths/absolute-imports/output/addon/controllers/password-reset.ts
+++ b/tests/fixtures/ember-engine/steps/use-relative-paths/absolute-imports/output/addon/controllers/password-reset.ts
@@ -1,0 +1,3 @@
+import AuthenticatedController from './authenticated';
+
+export default class PasswordResetController extends AuthenticatedController {}

--- a/tests/fixtures/ember-engine/steps/use-relative-paths/absolute-imports/output/addon/routes/index.ts
+++ b/tests/fixtures/ember-engine/steps/use-relative-paths/absolute-imports/output/addon/routes/index.ts
@@ -1,0 +1,7 @@
+import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
+import ApiService from '../services/api';
+
+export default class IndexRoute extends Route {
+  @service declare api: ApiService;
+}

--- a/tests/fixtures/ember-engine/steps/use-relative-paths/absolute-imports/output/addon/services/api.ts
+++ b/tests/fixtures/ember-engine/steps/use-relative-paths/absolute-imports/output/addon/services/api.ts
@@ -1,0 +1,3 @@
+import Service from '@ember/service';
+
+export default class ApiService extends Service {}

--- a/tests/fixtures/ember-engine/steps/use-relative-paths/absolute-imports/output/addon/services/form.ts
+++ b/tests/fixtures/ember-engine/steps/use-relative-paths/absolute-imports/output/addon/services/form.ts
@@ -1,0 +1,6 @@
+import Service, { inject as service } from '@ember/service';
+import ApiService from './api';
+
+export default class FormService extends Service {
+  @service declare api: ApiService;
+}

--- a/tests/fixtures/ember-engine/steps/use-relative-paths/absolute-imports/output/package.json
+++ b/tests/fixtures/ember-engine/steps/use-relative-paths/absolute-imports/output/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@namespace/package-name",
+  "version": "0.0.0"
+}

--- a/tests/fixtures/ember-engine/steps/use-relative-paths/absolute-imports/output/tests/dummy/app/components/new-password-reset-page/component.ts
+++ b/tests/fixtures/ember-engine/steps/use-relative-paths/absolute-imports/output/tests/dummy/app/components/new-password-reset-page/component.ts
@@ -1,0 +1,8 @@
+import { inject as service } from '@ember/service';
+import Component from '@glimmer/component';
+import type { PasswordResetFormModel } from '@namespace/package-name/components/ui/password-reset-form';
+import type FormService from '@namespace/package-name/services/form';
+
+export default class NewPasswordResetPageComponent extends Component {
+  @service declare form: FormService;
+}

--- a/tests/fixtures/ember-engine/steps/use-relative-paths/absolute-imports/output/tests/integration/components/ui/password-reset-form-test.ts
+++ b/tests/fixtures/ember-engine/steps/use-relative-paths/absolute-imports/output/tests/integration/components/ui/password-reset-form-test.ts
@@ -1,0 +1,3 @@
+import type { PasswordResetFormModel } from '@namespace/package-name/components/ui/password-reset-form';
+
+export type CustomType = string | unknown;

--- a/tests/fixtures/ember-engine/steps/use-relative-paths/absolute-imports/output/tests/integration/components/ui/password-reset-page-test.ts
+++ b/tests/fixtures/ember-engine/steps/use-relative-paths/absolute-imports/output/tests/integration/components/ui/password-reset-page-test.ts
@@ -1,0 +1,2 @@
+import type { PasswordResetFormModel } from '@namespace/package-name/components/ui/password-reset-form';
+import type { CustomType } from './password-reset-form-test';

--- a/tests/fixtures/ember-engine/steps/use-relative-paths/absolute-imports/output/tests/unit/controllers/authenticated-test.ts
+++ b/tests/fixtures/ember-engine/steps/use-relative-paths/absolute-imports/output/tests/unit/controllers/authenticated-test.ts
@@ -1,0 +1,1 @@
+import type AuthenticatedController from '@namespace/package-name/controllers/authenticated';

--- a/tests/fixtures/ember-engine/steps/use-relative-paths/absolute-imports/output/tests/unit/controllers/password-reset-test.ts
+++ b/tests/fixtures/ember-engine/steps/use-relative-paths/absolute-imports/output/tests/unit/controllers/password-reset-test.ts
@@ -1,0 +1,1 @@
+import type PasswordResetController from '@namespace/package-name/controllers/password-reset';

--- a/tests/fixtures/ember-engine/steps/use-relative-paths/absolute-imports/output/tests/unit/routes/index-test.ts
+++ b/tests/fixtures/ember-engine/steps/use-relative-paths/absolute-imports/output/tests/unit/routes/index-test.ts
@@ -1,0 +1,1 @@
+import type IndexRoute from '@namespace/package-name/routes/index';

--- a/tests/fixtures/ember-engine/steps/use-relative-paths/absolute-imports/output/tests/unit/services/api-test.ts
+++ b/tests/fixtures/ember-engine/steps/use-relative-paths/absolute-imports/output/tests/unit/services/api-test.ts
@@ -1,0 +1,1 @@
+import type ApiService from '@namespace/package-name/services/api';

--- a/tests/fixtures/ember-engine/steps/use-relative-paths/absolute-imports/output/tests/unit/services/form-test.ts
+++ b/tests/fixtures/ember-engine/steps/use-relative-paths/absolute-imports/output/tests/unit/services/form-test.ts
@@ -1,0 +1,1 @@
+import type FormService from '@namespace/package-name/services/form';

--- a/tests/fixtures/ember-engine/steps/use-relative-paths/relative-imports/input/addon/components/ui/password-reset-form.ts
+++ b/tests/fixtures/ember-engine/steps/use-relative-paths/relative-imports/input/addon/components/ui/password-reset-form.ts
@@ -1,0 +1,11 @@
+import Component from '@glimmer/component';
+
+export type PasswordResetFormModel = {};
+
+export default class UiPasswordResetFormComponent extends Component {
+  get model(): PasswordResetFormModel {
+    return {
+      // ...
+    };
+  }
+}

--- a/tests/fixtures/ember-engine/steps/use-relative-paths/relative-imports/input/addon/components/ui/password-reset-page.ts
+++ b/tests/fixtures/ember-engine/steps/use-relative-paths/relative-imports/input/addon/components/ui/password-reset-page.ts
@@ -1,0 +1,9 @@
+import { inject as service } from '@ember/service';
+import Component from '@glimmer/component';
+
+import type FormService from '@namespace/package-name/services/form';
+import type { PasswordResetFormModel } from '@namespace/package-name/components/ui/password-reset-form';
+
+export default class UiPasswordResetPageComponent extends Component {
+  @service declare form: FormService;
+}

--- a/tests/fixtures/ember-engine/steps/use-relative-paths/relative-imports/input/addon/controllers/authenticated.ts
+++ b/tests/fixtures/ember-engine/steps/use-relative-paths/relative-imports/input/addon/controllers/authenticated.ts
@@ -1,0 +1,3 @@
+import Controller from '@ember/controller';
+
+export default class AuthenticatedController extends Controller {}

--- a/tests/fixtures/ember-engine/steps/use-relative-paths/relative-imports/input/addon/controllers/password-reset.ts
+++ b/tests/fixtures/ember-engine/steps/use-relative-paths/relative-imports/input/addon/controllers/password-reset.ts
@@ -1,0 +1,3 @@
+import AuthenticatedController from '@namespace/package-name/controllers/authenticated';
+
+export default class PasswordResetController extends AuthenticatedController {}

--- a/tests/fixtures/ember-engine/steps/use-relative-paths/relative-imports/input/addon/routes/index.ts
+++ b/tests/fixtures/ember-engine/steps/use-relative-paths/relative-imports/input/addon/routes/index.ts
@@ -1,0 +1,8 @@
+import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
+
+import ApiService from '@namespace/package-name/services/api';
+
+export default class IndexRoute extends Route {
+  @service declare api: ApiService;
+}

--- a/tests/fixtures/ember-engine/steps/use-relative-paths/relative-imports/input/addon/services/api.ts
+++ b/tests/fixtures/ember-engine/steps/use-relative-paths/relative-imports/input/addon/services/api.ts
@@ -1,0 +1,3 @@
+import Service from '@ember/service';
+
+export default class ApiService extends Service {}

--- a/tests/fixtures/ember-engine/steps/use-relative-paths/relative-imports/input/addon/services/form.ts
+++ b/tests/fixtures/ember-engine/steps/use-relative-paths/relative-imports/input/addon/services/form.ts
@@ -1,0 +1,7 @@
+import Service, { inject as service } from '@ember/service';
+
+import ApiService from '@namespace/package-name/services/api';
+
+export default class FormService extends Service {
+  @service declare api: ApiService;
+}

--- a/tests/fixtures/ember-engine/steps/use-relative-paths/relative-imports/input/package.json
+++ b/tests/fixtures/ember-engine/steps/use-relative-paths/relative-imports/input/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@namespace/package-name",
+  "version": "0.0.0"
+}

--- a/tests/fixtures/ember-engine/steps/use-relative-paths/relative-imports/input/tests/dummy/app/components/new-password-reset-page/component.ts
+++ b/tests/fixtures/ember-engine/steps/use-relative-paths/relative-imports/input/tests/dummy/app/components/new-password-reset-page/component.ts
@@ -1,0 +1,8 @@
+import { inject as service } from '@ember/service';
+import Component from '@glimmer/component';
+import type { PasswordResetFormModel } from '@namespace/package-name/components/ui/password-reset-form';
+import type FormService from '@namespace/package-name/services/form';
+
+export default class NewPasswordResetPageComponent extends Component {
+  @service declare form: FormService;
+}

--- a/tests/fixtures/ember-engine/steps/use-relative-paths/relative-imports/input/tests/integration/components/ui/password-reset-form-test.ts
+++ b/tests/fixtures/ember-engine/steps/use-relative-paths/relative-imports/input/tests/integration/components/ui/password-reset-form-test.ts
@@ -1,0 +1,3 @@
+import type { PasswordResetFormModel } from '@namespace/package-name/components/ui/password-reset-form';
+
+export type CustomType = string | unknown;

--- a/tests/fixtures/ember-engine/steps/use-relative-paths/relative-imports/input/tests/integration/components/ui/password-reset-page-test.ts
+++ b/tests/fixtures/ember-engine/steps/use-relative-paths/relative-imports/input/tests/integration/components/ui/password-reset-page-test.ts
@@ -1,0 +1,3 @@
+import type { PasswordResetFormModel } from '@namespace/package-name/components/ui/password-reset-form';
+
+import type { CustomType } from 'dummy/tests/integration/components/ui/password-reset-form-test';

--- a/tests/fixtures/ember-engine/steps/use-relative-paths/relative-imports/input/tests/unit/controllers/authenticated-test.ts
+++ b/tests/fixtures/ember-engine/steps/use-relative-paths/relative-imports/input/tests/unit/controllers/authenticated-test.ts
@@ -1,0 +1,1 @@
+import type AuthenticatedController from '@namespace/package-name/controllers/authenticated';

--- a/tests/fixtures/ember-engine/steps/use-relative-paths/relative-imports/input/tests/unit/controllers/password-reset-test.ts
+++ b/tests/fixtures/ember-engine/steps/use-relative-paths/relative-imports/input/tests/unit/controllers/password-reset-test.ts
@@ -1,0 +1,1 @@
+import type PasswordResetController from '@namespace/package-name/controllers/password-reset';

--- a/tests/fixtures/ember-engine/steps/use-relative-paths/relative-imports/input/tests/unit/routes/index-test.ts
+++ b/tests/fixtures/ember-engine/steps/use-relative-paths/relative-imports/input/tests/unit/routes/index-test.ts
@@ -1,0 +1,1 @@
+import type IndexRoute from '@namespace/package-name/routes/index';

--- a/tests/fixtures/ember-engine/steps/use-relative-paths/relative-imports/input/tests/unit/services/api-test.ts
+++ b/tests/fixtures/ember-engine/steps/use-relative-paths/relative-imports/input/tests/unit/services/api-test.ts
@@ -1,0 +1,1 @@
+import type ApiService from '@namespace/package-name/services/api';

--- a/tests/fixtures/ember-engine/steps/use-relative-paths/relative-imports/input/tests/unit/services/form-test.ts
+++ b/tests/fixtures/ember-engine/steps/use-relative-paths/relative-imports/input/tests/unit/services/form-test.ts
@@ -1,0 +1,1 @@
+import type FormService from '@namespace/package-name/services/form';

--- a/tests/fixtures/ember-engine/steps/use-relative-paths/relative-imports/output/addon/components/ui/password-reset-form.ts
+++ b/tests/fixtures/ember-engine/steps/use-relative-paths/relative-imports/output/addon/components/ui/password-reset-form.ts
@@ -1,0 +1,11 @@
+import Component from '@glimmer/component';
+
+export type PasswordResetFormModel = {};
+
+export default class UiPasswordResetFormComponent extends Component {
+  get model(): PasswordResetFormModel {
+    return {
+      // ...
+    };
+  }
+}

--- a/tests/fixtures/ember-engine/steps/use-relative-paths/relative-imports/output/addon/components/ui/password-reset-page.ts
+++ b/tests/fixtures/ember-engine/steps/use-relative-paths/relative-imports/output/addon/components/ui/password-reset-page.ts
@@ -1,0 +1,9 @@
+import { inject as service } from '@ember/service';
+import Component from '@glimmer/component';
+
+import type FormService from '../../services/form';
+import type { PasswordResetFormModel } from './password-reset-form';
+
+export default class UiPasswordResetPageComponent extends Component {
+  @service declare form: FormService;
+}

--- a/tests/fixtures/ember-engine/steps/use-relative-paths/relative-imports/output/addon/controllers/authenticated.ts
+++ b/tests/fixtures/ember-engine/steps/use-relative-paths/relative-imports/output/addon/controllers/authenticated.ts
@@ -1,0 +1,3 @@
+import Controller from '@ember/controller';
+
+export default class AuthenticatedController extends Controller {}

--- a/tests/fixtures/ember-engine/steps/use-relative-paths/relative-imports/output/addon/controllers/password-reset.ts
+++ b/tests/fixtures/ember-engine/steps/use-relative-paths/relative-imports/output/addon/controllers/password-reset.ts
@@ -1,0 +1,3 @@
+import AuthenticatedController from './authenticated';
+
+export default class PasswordResetController extends AuthenticatedController {}

--- a/tests/fixtures/ember-engine/steps/use-relative-paths/relative-imports/output/addon/routes/index.ts
+++ b/tests/fixtures/ember-engine/steps/use-relative-paths/relative-imports/output/addon/routes/index.ts
@@ -1,0 +1,8 @@
+import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
+
+import ApiService from '../services/api';
+
+export default class IndexRoute extends Route {
+  @service declare api: ApiService;
+}

--- a/tests/fixtures/ember-engine/steps/use-relative-paths/relative-imports/output/addon/services/api.ts
+++ b/tests/fixtures/ember-engine/steps/use-relative-paths/relative-imports/output/addon/services/api.ts
@@ -1,0 +1,3 @@
+import Service from '@ember/service';
+
+export default class ApiService extends Service {}

--- a/tests/fixtures/ember-engine/steps/use-relative-paths/relative-imports/output/addon/services/form.ts
+++ b/tests/fixtures/ember-engine/steps/use-relative-paths/relative-imports/output/addon/services/form.ts
@@ -1,0 +1,7 @@
+import Service, { inject as service } from '@ember/service';
+
+import ApiService from './api';
+
+export default class FormService extends Service {
+  @service declare api: ApiService;
+}

--- a/tests/fixtures/ember-engine/steps/use-relative-paths/relative-imports/output/package.json
+++ b/tests/fixtures/ember-engine/steps/use-relative-paths/relative-imports/output/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@namespace/package-name",
+  "version": "0.0.0"
+}

--- a/tests/fixtures/ember-engine/steps/use-relative-paths/relative-imports/output/tests/dummy/app/components/new-password-reset-page/component.ts
+++ b/tests/fixtures/ember-engine/steps/use-relative-paths/relative-imports/output/tests/dummy/app/components/new-password-reset-page/component.ts
@@ -1,0 +1,8 @@
+import { inject as service } from '@ember/service';
+import Component from '@glimmer/component';
+import type { PasswordResetFormModel } from '@namespace/package-name/components/ui/password-reset-form';
+import type FormService from '@namespace/package-name/services/form';
+
+export default class NewPasswordResetPageComponent extends Component {
+  @service declare form: FormService;
+}

--- a/tests/fixtures/ember-engine/steps/use-relative-paths/relative-imports/output/tests/integration/components/ui/password-reset-form-test.ts
+++ b/tests/fixtures/ember-engine/steps/use-relative-paths/relative-imports/output/tests/integration/components/ui/password-reset-form-test.ts
@@ -1,0 +1,3 @@
+import type { PasswordResetFormModel } from '@namespace/package-name/components/ui/password-reset-form';
+
+export type CustomType = string | unknown;

--- a/tests/fixtures/ember-engine/steps/use-relative-paths/relative-imports/output/tests/integration/components/ui/password-reset-page-test.ts
+++ b/tests/fixtures/ember-engine/steps/use-relative-paths/relative-imports/output/tests/integration/components/ui/password-reset-page-test.ts
@@ -1,0 +1,3 @@
+import type { PasswordResetFormModel } from '@namespace/package-name/components/ui/password-reset-form';
+
+import type { CustomType } from './password-reset-form-test';

--- a/tests/fixtures/ember-engine/steps/use-relative-paths/relative-imports/output/tests/unit/controllers/authenticated-test.ts
+++ b/tests/fixtures/ember-engine/steps/use-relative-paths/relative-imports/output/tests/unit/controllers/authenticated-test.ts
@@ -1,0 +1,1 @@
+import type AuthenticatedController from '@namespace/package-name/controllers/authenticated';

--- a/tests/fixtures/ember-engine/steps/use-relative-paths/relative-imports/output/tests/unit/controllers/password-reset-test.ts
+++ b/tests/fixtures/ember-engine/steps/use-relative-paths/relative-imports/output/tests/unit/controllers/password-reset-test.ts
@@ -1,0 +1,1 @@
+import type PasswordResetController from '@namespace/package-name/controllers/password-reset';

--- a/tests/fixtures/ember-engine/steps/use-relative-paths/relative-imports/output/tests/unit/routes/index-test.ts
+++ b/tests/fixtures/ember-engine/steps/use-relative-paths/relative-imports/output/tests/unit/routes/index-test.ts
@@ -1,0 +1,1 @@
+import type IndexRoute from '@namespace/package-name/routes/index';

--- a/tests/fixtures/ember-engine/steps/use-relative-paths/relative-imports/output/tests/unit/services/api-test.ts
+++ b/tests/fixtures/ember-engine/steps/use-relative-paths/relative-imports/output/tests/unit/services/api-test.ts
@@ -1,0 +1,1 @@
+import type ApiService from '@namespace/package-name/services/api';

--- a/tests/fixtures/ember-engine/steps/use-relative-paths/relative-imports/output/tests/unit/services/form-test.ts
+++ b/tests/fixtures/ember-engine/steps/use-relative-paths/relative-imports/output/tests/unit/services/form-test.ts
@@ -1,0 +1,1 @@
+import type FormService from '@namespace/package-name/services/form';

--- a/tests/helpers/shared-test-setups/ember-engine/absolute-imports.js
+++ b/tests/helpers/shared-test-setups/ember-engine/absolute-imports.js
@@ -1,0 +1,16 @@
+const codemodOptions = {
+  podPath: '',
+  projectRoot: 'tmp/ember-engine/absolute-imports',
+  projectType: 'engine',
+  testRun: false,
+};
+
+const options = {
+  podPath: '',
+  projectName: '@namespace/package-name',
+  projectRoot: 'tmp/ember-engine/absolute-imports',
+  projectType: 'engine',
+  testRun: false,
+};
+
+export { codemodOptions, options };

--- a/tests/helpers/shared-test-setups/ember-engine/relative-imports.js
+++ b/tests/helpers/shared-test-setups/ember-engine/relative-imports.js
@@ -1,0 +1,16 @@
+const codemodOptions = {
+  podPath: '',
+  projectRoot: 'tmp/ember-engine/relative-imports',
+  projectType: 'engine',
+  testRun: false,
+};
+
+const options = {
+  podPath: '',
+  projectName: '@namespace/package-name',
+  projectRoot: 'tmp/ember-engine/relative-imports',
+  projectType: 'engine',
+  testRun: false,
+};
+
+export { codemodOptions, options };

--- a/tests/migration/ember-engine/index/absolute-imports.test.js
+++ b/tests/migration/ember-engine/index/absolute-imports.test.js
@@ -1,0 +1,20 @@
+import { migrateEmberEngine } from '../../../../src/migration/ember-engine/index.js';
+import {
+  inputProject,
+  outputProject,
+} from '../../../fixtures/ember-engine/absolute-imports/index.js';
+import { codemodOptions } from '../../../helpers/shared-test-setups/ember-engine/absolute-imports.js';
+import { assertFixture, loadFixture, test } from '../../../helpers/testing.js';
+
+test('migration | ember-engine | index > absolute-imports', function () {
+  loadFixture(inputProject, codemodOptions);
+
+  migrateEmberEngine(codemodOptions);
+
+  assertFixture(outputProject, codemodOptions);
+
+  // Check idempotence
+  migrateEmberEngine(codemodOptions);
+
+  assertFixture(outputProject, codemodOptions);
+});

--- a/tests/migration/ember-engine/index/relative-imports.test.js
+++ b/tests/migration/ember-engine/index/relative-imports.test.js
@@ -1,0 +1,20 @@
+import { migrateEmberEngine } from '../../../../src/migration/ember-engine/index.js';
+import {
+  inputProject,
+  outputProject,
+} from '../../../fixtures/ember-engine/relative-imports/index.js';
+import { codemodOptions } from '../../../helpers/shared-test-setups/ember-engine/relative-imports.js';
+import { assertFixture, loadFixture, test } from '../../../helpers/testing.js';
+
+test('migration | ember-engine | index > relative-imports', function () {
+  loadFixture(inputProject, codemodOptions);
+
+  migrateEmberEngine(codemodOptions);
+
+  assertFixture(outputProject, codemodOptions);
+
+  // Check idempotence
+  migrateEmberEngine(codemodOptions);
+
+  assertFixture(outputProject, codemodOptions);
+});

--- a/tests/migration/ember-engine/steps/update-absolute-paths/absolute-imports.test.js
+++ b/tests/migration/ember-engine/steps/update-absolute-paths/absolute-imports.test.js
@@ -19,9 +19,39 @@ test('migration | ember-engine | steps | update-absolute-paths > absolute-import
     'ember-engine/steps/update-absolute-paths/absolute-imports/output'
   );
 
+  const migrationStrategy = new Map([
+    [
+      'addon/components/ui/password-reset-form/component.ts',
+      'addon/components/ui/password-reset-form.ts',
+    ],
+    [
+      'addon/components/ui/password-reset-page/component.ts',
+      'addon/components/ui/password-reset-page.ts',
+    ],
+    ['addon/authenticated/controller.ts', 'addon/controllers/authenticated.ts'],
+    [
+      'addon/password-reset/controller.ts',
+      'addon/controllers/password-reset.ts',
+    ],
+    ['addon/index/route.ts', 'addon/routes/index.ts'],
+    [
+      'tests/integration/components/ui/password-reset-form/component-test.ts',
+      'tests/integration/components/ui/password-reset-form-test.ts',
+    ],
+    [
+      'tests/integration/components/ui/password-reset-page/component-test.ts',
+      'tests/integration/components/ui/password-reset-page-test.ts',
+    ],
+    [
+      'tests/unit/authenticated/controller-test.ts',
+      'tests/unit/controllers/authenticated-test.ts',
+    ],
+    ['tests/unit/index/route-test.ts', 'tests/unit/routes/index-test.ts'],
+  ]);
+
   loadFixture(inputProject, codemodOptions);
 
-  updateAbsolutePaths(options);
+  updateAbsolutePaths(migrationStrategy, options);
 
   assertFixture(outputProject, codemodOptions);
 });

--- a/tests/migration/ember-engine/steps/update-absolute-paths/absolute-imports.test.js
+++ b/tests/migration/ember-engine/steps/update-absolute-paths/absolute-imports.test.js
@@ -1,0 +1,27 @@
+import { updateAbsolutePaths } from '../../../../../src/migration/ember-engine/steps/index.js';
+import {
+  codemodOptions,
+  options,
+} from '../../../../helpers/shared-test-setups/ember-engine/absolute-imports.js';
+import {
+  assertFixture,
+  convertFixtureToJson,
+  loadFixture,
+  test,
+} from '../../../../helpers/testing.js';
+
+test('migration | ember-engine | steps | update-absolute-paths > absolute-imports', function () {
+  const inputProject = convertFixtureToJson(
+    'ember-engine/steps/update-absolute-paths/absolute-imports/input'
+  );
+
+  const outputProject = convertFixtureToJson(
+    'ember-engine/steps/update-absolute-paths/absolute-imports/output'
+  );
+
+  loadFixture(inputProject, codemodOptions);
+
+  updateAbsolutePaths(options);
+
+  assertFixture(outputProject, codemodOptions);
+});

--- a/tests/migration/ember-engine/steps/update-absolute-paths/relative-imports.test.js
+++ b/tests/migration/ember-engine/steps/update-absolute-paths/relative-imports.test.js
@@ -19,9 +19,39 @@ test('migration | ember-engine | steps | update-absolute-paths > relative-import
     'ember-engine/steps/update-absolute-paths/relative-imports/output'
   );
 
+  const migrationStrategy = new Map([
+    [
+      'addon/components/ui/password-reset-form/component.ts',
+      'addon/components/ui/password-reset-form.ts',
+    ],
+    [
+      'addon/components/ui/password-reset-page/component.ts',
+      'addon/components/ui/password-reset-page.ts',
+    ],
+    ['addon/authenticated/controller.ts', 'addon/controllers/authenticated.ts'],
+    [
+      'addon/password-reset/controller.ts',
+      'addon/controllers/password-reset.ts',
+    ],
+    ['addon/index/route.ts', 'addon/routes/index.ts'],
+    [
+      'tests/integration/components/ui/password-reset-form/component-test.ts',
+      'tests/integration/components/ui/password-reset-form-test.ts',
+    ],
+    [
+      'tests/integration/components/ui/password-reset-page/component-test.ts',
+      'tests/integration/components/ui/password-reset-page-test.ts',
+    ],
+    [
+      'tests/unit/authenticated/controller-test.ts',
+      'tests/unit/controllers/authenticated-test.ts',
+    ],
+    ['tests/unit/index/route-test.ts', 'tests/unit/routes/index-test.ts'],
+  ]);
+
   loadFixture(inputProject, codemodOptions);
 
-  updateAbsolutePaths(options);
+  updateAbsolutePaths(migrationStrategy, options);
 
   assertFixture(outputProject, codemodOptions);
 });

--- a/tests/migration/ember-engine/steps/update-absolute-paths/relative-imports.test.js
+++ b/tests/migration/ember-engine/steps/update-absolute-paths/relative-imports.test.js
@@ -1,0 +1,27 @@
+import { updateAbsolutePaths } from '../../../../../src/migration/ember-engine/steps/index.js';
+import {
+  codemodOptions,
+  options,
+} from '../../../../helpers/shared-test-setups/ember-engine/relative-imports.js';
+import {
+  assertFixture,
+  convertFixtureToJson,
+  loadFixture,
+  test,
+} from '../../../../helpers/testing.js';
+
+test('migration | ember-engine | steps | update-absolute-paths > relative-imports', function () {
+  const inputProject = convertFixtureToJson(
+    'ember-engine/steps/update-absolute-paths/relative-imports/input'
+  );
+
+  const outputProject = convertFixtureToJson(
+    'ember-engine/steps/update-absolute-paths/relative-imports/output'
+  );
+
+  loadFixture(inputProject, codemodOptions);
+
+  updateAbsolutePaths(options);
+
+  assertFixture(outputProject, codemodOptions);
+});

--- a/tests/migration/ember-engine/steps/use-absolute-paths/absolute-imports.test.js
+++ b/tests/migration/ember-engine/steps/use-absolute-paths/absolute-imports.test.js
@@ -1,0 +1,27 @@
+import { useAbsolutePaths } from '../../../../../src/migration/ember-engine/steps/index.js';
+import {
+  codemodOptions,
+  options,
+} from '../../../../helpers/shared-test-setups/ember-engine/absolute-imports.js';
+import {
+  assertFixture,
+  convertFixtureToJson,
+  loadFixture,
+  test,
+} from '../../../../helpers/testing.js';
+
+test('migration | ember-engine | steps | use-absolute-paths > absolute-imports', function () {
+  const inputProject = convertFixtureToJson(
+    'ember-engine/steps/use-absolute-paths/absolute-imports/input'
+  );
+
+  const outputProject = convertFixtureToJson(
+    'ember-engine/steps/use-absolute-paths/absolute-imports/output'
+  );
+
+  loadFixture(inputProject, codemodOptions);
+
+  useAbsolutePaths(options);
+
+  assertFixture(outputProject, codemodOptions);
+});

--- a/tests/migration/ember-engine/steps/use-absolute-paths/relative-imports.test.js
+++ b/tests/migration/ember-engine/steps/use-absolute-paths/relative-imports.test.js
@@ -1,0 +1,27 @@
+import { useAbsolutePaths } from '../../../../../src/migration/ember-engine/steps/index.js';
+import {
+  codemodOptions,
+  options,
+} from '../../../../helpers/shared-test-setups/ember-engine/relative-imports.js';
+import {
+  assertFixture,
+  convertFixtureToJson,
+  loadFixture,
+  test,
+} from '../../../../helpers/testing.js';
+
+test('migration | ember-engine | steps | use-absolute-paths > relative-imports', function () {
+  const inputProject = convertFixtureToJson(
+    'ember-engine/steps/use-absolute-paths/relative-imports/input'
+  );
+
+  const outputProject = convertFixtureToJson(
+    'ember-engine/steps/use-absolute-paths/relative-imports/output'
+  );
+
+  loadFixture(inputProject, codemodOptions);
+
+  useAbsolutePaths(options);
+
+  assertFixture(outputProject, codemodOptions);
+});

--- a/tests/migration/ember-engine/steps/use-relative-paths/absolute-imports.test.js
+++ b/tests/migration/ember-engine/steps/use-relative-paths/absolute-imports.test.js
@@ -1,0 +1,27 @@
+import { useRelativePaths } from '../../../../../src/migration/ember-engine/steps/index.js';
+import {
+  codemodOptions,
+  options,
+} from '../../../../helpers/shared-test-setups/ember-engine/absolute-imports.js';
+import {
+  assertFixture,
+  convertFixtureToJson,
+  loadFixture,
+  test,
+} from '../../../../helpers/testing.js';
+
+test('migration | ember-engine | steps | use-relative-paths > absolute-imports', function () {
+  const inputProject = convertFixtureToJson(
+    'ember-engine/steps/use-relative-paths/absolute-imports/input'
+  );
+
+  const outputProject = convertFixtureToJson(
+    'ember-engine/steps/use-relative-paths/absolute-imports/output'
+  );
+
+  loadFixture(inputProject, codemodOptions);
+
+  useRelativePaths(options);
+
+  assertFixture(outputProject, codemodOptions);
+});

--- a/tests/migration/ember-engine/steps/use-relative-paths/relative-imports.test.js
+++ b/tests/migration/ember-engine/steps/use-relative-paths/relative-imports.test.js
@@ -1,0 +1,27 @@
+import { useRelativePaths } from '../../../../../src/migration/ember-engine/steps/index.js';
+import {
+  codemodOptions,
+  options,
+} from '../../../../helpers/shared-test-setups/ember-engine/relative-imports.js';
+import {
+  assertFixture,
+  convertFixtureToJson,
+  loadFixture,
+  test,
+} from '../../../../helpers/testing.js';
+
+test('migration | ember-engine | steps | use-relative-paths > relative-imports', function () {
+  const inputProject = convertFixtureToJson(
+    'ember-engine/steps/use-relative-paths/relative-imports/input'
+  );
+
+  const outputProject = convertFixtureToJson(
+    'ember-engine/steps/use-relative-paths/relative-imports/output'
+  );
+
+  loadFixture(inputProject, codemodOptions);
+
+  useRelativePaths(options);
+
+  assertFixture(outputProject, codemodOptions);
+});

--- a/tests/utils/ember-addon/app/components.test.js
+++ b/tests/utils/ember-addon/app/components.test.js
@@ -1,4 +1,4 @@
-import { updatePaths } from '../../../../src/utils/ember-addon/app/components.js';
+import { updatePathsInAppFolder } from '../../../../src/utils/ember-addon/app/components.js';
 import { moveFiles } from '../../../../src/utils/files.js';
 import {
   codemodOptions,
@@ -46,7 +46,7 @@ test('utils | ember-addon | app | components', function () {
 
   moveFiles(migrationStrategy, options);
 
-  updatePaths(migrationStrategy, options);
+  updatePathsInAppFolder(migrationStrategy, options);
 
   assertFixture(outputProject, codemodOptions);
 });


### PR DESCRIPTION
## Background

When I had run the codemod on a production app, I had found that updating import paths (references to the moved files) is time-consuming and can lead to mistakes.

We can improve the developer experience if the codemod updates the import paths (within the project).


## Solution

As a proof of concept, I updated the migration steps for Ember engines. There will be separate pull requests for Ember apps and addons, as well as refactoring to remove code duplication (if this makes sense).

A high-level overview of how to update import paths:

- Change existing relative paths back to absolute paths (add "Ember magic")
- Move the files, as done previously
- Update the project-relevant import paths
- Change absolute paths to relative paths (remove "Ember magic")