### PR TITLE
Wrapped glob

### DIFF
--- a/src/migration/ember-addon/addon/component-classes.js
+++ b/src/migration/ember-addon/addon/component-classes.js
@@ -1,11 +1,9 @@
-import glob from 'glob';
-
-import { mapFilePath } from '../../../utils/files.js';
+import { findFiles, mapFilePath } from '../../../utils/files.js';
 
 export function migrationStrategyForComponentClasses(options) {
   const { projectRoot } = options;
 
-  const oldPaths = glob.sync('addon/components/**/component.{d.ts,js,ts}', {
+  const oldPaths = findFiles('addon/components/**/component.{d.ts,js,ts}', {
     cwd: projectRoot,
   });
 

--- a/src/migration/ember-addon/addon/component-stylesheets.js
+++ b/src/migration/ember-addon/addon/component-stylesheets.js
@@ -1,11 +1,9 @@
-import glob from 'glob';
-
-import { mapFilePath } from '../../../utils/files.js';
+import { findFiles, mapFilePath } from '../../../utils/files.js';
 
 export function migrationStrategyForComponentStylesheets(options) {
   const { projectRoot } = options;
 
-  const oldPaths = glob.sync('addon/components/**/styles.{css,scss}', {
+  const oldPaths = findFiles('addon/components/**/styles.{css,scss}', {
     cwd: projectRoot,
   });
 

--- a/src/migration/ember-addon/addon/component-templates.js
+++ b/src/migration/ember-addon/addon/component-templates.js
@@ -1,11 +1,9 @@
-import glob from 'glob';
-
-import { mapFilePath } from '../../../utils/files.js';
+import { findFiles, mapFilePath } from '../../../utils/files.js';
 
 export function migrationStrategyForComponentTemplates(options) {
   const { projectRoot } = options;
 
-  const oldPaths = glob.sync('addon/components/**/template.hbs', {
+  const oldPaths = findFiles('addon/components/**/template.hbs', {
     cwd: projectRoot,
   });
 

--- a/src/migration/ember-addon/app/component-classes.js
+++ b/src/migration/ember-addon/app/component-classes.js
@@ -1,11 +1,9 @@
-import glob from 'glob';
-
-import { mapFilePath } from '../../../utils/files.js';
+import { findFiles, mapFilePath } from '../../../utils/files.js';
 
 export function migrationStrategyForComponentClasses(options) {
   const { projectRoot } = options;
 
-  const oldPaths = glob.sync('app/components/**/component.js', {
+  const oldPaths = findFiles('app/components/**/component.js', {
     cwd: projectRoot,
   });
 

--- a/src/migration/ember-addon/app/component-stylesheets.js
+++ b/src/migration/ember-addon/app/component-stylesheets.js
@@ -1,11 +1,9 @@
-import glob from 'glob';
-
-import { mapFilePath } from '../../../utils/files.js';
+import { findFiles, mapFilePath } from '../../../utils/files.js';
 
 export function migrationStrategyForComponentStylesheets(options) {
   const { projectRoot } = options;
 
-  const oldPaths = glob.sync('app/components/**/styles.js', {
+  const oldPaths = findFiles('app/components/**/styles.js', {
     cwd: projectRoot,
   });
 

--- a/src/migration/ember-addon/app/component-templates.js
+++ b/src/migration/ember-addon/app/component-templates.js
@@ -1,11 +1,9 @@
-import glob from 'glob';
-
-import { mapFilePath } from '../../../utils/files.js';
+import { findFiles, mapFilePath } from '../../../utils/files.js';
 
 export function migrationStrategyForComponentTemplates(options) {
   const { projectRoot } = options;
 
-  const oldPaths = glob.sync('app/components/**/template.js', {
+  const oldPaths = findFiles('app/components/**/template.js', {
     cwd: projectRoot,
   });
 

--- a/src/migration/ember-addon/tests/components.js
+++ b/src/migration/ember-addon/tests/components.js
@@ -1,11 +1,9 @@
-import glob from 'glob';
-
-import { mapFilePath } from '../../../utils/files.js';
+import { findFiles, mapFilePath } from '../../../utils/files.js';
 
 export function migrationStrategyForComponents(options) {
   const { projectRoot } = options;
 
-  const oldPaths = glob.sync(
+  const oldPaths = findFiles(
     'tests/integration/components/**/component-test.{js,ts}',
     {
       cwd: projectRoot,

--- a/src/migration/ember-app/app/component-classes.js
+++ b/src/migration/ember-app/app/component-classes.js
@@ -1,13 +1,11 @@
 import { join } from 'node:path';
 
-import glob from 'glob';
-
-import { mapFilePath } from '../../../utils/files.js';
+import { findFiles, mapFilePath } from '../../../utils/files.js';
 
 export function migrationStrategyForComponentClasses(options) {
   const { podPath, projectRoot } = options;
 
-  const oldPaths = glob.sync(
+  const oldPaths = findFiles(
     join('app', podPath, 'components', '**', 'component.{d.ts,js,ts}'),
     {
       cwd: projectRoot,

--- a/src/migration/ember-app/app/component-stylesheets.js
+++ b/src/migration/ember-app/app/component-stylesheets.js
@@ -1,13 +1,11 @@
 import { join } from 'node:path';
 
-import glob from 'glob';
-
-import { mapFilePath } from '../../../utils/files.js';
+import { findFiles, mapFilePath } from '../../../utils/files.js';
 
 export function migrationStrategyForComponentStylesheets(options) {
   const { podPath, projectRoot } = options;
 
-  const oldPaths = glob.sync(
+  const oldPaths = findFiles(
     join('app', podPath, 'components', '**', 'styles.{css,scss}'),
     {
       cwd: projectRoot,

--- a/src/migration/ember-app/app/component-templates.js
+++ b/src/migration/ember-app/app/component-templates.js
@@ -1,13 +1,11 @@
 import { join } from 'node:path';
 
-import glob from 'glob';
-
-import { mapFilePath } from '../../../utils/files.js';
+import { findFiles, mapFilePath } from '../../../utils/files.js';
 
 export function migrationStrategyForComponentTemplates(options) {
   const { podPath, projectRoot } = options;
 
-  const oldPaths = glob.sync(
+  const oldPaths = findFiles(
     join('app', podPath, 'components', '**', 'template.hbs'),
     {
       cwd: projectRoot,

--- a/src/migration/ember-app/app/route-adapters.js
+++ b/src/migration/ember-app/app/route-adapters.js
@@ -1,13 +1,11 @@
 import { join } from 'node:path';
 
-import glob from 'glob';
-
-import { mapFilePath } from '../../../utils/files.js';
+import { findFiles, mapFilePath } from '../../../utils/files.js';
 
 export function migrationStrategyForRouteAdapters(options) {
   const { podPath, projectRoot } = options;
 
-  const oldPaths = glob.sync(join('app', podPath, '**', 'adapter.{js,ts}'), {
+  const oldPaths = findFiles(join('app', podPath, '**', 'adapter.{js,ts}'), {
     cwd: projectRoot,
   });
 

--- a/src/migration/ember-app/app/route-controllers.js
+++ b/src/migration/ember-app/app/route-controllers.js
@@ -1,13 +1,11 @@
 import { join } from 'node:path';
 
-import glob from 'glob';
-
-import { mapFilePath } from '../../../utils/files.js';
+import { findFiles, mapFilePath } from '../../../utils/files.js';
 
 export function migrationStrategyForRouteControllers(options) {
   const { podPath, projectRoot } = options;
 
-  const oldPaths = glob.sync(join('app', podPath, '**', 'controller.{js,ts}'), {
+  const oldPaths = findFiles(join('app', podPath, '**', 'controller.{js,ts}'), {
     cwd: projectRoot,
   });
 

--- a/src/migration/ember-app/app/route-models.js
+++ b/src/migration/ember-app/app/route-models.js
@@ -1,13 +1,11 @@
 import { join } from 'node:path';
 
-import glob from 'glob';
-
-import { mapFilePath } from '../../../utils/files.js';
+import { findFiles, mapFilePath } from '../../../utils/files.js';
 
 export function migrationStrategyForRouteModels(options) {
   const { podPath, projectRoot } = options;
 
-  const oldPaths = glob.sync(join('app', podPath, '**', 'model.{js,ts}'), {
+  const oldPaths = findFiles(join('app', podPath, '**', 'model.{js,ts}'), {
     cwd: projectRoot,
   });
 

--- a/src/migration/ember-app/app/route-routes.js
+++ b/src/migration/ember-app/app/route-routes.js
@@ -1,13 +1,11 @@
 import { join } from 'node:path';
 
-import glob from 'glob';
-
-import { mapFilePath } from '../../../utils/files.js';
+import { findFiles, mapFilePath } from '../../../utils/files.js';
 
 export function migrationStrategyForRouteRoutes(options) {
   const { podPath, projectRoot } = options;
 
-  const oldPaths = glob.sync(join('app', podPath, '**', 'route.{js,ts}'), {
+  const oldPaths = findFiles(join('app', podPath, '**', 'route.{js,ts}'), {
     cwd: projectRoot,
   });
 

--- a/src/migration/ember-app/app/route-serializers.js
+++ b/src/migration/ember-app/app/route-serializers.js
@@ -1,13 +1,11 @@
 import { join } from 'node:path';
 
-import glob from 'glob';
-
-import { mapFilePath } from '../../../utils/files.js';
+import { findFiles, mapFilePath } from '../../../utils/files.js';
 
 export function migrationStrategyForRouteSerializers(options) {
   const { podPath, projectRoot } = options;
 
-  const oldPaths = glob.sync(join('app', podPath, '**', 'serializer.{js,ts}'), {
+  const oldPaths = findFiles(join('app', podPath, '**', 'serializer.{js,ts}'), {
     cwd: projectRoot,
   });
 

--- a/src/migration/ember-app/app/route-stylesheets.js
+++ b/src/migration/ember-app/app/route-stylesheets.js
@@ -1,13 +1,11 @@
 import { join } from 'node:path';
 
-import glob from 'glob';
-
-import { mapFilePath } from '../../../utils/files.js';
+import { findFiles, mapFilePath } from '../../../utils/files.js';
 
 export function migrationStrategyForRouteStylesheets(options) {
   const { podPath, projectRoot } = options;
 
-  const oldPaths = glob.sync(
+  const oldPaths = findFiles(
     join('app', podPath, '!(components)', '**', 'styles.{css,scss}'),
     {
       cwd: projectRoot,

--- a/src/migration/ember-app/app/route-templates.js
+++ b/src/migration/ember-app/app/route-templates.js
@@ -1,13 +1,11 @@
 import { join } from 'node:path';
 
-import glob from 'glob';
-
-import { mapFilePath } from '../../../utils/files.js';
+import { findFiles, mapFilePath } from '../../../utils/files.js';
 
 export function migrationStrategyForRouteTemplates(options) {
   const { podPath, projectRoot } = options;
 
-  const oldPaths = glob.sync(
+  const oldPaths = findFiles(
     join('app', podPath, '!(components)', '**', 'template.hbs'),
     {
       cwd: projectRoot,

--- a/src/migration/ember-app/app/services.js
+++ b/src/migration/ember-app/app/services.js
@@ -1,13 +1,11 @@
 import { join } from 'node:path';
 
-import glob from 'glob';
-
-import { mapFilePath } from '../../../utils/files.js';
+import { findFiles, mapFilePath } from '../../../utils/files.js';
 
 export function migrationStrategyForServices(options) {
   const { podPath, projectRoot } = options;
 
-  const oldPaths = glob.sync(join('app', podPath, '**', 'service.{js,ts}'), {
+  const oldPaths = findFiles(join('app', podPath, '**', 'service.{js,ts}'), {
     cwd: projectRoot,
   });
 

--- a/src/migration/ember-app/tests/components.js
+++ b/src/migration/ember-app/tests/components.js
@@ -1,13 +1,11 @@
 import { join } from 'node:path';
 
-import glob from 'glob';
-
-import { mapFilePath } from '../../../utils/files.js';
+import { findFiles, mapFilePath } from '../../../utils/files.js';
 
 export function migrationStrategyForComponents(options) {
   const { podPath, projectRoot } = options;
 
-  const oldPaths = glob.sync(
+  const oldPaths = findFiles(
     join(
       'tests/integration',
       podPath,

--- a/src/migration/ember-app/tests/route-controllers.js
+++ b/src/migration/ember-app/tests/route-controllers.js
@@ -1,8 +1,6 @@
 import { join } from 'node:path';
 
-import glob from 'glob';
-
-import { mapFilePath } from '../../../utils/files.js';
+import { findFiles, mapFilePath } from '../../../utils/files.js';
 
 export function migrationStrategyForRouteControllers(options) {
   const { podPath, projectRoot } = options;
@@ -10,7 +8,7 @@ export function migrationStrategyForRouteControllers(options) {
   /*
     Case 1: Didn't pass the --pod flag, but configured { usePods: true } in .ember-cli
   */
-  const oldPaths1 = glob.sync(
+  const oldPaths1 = findFiles(
     join(
       'tests/unit',
       podPath,
@@ -50,7 +48,7 @@ export function migrationStrategyForRouteControllers(options) {
   /*
     Case 2: Passed the --pod flag to Ember CLI
   */
-  const oldPaths2 = glob.sync(
+  const oldPaths2 = findFiles(
     join('tests/unit', podPath, 'controllers/**/controller-test.{js,ts}'),
     {
       cwd: projectRoot,

--- a/src/migration/ember-app/tests/route-routes.js
+++ b/src/migration/ember-app/tests/route-routes.js
@@ -1,8 +1,6 @@
 import { join } from 'node:path';
 
-import glob from 'glob';
-
-import { mapFilePath } from '../../../utils/files.js';
+import { findFiles, mapFilePath } from '../../../utils/files.js';
 
 export function migrationStrategyForRouteRoutes(options) {
   const { podPath, projectRoot } = options;
@@ -10,7 +8,7 @@ export function migrationStrategyForRouteRoutes(options) {
   /*
     Case 1: Didn't pass the --pod flag, but configured { usePods: true } in .ember-cli
   */
-  const oldPaths1 = glob.sync(
+  const oldPaths1 = findFiles(
     join('tests/unit', podPath, '!(routes)', '**', 'route-test.{js,ts}'),
     {
       cwd: projectRoot,
@@ -44,7 +42,7 @@ export function migrationStrategyForRouteRoutes(options) {
   /*
     Case 2: Passed the --pod flag to Ember CLI
   */
-  const oldPaths2 = glob.sync(
+  const oldPaths2 = findFiles(
     join('tests/unit', podPath, 'routes/**/route-test.{js,ts}'),
     {
       cwd: projectRoot,

--- a/src/migration/ember-app/tests/services.js
+++ b/src/migration/ember-app/tests/services.js
@@ -1,13 +1,11 @@
 import { join } from 'node:path';
 
-import glob from 'glob';
-
-import { mapFilePath } from '../../../utils/files.js';
+import { findFiles, mapFilePath } from '../../../utils/files.js';
 
 export function migrationStrategyForServices(options) {
   const { podPath, projectRoot } = options;
 
-  const oldPaths = glob.sync(
+  const oldPaths = findFiles(
     join('tests/unit', podPath, '!(services)', '**', 'service-test.{js,ts}'),
     {
       cwd: projectRoot,

--- a/src/migration/ember-engine/addon/component-classes.js
+++ b/src/migration/ember-engine/addon/component-classes.js
@@ -1,11 +1,9 @@
-import glob from 'glob';
-
-import { mapFilePath } from '../../../utils/files.js';
+import { findFiles, mapFilePath } from '../../../utils/files.js';
 
 export function migrationStrategyForComponentClasses(options) {
   const { projectRoot } = options;
 
-  const oldPaths = glob.sync('addon/components/**/component.{d.ts,js,ts}', {
+  const oldPaths = findFiles('addon/components/**/component.{d.ts,js,ts}', {
     cwd: projectRoot,
   });
 

--- a/src/migration/ember-engine/addon/component-stylesheets.js
+++ b/src/migration/ember-engine/addon/component-stylesheets.js
@@ -1,11 +1,9 @@
-import glob from 'glob';
-
-import { mapFilePath } from '../../../utils/files.js';
+import { findFiles, mapFilePath } from '../../../utils/files.js';
 
 export function migrationStrategyForComponentStylesheets(options) {
   const { projectRoot } = options;
 
-  const oldPaths = glob.sync('addon/components/**/styles.{css,scss}', {
+  const oldPaths = findFiles('addon/components/**/styles.{css,scss}', {
     cwd: projectRoot,
   });
 

--- a/src/migration/ember-engine/addon/component-templates.js
+++ b/src/migration/ember-engine/addon/component-templates.js
@@ -1,11 +1,9 @@
-import glob from 'glob';
-
-import { mapFilePath } from '../../../utils/files.js';
+import { findFiles, mapFilePath } from '../../../utils/files.js';
 
 export function migrationStrategyForComponentTemplates(options) {
   const { projectRoot } = options;
 
-  const oldPaths = glob.sync('addon/components/**/template.hbs', {
+  const oldPaths = findFiles('addon/components/**/template.hbs', {
     cwd: projectRoot,
   });
 

--- a/src/migration/ember-engine/addon/route-controllers.js
+++ b/src/migration/ember-engine/addon/route-controllers.js
@@ -1,11 +1,9 @@
-import glob from 'glob';
-
-import { mapFilePath } from '../../../utils/files.js';
+import { findFiles, mapFilePath } from '../../../utils/files.js';
 
 export function migrationStrategyForRouteControllers(options) {
   const { projectRoot } = options;
 
-  const oldPaths = glob.sync('addon/**/controller.{js,ts}', {
+  const oldPaths = findFiles('addon/**/controller.{js,ts}', {
     cwd: projectRoot,
   });
 

--- a/src/migration/ember-engine/addon/route-routes.js
+++ b/src/migration/ember-engine/addon/route-routes.js
@@ -1,11 +1,9 @@
-import glob from 'glob';
-
-import { mapFilePath } from '../../../utils/files.js';
+import { findFiles, mapFilePath } from '../../../utils/files.js';
 
 export function migrationStrategyForRouteRoutes(options) {
   const { projectRoot } = options;
 
-  const oldPaths = glob.sync('addon/**/route.{js,ts}', {
+  const oldPaths = findFiles('addon/**/route.{js,ts}', {
     cwd: projectRoot,
   });
 

--- a/src/migration/ember-engine/addon/route-stylesheets.js
+++ b/src/migration/ember-engine/addon/route-stylesheets.js
@@ -1,11 +1,9 @@
-import glob from 'glob';
-
-import { mapFilePath } from '../../../utils/files.js';
+import { findFiles, mapFilePath } from '../../../utils/files.js';
 
 export function migrationStrategyForRouteStylesheets(options) {
   const { projectRoot } = options;
 
-  const oldPaths = glob.sync('addon/!(components)/**/styles.{css,scss}', {
+  const oldPaths = findFiles('addon/!(components)/**/styles.{css,scss}', {
     cwd: projectRoot,
   });
 

--- a/src/migration/ember-engine/addon/route-templates.js
+++ b/src/migration/ember-engine/addon/route-templates.js
@@ -1,11 +1,9 @@
-import glob from 'glob';
-
-import { mapFilePath } from '../../../utils/files.js';
+import { findFiles, mapFilePath } from '../../../utils/files.js';
 
 export function migrationStrategyForRouteTemplates(options) {
   const { projectRoot } = options;
 
-  const oldPaths = glob.sync('addon/!(components)/**/template.hbs', {
+  const oldPaths = findFiles('addon/!(components)/**/template.hbs', {
     cwd: projectRoot,
   });
 

--- a/src/migration/ember-engine/steps/update-absolute-paths.js
+++ b/src/migration/ember-engine/steps/update-absolute-paths.js
@@ -1,7 +1,7 @@
 import { readFileSync, writeFileSync } from 'node:fs';
 import { join, parse } from 'node:path';
 
-import glob from 'glob';
+import { findFiles } from '../../../utils/files.js';
 
 function removeFileExtension(path) {
   const { dir, name } = parse(path);
@@ -73,10 +73,8 @@ function updatePaths(mapping, options) {
 
   // File extensions had been specified, partly to encode assumptions
   // about Ember, and partly to avoid corrupting non-text files
-  const filePaths = glob.sync('{addon,tests}/**/*.{d.ts,js,ts}', {
+  const filePaths = findFiles('{addon,tests}/**/*.{d.ts,js,ts}', {
     cwd: projectRoot,
-    dot: true,
-    nodir: true,
   });
 
   filePaths.forEach((filePath) => {

--- a/src/migration/ember-engine/steps/use-absolute-paths.js
+++ b/src/migration/ember-engine/steps/use-absolute-paths.js
@@ -1,7 +1,7 @@
 import { readFileSync, writeFileSync } from 'node:fs';
 import { dirname, join, relative, resolve } from 'node:path';
 
-import glob from 'glob';
+import { findFiles } from '../../../utils/files.js';
 
 function removeRelativePaths(oldFile, { filePath, projectName, projectRoot }) {
   const regex = new RegExp(`(?:'|")(.{1,2}/(.*))(?:'|")`, 'g');
@@ -35,10 +35,8 @@ function updatePaths(options) {
 
   // File extensions had been specified, partly to encode assumptions
   // about Ember, and partly to avoid corrupting non-text files
-  const filePaths = glob.sync('{addon,tests}/**/*.{d.ts,js,ts}', {
+  const filePaths = findFiles('{addon,tests}/**/*.{d.ts,js,ts}', {
     cwd: projectRoot,
-    dot: true,
-    nodir: true,
   });
 
   filePaths.forEach((filePath) => {

--- a/src/migration/ember-engine/steps/use-relative-paths.js
+++ b/src/migration/ember-engine/steps/use-relative-paths.js
@@ -1,7 +1,7 @@
 import { readFileSync, writeFileSync } from 'node:fs';
 import { dirname, join, relative } from 'node:path';
 
-import glob from 'glob';
+import { findFiles } from '../../../utils/files.js';
 
 function normalizeRelativePath(relativePath) {
   if (relativePath.startsWith('..')) {
@@ -38,10 +38,8 @@ function useRelativePathInAddonFolder(options) {
 
   // File extensions had been specified, partly to encode assumptions
   // about Ember, and partly to avoid corrupting non-text files
-  const filePaths = glob.sync('addon/**/*.{d.ts,js,ts}', {
+  const filePaths = findFiles('addon/**/*.{d.ts,js,ts}', {
     cwd: projectRoot,
-    dot: true,
-    nodir: true,
   });
 
   filePaths.forEach((filePath) => {
@@ -63,11 +61,9 @@ function useRelativePathInTestsFolder(options) {
 
   // File extensions had been specified, partly to encode assumptions
   // about Ember, and partly to avoid corrupting non-text files
-  const filePaths = glob.sync('tests/**/*.{d.ts,js,ts}', {
+  const filePaths = findFiles('tests/**/*.{d.ts,js,ts}', {
     cwd: projectRoot,
-    dot: true,
-    ignore: 'tests/dummy/**/*',
-    nodir: true,
+    ignoreList: ['tests/dummy/**/*'],
   });
 
   filePaths.forEach((filePath) => {
@@ -89,10 +85,8 @@ function useRelativePathInTestsDummyFolder(options) {
 
   // File extensions had been specified, partly to encode assumptions
   // about Ember, and partly to avoid corrupting non-text files
-  const filePaths = glob.sync('tests/dummy/**/*.{d.ts,js,ts}', {
+  const filePaths = findFiles('tests/dummy/**/*.{d.ts,js,ts}', {
     cwd: projectRoot,
-    dot: true,
-    nodir: true,
   });
 
   filePaths.forEach((filePath) => {

--- a/src/migration/ember-engine/tests/components.js
+++ b/src/migration/ember-engine/tests/components.js
@@ -1,11 +1,9 @@
-import glob from 'glob';
-
-import { mapFilePath } from '../../../utils/files.js';
+import { findFiles, mapFilePath } from '../../../utils/files.js';
 
 export function migrationStrategyForComponents(options) {
   const { projectRoot } = options;
 
-  const oldPaths = glob.sync(
+  const oldPaths = findFiles(
     'tests/integration/components/**/component-test.{js,ts}',
     {
       cwd: projectRoot,

--- a/src/migration/ember-engine/tests/route-controllers.js
+++ b/src/migration/ember-engine/tests/route-controllers.js
@@ -1,6 +1,4 @@
-import glob from 'glob';
-
-import { mapFilePath } from '../../../utils/files.js';
+import { findFiles, mapFilePath } from '../../../utils/files.js';
 
 export function migrationStrategyForRouteControllers(options) {
   const { projectRoot } = options;
@@ -8,7 +6,7 @@ export function migrationStrategyForRouteControllers(options) {
   /*
     Case 1: Didn't pass the --pod flag, but configured { usePods: true } in .ember-cli
   */
-  const oldPaths1 = glob.sync(
+  const oldPaths1 = findFiles(
     'tests/unit/!(controllers)/**/controller-test.{js,ts}',
     {
       cwd: projectRoot,
@@ -42,7 +40,7 @@ export function migrationStrategyForRouteControllers(options) {
   /*
     Case 2: Passed the --pod flag to Ember CLI
   */
-  const oldPaths2 = glob.sync(
+  const oldPaths2 = findFiles(
     'tests/unit/controllers/**/controller-test.{js,ts}',
     {
       cwd: projectRoot,

--- a/src/migration/ember-engine/tests/route-routes.js
+++ b/src/migration/ember-engine/tests/route-routes.js
@@ -1,6 +1,4 @@
-import glob from 'glob';
-
-import { mapFilePath } from '../../../utils/files.js';
+import { findFiles, mapFilePath } from '../../../utils/files.js';
 
 export function migrationStrategyForRouteRoutes(options) {
   const { projectRoot } = options;
@@ -8,7 +6,7 @@ export function migrationStrategyForRouteRoutes(options) {
   /*
     Case 1: Didn't pass the --pod flag, but configured { usePods: true } in .ember-cli
   */
-  const oldPaths1 = glob.sync('tests/unit/!(routes)/**/route-test.{js,ts}', {
+  const oldPaths1 = findFiles('tests/unit/!(routes)/**/route-test.{js,ts}', {
     cwd: projectRoot,
   });
 
@@ -39,7 +37,7 @@ export function migrationStrategyForRouteRoutes(options) {
   /*
     Case 2: Passed the --pod flag to Ember CLI
   */
-  const oldPaths2 = glob.sync('tests/unit/routes/**/route-test.{js,ts}', {
+  const oldPaths2 = findFiles('tests/unit/routes/**/route-test.{js,ts}', {
     cwd: projectRoot,
   });
 

--- a/src/utils/files.js
+++ b/src/utils/files.js
@@ -1,3 +1,4 @@
+export * from './files/find-files.js';
 export * from './files/map-file-path.js';
 export * from './files/move-files.js';
 export * from './files/remove-directory-if-empty.js';

--- a/src/utils/files/find-files.js
+++ b/src/utils/files/find-files.js
@@ -1,0 +1,28 @@
+import glob from 'glob';
+
+export function findFiles(pattern, { cwd, ignoreList = [] }) {
+  if (!pattern) {
+    throw new RangeError('ERROR: The glob pattern is unknown.\n');
+  }
+
+  if (!cwd) {
+    throw new RangeError('ERROR: The current working directory is unknown.\n');
+  }
+
+  const filePaths = glob.sync(pattern, {
+    cwd,
+    dot: true,
+    ignore: ignoreList,
+    nodir: true,
+  });
+
+  return filePaths;
+}
+
+export function unionize(files) {
+  if (files.length <= 1) {
+    return files.join(',');
+  }
+
+  return `{${files.join(',')}}`;
+}

--- a/tests/helpers/testing/convert-fixture-to-json.js
+++ b/tests/helpers/testing/convert-fixture-to-json.js
@@ -3,12 +3,12 @@ import { join } from 'node:path';
 
 import glob from 'glob';
 
-function updateJson(json, { keys, projectRoot }) {
+function updateJson(json, { currentDirectory, keys }) {
   const key = keys.shift();
   const isFile = keys.length === 0;
 
   if (isFile) {
-    json[key] = readFileSync(join(projectRoot, key), 'utf8');
+    json[key] = readFileSync(join(currentDirectory, key), 'utf8');
 
     return;
   }
@@ -18,31 +18,31 @@ function updateJson(json, { keys, projectRoot }) {
   }
 
   updateJson(json[key], {
+    currentDirectory: join(currentDirectory, key),
     keys,
-    projectRoot: join(projectRoot, key),
   });
 }
 
-function createJson(filePaths = [], projectRoot) {
+function createJson(filePaths = [], currentDirectory) {
   const json = {};
 
   filePaths.forEach((filePath) => {
     const keys = filePath.split('/');
 
-    updateJson(json, { keys, projectRoot });
+    updateJson(json, { currentDirectory, keys });
   });
 
   return json;
 }
 
 export function convertFixtureToJson(projectRoot) {
-  const absolutePath = `${process.cwd()}/tests/fixtures/${projectRoot}`;
+  const currentDirectory = `${process.cwd()}/tests/fixtures/${projectRoot}`;
 
   const filePaths = glob.sync('**/*', {
-    cwd: absolutePath,
+    cwd: currentDirectory,
     dot: true,
     nodir: true,
   });
 
-  return createJson(filePaths, absolutePath);
+  return createJson(filePaths, currentDirectory);
 }

--- a/tests/utils/files/find-files.test.js
+++ b/tests/utils/files/find-files.test.js
@@ -1,0 +1,57 @@
+import { findFiles } from '../../../src/utils/files.js';
+import { codemodOptions } from '../../helpers/shared-test-setups/ember-addon/typescript.js';
+import { assert, loadFixture, test } from '../../helpers/testing.js';
+
+test('utils | files | find-files', function () {
+  const inputProject = {
+    tests: {
+      dummy: {
+        app: {
+          '.eslintrc.js': '',
+          'app.ts': '',
+          'index.html': '',
+          'router.ts': '',
+        },
+        config: {
+          'environment.js': '',
+          'optional-features.json': '',
+          'targets.js': '',
+        },
+      },
+      integration: {
+        components: {
+          'container-query-test.ts': '',
+        },
+      },
+      'index.html': '',
+      'test-helper.ts': '',
+    },
+    'ember-cli-build.js': '',
+    'index.js': '',
+    'package.json': '',
+  };
+
+  loadFixture(inputProject, codemodOptions);
+
+  let filePaths = findFiles('tests/dummy/**/*.{js,ts}', {
+    cwd: codemodOptions.projectRoot,
+  });
+
+  assert.deepStrictEqual(filePaths.sort(), [
+    'tests/dummy/app/.eslintrc.js',
+    'tests/dummy/app/app.ts',
+    'tests/dummy/app/router.ts',
+    'tests/dummy/config/environment.js',
+    'tests/dummy/config/targets.js',
+  ]);
+
+  filePaths = findFiles('tests/**/*.{js,ts}', {
+    cwd: codemodOptions.projectRoot,
+    ignoreList: ['tests/dummy/**/*'],
+  });
+
+  assert.deepStrictEqual(filePaths.sort(), [
+    'tests/integration/components/container-query-test.ts',
+    'tests/test-helper.ts',
+  ]);
+});


### PR DESCRIPTION
## Description

In anticipation of updating `glob` to `v10` (only named imports will be allowed), I created the wrapper function `findFiles` so that the use of `glob.sync` is limited to two (2) places.


## References

- https://github.com/ijlee2/ember-codemod-v1-to-v2/pull/24
- https://github.com/isaacs/node-glob/blob/v10.2.2/changelog.md?plain=1#L14-L16