### PR TITLE
Replace assert.deepEqual with assert.deepStrictEqual

### DIFF
--- a/tests/migration/ember-addon/steps/create-options/javascript.test.js
+++ b/tests/migration/ember-addon/steps/create-options/javascript.test.js
@@ -20,5 +20,5 @@ test('migration | ember-addon | steps | create-options > javascript', function (
 
   loadFixture(inputProject, codemodOptions);
 
-  assert.deepEqual(createOptions(codemodOptions), options);
+  assert.deepStrictEqual(createOptions(codemodOptions), options);
 });

--- a/tests/migration/ember-app/steps/create-options/javascript.test.js
+++ b/tests/migration/ember-app/steps/create-options/javascript.test.js
@@ -20,5 +20,5 @@ test('migration | ember-app | steps | create-options > javascript', function () 
 
   loadFixture(inputProject, codemodOptions);
 
-  assert.deepEqual(createOptions(codemodOptions), options);
+  assert.deepStrictEqual(createOptions(codemodOptions), options);
 });

--- a/tests/migration/ember-engine/steps/create-options/javascript.test.js
+++ b/tests/migration/ember-engine/steps/create-options/javascript.test.js
@@ -20,5 +20,5 @@ test('migration | ember-engine | steps | create-options > javascript', function 
 
   loadFixture(inputProject, codemodOptions);
 
-  assert.deepEqual(createOptions(codemodOptions), options);
+  assert.deepStrictEqual(createOptions(codemodOptions), options);
 });


### PR DESCRIPTION
## Description

While [documenting `@codemod-utils/tests`](https://github.com/ijlee2/codemod-utils/pull/11), I learned that `assert.deepEqual` is an alias of `assert.deepStrictEqual` and the latter should be used to avoid unexpected results.

> **Strict assertion mode**
>
> An alias of [assert.deepStrictEqual()](https://nodejs.org/api/assert.html#assertdeepstrictequalactual-expected-message).
>
> **Legacy assertion mode**
> 
> [Stability: 3](https://nodejs.org/api/documentation.html#stability-index) - Legacy: Use [assert.deepStrictEqual()](https://nodejs.org/api/assert.html#assertdeepstrictequalactual-expected-message) instead.
>
> Tests for deep equality between the actual and expected parameters. Consider using [assert.deepStrictEqual()](https://nodejs.org/api/assert.html#assertdeepstrictequalactual-expected-message) instead. [assert.deepEqual()](https://nodejs.org/api/assert.html#assertdeepequalactual-expected-message) can have surprising results.

https://nodejs.org/api/assert.html#assertdeepequalactual-expected-message