### PR TITLE
Removed references to a migration strategy

### DIFF
--- a/src/migration/ember-addon/steps/create-file-path-maps.ts
+++ b/src/migration/ember-addon/steps/create-file-path-maps.ts
@@ -5,13 +5,13 @@ import { mapAddonFolder } from './create-file-path-maps/addon/index.js';
 import { mapAppFolder } from './create-file-path-maps/app/index.js';
 import { mapTestsFolder } from './create-file-path-maps/tests/index.js';
 
-type MigrationStrategies = {
+type FilePathMaps = {
   addon: FilePathMap;
   app: FilePathMap;
   tests: FilePathMap;
 };
 
-export function createFilePathMaps(options: Options): MigrationStrategies {
+export function createFilePathMaps(options: Options): FilePathMaps {
   return {
     addon: mapAddonFolder(options),
     app: mapAppFolder(options),

--- a/src/migration/ember-addon/steps/update-paths-in-app-folder.ts
+++ b/src/migration/ember-addon/steps/update-paths-in-app-folder.ts
@@ -4,26 +4,19 @@ import { join } from 'node:path';
 import type { FilePathMap, Options } from '../../../types/index.js';
 
 export function updatePathsInAppFolder(
-  migrationStrategy: FilePathMap,
+  filePathMap: FilePathMap,
   options: Options,
 ): void {
   const { projectRoot } = options;
 
-  migrationStrategy.forEach((newFilePath, oldFilePath) => {
-    // Read file
+  filePathMap.forEach((newFilePath, oldFilePath) => {
     const newAbsolutePath = join(projectRoot, newFilePath);
     const file = readFileSync(newAbsolutePath, 'utf8');
 
-    // Update file
-    const oldRelativePath = oldFilePath
-      .replace(/^app\//, '')
-      .replace(/\.js$/, '');
+    const text = oldFilePath.replace(/^app\//, '').replace(/\.js$/, '');
+    const newText = newFilePath.replace(/^app\//, '').replace(/\.js$/, '');
+    const newFile = file.replace(new RegExp(text), newText);
 
-    const newRelativePath = newFilePath
-      .replace(/^app\//, '')
-      .replace(/\.js$/, '');
-
-    const newFile = file.replace(new RegExp(oldRelativePath), newRelativePath);
     writeFileSync(newAbsolutePath, newFile, 'utf8');
   });
 }

--- a/src/migration/ember-app/steps/create-file-path-maps.ts
+++ b/src/migration/ember-app/steps/create-file-path-maps.ts
@@ -4,12 +4,12 @@ import type { Options } from '../../../types/index.js';
 import { mapAppFolder } from './create-file-path-maps/app/index.js';
 import { mapTestsFolder } from './create-file-path-maps/tests/index.js';
 
-type MigrationStrategies = {
+type FilePathMaps = {
   app: FilePathMap;
   tests: FilePathMap;
 };
 
-export function createFilePathMaps(options: Options): MigrationStrategies {
+export function createFilePathMaps(options: Options): FilePathMaps {
   return {
     app: mapAppFolder(options),
     tests: mapTestsFolder(options),

--- a/src/migration/ember-engine/steps/create-file-path-maps.ts
+++ b/src/migration/ember-engine/steps/create-file-path-maps.ts
@@ -4,12 +4,12 @@ import type { Options } from '../../../types/index.js';
 import { mapAddonFolder } from './create-file-path-maps/addon/index.js';
 import { mapTestsFolder } from './create-file-path-maps/tests/index.js';
 
-type MigrationStrategies = {
+type FilePathMaps = {
   addon: FilePathMap;
   tests: FilePathMap;
 };
 
-export function createFilePathMaps(options: Options): MigrationStrategies {
+export function createFilePathMaps(options: Options): FilePathMaps {
   return {
     addon: mapAddonFolder(options),
     tests: mapTestsFolder(options),

--- a/tests/migration/ember-addon/steps/update-paths-in-app-folder/javascript.test.ts
+++ b/tests/migration/ember-addon/steps/update-paths-in-app-folder/javascript.test.ts
@@ -38,16 +38,16 @@ test('migration | ember-addon | steps | update-paths-in-app-folder > javascript'
 
   loadFixture(inputProject, codemodOptions);
 
-  const migrationStrategy = new Map([
+  const filePathMap = new Map([
     [
       'app/components/ui/form/checkbox/component.js',
       'app/components/ui/form/checkbox.js',
     ],
   ]);
 
-  moveFiles(migrationStrategy, options);
+  moveFiles(filePathMap, options);
 
-  updatePathsInAppFolder(migrationStrategy, options);
+  updatePathsInAppFolder(filePathMap, options);
 
   assertFixture(outputProject, codemodOptions);
 });


### PR DESCRIPTION
## Description

Patches #43. There were still a few references to a "migration strategy." I replaced these with the term "file path map."
