### PR TITLE
Allowed running the codemod locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,10 +115,13 @@ To better meet your needs, consider cloning the repo and running the codemod loc
 
 ```sh
 cd <your/cloned/repo>
-npx ts-node ./bin/ember-codemod-pod-to-octane.js --root=<your/project/path>
-```
 
-⚠️ At the moment, it is not possible to run the codemod locally, because `ts-node@10.9.1` doesn't support `typescript@v5` correctly. You can track the progress in [#32](https://github.com/ijlee2/ember-codemod-pod-to-octane/issues/32).
+# Compile TypeScript
+pnpm build
+
+# Run codemod
+./dist/bin/ember-codemod-pod-to-octane.js --root=<your/project/path>
+```
 
 
 ## Compatibility

--- a/codemod-test-fixture.sh
+++ b/codemod-test-fixture.sh
@@ -50,7 +50,7 @@ fi
 rm -r "tests/fixtures/$FIXTURE/output"
 cp -r "tests/fixtures/$FIXTURE/input" "tests/fixtures/$FIXTURE/output"
 
-./bin/ember-codemod-pod-to-octane.js \
+./dist/bin/ember-codemod-pod-to-octane.js \
   --pod-path=$POD_PATH \
   --root="tests/fixtures/$FIXTURE/output" \
   --test=false \

--- a/codemod-test-fixtures.sh
+++ b/codemod-test-fixtures.sh
@@ -12,6 +12,9 @@
 #
 #---------
 
+# Compile TypeScript
+pnpm build
+
 ./codemod-test-fixture.sh -t "addon" ember-addon/javascript
 ./codemod-test-fixture.sh -t "addon" ember-addon/sass
 ./codemod-test-fixture.sh -t "addon" ember-addon/typescript

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsc --project tsconfig.build.json",
+    "build": "tsc --project tsconfig.build.json && chmod +x dist/bin/ember-codemod-pod-to-octane.js",
     "changelog": "lerna-changelog",
     "lint": "concurrently \"npm:lint:*(!fix)\" --names \"lint:\"",
     "lint:fix": "concurrently \"npm:lint:*:fix\" --names \"fix:\"",


### PR DESCRIPTION
## Description

Fixes #32. By pointing to `dist/bin` instead of `bin`, I was able to get run the codemod as well as `./codemod-test-fixtures.sh`.