### PR TITLE
Patch #33

### DIFF
--- a/bin/ember-codemod-pod-to-octane.ts
+++ b/bin/ember-codemod-pod-to-octane.ts
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+// eslint-disable-next-line n/shebang
 'use strict';
 
 import yargs from 'yargs';

--- a/package.json
+++ b/package.json
@@ -15,16 +15,8 @@
   "license": "MIT",
   "author": "Isaac J. Lee",
   "type": "module",
-  "main": "dist/src/index.js",
-  "types": "dist/src/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "*": [
-        "dist/*"
-      ]
-    }
-  },
-  "bin": "dist/bin/ember-codemod-pod-to-octane.js",
+  "main": "src/index.js",
+  "bin": "bin/ember-codemod-pod-to-octane.js",
   "directories": {
     "test": "tests"
   },


### PR DESCRIPTION
## Description

Adding a shebang (the line was removed in tag `1.2.0`) may help fix this error:

```sh
❯ npx ember-codemod-pod-to-octane@1.2.1 
Need to install the following packages:
  ember-codemod-pod-to-octane@1.2.1
Ok to proceed? (y) 
/.npm/_npx/11ff915a70f84420/node_modules/.bin/ember-codemod-pod-to-octane: line 1: use strict: command not found

import: delegate library support not built-in '' (X11) @ error/import.c/ImportImageCommand/1302.

import: delegate library support not built-in '' (X11) @ error/import.c/ImportImageCommand/1302.
/.npm/_npx/11ff915a70f84420/node_modules/.bin/ember-codemod-pod-to-octane: line 5: //: is a directory
/.npm/_npx/11ff915a70f84420/node_modules/.bin/ember-codemod-pod-to-octane: line 6: process.title: command not found
/.npm/_npx/11ff915a70f84420/node_modules/.bin/ember-codemod-pod-to-octane: line 7: //: is a directory
/.npm/_npx/11ff915a70f84420/node_modules/.bin/ember-codemod-pod-to-octane: line 8: syntax error near unexpected token `('
/.npm/_npx/11ff915a70f84420/node_modules/.bin/ember-codemod-pod-to-octane: line 8: `const argv = yargs(hideBin(process.argv))'
```