### PR TITLE
Incremental pod support

### DIFF
--- a/bin/ember-codemod-pod-to-octane.ts
+++ b/bin/ember-codemod-pod-to-octane.ts
@@ -12,6 +12,11 @@ process.title = 'ember-codemod-pod-to-octane';
 
 // Set codemod options
 const argv = yargs(hideBin(process.argv))
+  .option('pod', {
+    default: '',
+    describe: 'A specific pod to migrate instead of migrating all pods',
+    type: 'string',
+  })
   .option('pod-path', {
     default: '',
     describe: 'Namespace used for the pod layout',
@@ -35,6 +40,7 @@ const argv = yargs(hideBin(process.argv))
   .parseSync();
 
 const codemodOptions: CodemodOptions = {
+  pod: argv['pod'],
   podPath: argv['pod-path'],
   projectRoot: argv['root'] ?? process.cwd(),
   projectType: argv['type'],

--- a/src/migration/ember-addon/steps/create-options.ts
+++ b/src/migration/ember-addon/steps/create-options.ts
@@ -2,6 +2,7 @@ import type { CodemodOptions, Options } from '../../../types/index.js';
 
 export function createOptions(codemodOptions: CodemodOptions): Options {
   return {
+    pod: codemodOptions.pod,
     podPath: codemodOptions.podPath,
     projectRoot: codemodOptions.projectRoot,
     projectType: codemodOptions.projectType,

--- a/src/migration/ember-app/steps/create-file-path-maps/app/map-component-classes.ts
+++ b/src/migration/ember-app/steps/create-file-path-maps/app/map-component-classes.ts
@@ -9,10 +9,10 @@ import type {
 import { renamePodPath } from '../../../../../utils/files/index.js';
 
 export function mapComponentClasses(options: Options): FilePathMapEntries {
-  const { podPath, projectRoot } = options;
+  const { pod, podPath, projectRoot } = options;
 
   const filePaths = findFiles(
-    join('app', podPath, 'components', '**', 'component.{d.ts,js,ts}'),
+    join('app', podPath, pod, 'components', '**', 'component.{d.ts,js,ts}'),
     {
       projectRoot,
     },

--- a/src/migration/ember-app/steps/create-file-path-maps/app/map-component-classes.ts
+++ b/src/migration/ember-app/steps/create-file-path-maps/app/map-component-classes.ts
@@ -12,7 +12,7 @@ export function mapComponentClasses(options: Options): FilePathMapEntries {
   const { pod, podPath, projectRoot } = options;
 
   const filePaths = findFiles(
-    join('app', podPath, pod, 'components', '**', 'component.{d.ts,js,ts}'),
+    join('app', podPath, 'components', pod, '**', 'component.{d.ts,js,ts}'),
     {
       projectRoot,
     },

--- a/src/migration/ember-app/steps/create-file-path-maps/app/map-component-stylesheets.ts
+++ b/src/migration/ember-app/steps/create-file-path-maps/app/map-component-stylesheets.ts
@@ -12,7 +12,7 @@ export function mapComponentStylesheets(options: Options): FilePathMapEntries {
   const { pod, podPath, projectRoot } = options;
 
   const filePaths = findFiles(
-    join('app', podPath, pod, 'components', '**', 'styles.{css,scss}'),
+    join('app', podPath, 'components', pod, '**', 'styles.{css,scss}'),
     {
       projectRoot,
     },

--- a/src/migration/ember-app/steps/create-file-path-maps/app/map-component-stylesheets.ts
+++ b/src/migration/ember-app/steps/create-file-path-maps/app/map-component-stylesheets.ts
@@ -9,10 +9,10 @@ import type {
 import { renamePodPath } from '../../../../../utils/files/index.js';
 
 export function mapComponentStylesheets(options: Options): FilePathMapEntries {
-  const { podPath, projectRoot } = options;
+  const { pod, podPath, projectRoot } = options;
 
   const filePaths = findFiles(
-    join('app', podPath, 'components', '**', 'styles.{css,scss}'),
+    join('app', podPath, pod, 'components', '**', 'styles.{css,scss}'),
     {
       projectRoot,
     },

--- a/src/migration/ember-app/steps/create-file-path-maps/app/map-component-templates.ts
+++ b/src/migration/ember-app/steps/create-file-path-maps/app/map-component-templates.ts
@@ -12,7 +12,7 @@ export function mapComponentTemplates(options: Options): FilePathMapEntries {
   const { pod, podPath, projectRoot } = options;
 
   const filePaths = findFiles(
-    join('app', podPath, pod, 'components', '**', 'template.hbs'),
+    join('app', podPath, 'components', pod, '**', 'template.hbs'),
     {
       projectRoot,
     },

--- a/src/migration/ember-app/steps/create-file-path-maps/app/map-component-templates.ts
+++ b/src/migration/ember-app/steps/create-file-path-maps/app/map-component-templates.ts
@@ -9,10 +9,10 @@ import type {
 import { renamePodPath } from '../../../../../utils/files/index.js';
 
 export function mapComponentTemplates(options: Options): FilePathMapEntries {
-  const { podPath, projectRoot } = options;
+  const { pod, podPath, projectRoot } = options;
 
   const filePaths = findFiles(
-    join('app', podPath, 'components', '**', 'template.hbs'),
+    join('app', podPath, pod, 'components', '**', 'template.hbs'),
     {
       projectRoot,
     },

--- a/src/migration/ember-app/steps/create-file-path-maps/app/map-route-adapters.ts
+++ b/src/migration/ember-app/steps/create-file-path-maps/app/map-route-adapters.ts
@@ -9,9 +9,9 @@ import type {
 import { renamePodPath } from '../../../../../utils/files/index.js';
 
 export function mapRouteAdapters(options: Options): FilePathMapEntries {
-  const { podPath, projectRoot } = options;
+  const { pod, podPath, projectRoot } = options;
 
-  const filePaths = findFiles(join('app', podPath, '**', 'adapter.{js,ts}'), {
+  const filePaths = findFiles(join('app', podPath, pod, '**', 'adapter.{js,ts}'), {
     projectRoot,
   });
 

--- a/src/migration/ember-app/steps/create-file-path-maps/app/map-route-adapters.ts
+++ b/src/migration/ember-app/steps/create-file-path-maps/app/map-route-adapters.ts
@@ -11,9 +11,12 @@ import { renamePodPath } from '../../../../../utils/files/index.js';
 export function mapRouteAdapters(options: Options): FilePathMapEntries {
   const { pod, podPath, projectRoot } = options;
 
-  const filePaths = findFiles(join('app', podPath, pod, '**', 'adapter.{js,ts}'), {
-    projectRoot,
-  });
+  const filePaths = findFiles(
+    join('app', podPath, pod, '**', 'adapter.{js,ts}'),
+    {
+      projectRoot,
+    },
+  );
 
   return filePaths.map((oldFilePath) => {
     const newFilePath = renamePodPath(oldFilePath, {

--- a/src/migration/ember-app/steps/create-file-path-maps/app/map-route-controllers.ts
+++ b/src/migration/ember-app/steps/create-file-path-maps/app/map-route-controllers.ts
@@ -9,10 +9,10 @@ import type {
 import { renamePodPath } from '../../../../../utils/files/index.js';
 
 export function mapRouteControllers(options: Options): FilePathMapEntries {
-  const { podPath, projectRoot } = options;
+  const { pod, podPath, projectRoot } = options;
 
   const filePaths = findFiles(
-    join('app', podPath, '**', 'controller.{js,ts}'),
+    join('app', podPath, pod, '**', 'controller.{js,ts}'),
     {
       projectRoot,
     },

--- a/src/migration/ember-app/steps/create-file-path-maps/app/map-route-models.ts
+++ b/src/migration/ember-app/steps/create-file-path-maps/app/map-route-models.ts
@@ -11,9 +11,12 @@ import { renamePodPath } from '../../../../../utils/files/index.js';
 export function mapRouteModels(options: Options): FilePathMapEntries {
   const { pod, podPath, projectRoot } = options;
 
-  const filePaths = findFiles(join('app', podPath, pod, '**', 'model.{js,ts}'), {
-    projectRoot,
-  });
+  const filePaths = findFiles(
+    join('app', podPath, pod, '**', 'model.{js,ts}'),
+    {
+      projectRoot,
+    },
+  );
 
   return filePaths.map((oldFilePath) => {
     const newFilePath = renamePodPath(oldFilePath, {

--- a/src/migration/ember-app/steps/create-file-path-maps/app/map-route-models.ts
+++ b/src/migration/ember-app/steps/create-file-path-maps/app/map-route-models.ts
@@ -9,9 +9,9 @@ import type {
 import { renamePodPath } from '../../../../../utils/files/index.js';
 
 export function mapRouteModels(options: Options): FilePathMapEntries {
-  const { podPath, projectRoot } = options;
+  const { pod, podPath, projectRoot } = options;
 
-  const filePaths = findFiles(join('app', podPath, '**', 'model.{js,ts}'), {
+  const filePaths = findFiles(join('app', podPath, pod, '**', 'model.{js,ts}'), {
     projectRoot,
   });
 

--- a/src/migration/ember-app/steps/create-file-path-maps/app/map-route-routes.ts
+++ b/src/migration/ember-app/steps/create-file-path-maps/app/map-route-routes.ts
@@ -9,11 +9,14 @@ import type {
 import { renamePodPath } from '../../../../../utils/files/index.js';
 
 export function mapRouteRoutes(options: Options): FilePathMapEntries {
-  const { podPath, projectRoot } = options;
+  const { pod, podPath, projectRoot } = options;
 
-  const filePaths = findFiles(join('app', podPath, '**', 'route.{js,ts}'), {
-    projectRoot,
-  });
+  const filePaths = findFiles(
+    join('app', podPath, pod, '**', 'route.{js,ts}'),
+    {
+      projectRoot,
+    },
+  );
 
   return filePaths.map((oldFilePath) => {
     const newFilePath = renamePodPath(oldFilePath, {

--- a/src/migration/ember-app/steps/create-file-path-maps/app/map-route-serializers.ts
+++ b/src/migration/ember-app/steps/create-file-path-maps/app/map-route-serializers.ts
@@ -9,10 +9,10 @@ import type {
 import { renamePodPath } from '../../../../../utils/files/index.js';
 
 export function mapRouteSerializers(options: Options): FilePathMapEntries {
-  const { podPath, projectRoot } = options;
+  const { pod, podPath, projectRoot } = options;
 
   const filePaths = findFiles(
-    join('app', podPath, '**', 'serializer.{js,ts}'),
+    join('app', podPath, pod, '**', 'serializer.{js,ts}'),
     {
       projectRoot,
     },

--- a/src/migration/ember-app/steps/create-file-path-maps/app/map-route-stylesheets.ts
+++ b/src/migration/ember-app/steps/create-file-path-maps/app/map-route-stylesheets.ts
@@ -9,10 +9,10 @@ import type {
 import { renamePodPath } from '../../../../../utils/files/index.js';
 
 export function mapRouteStylesheets(options: Options): FilePathMapEntries {
-  const { podPath, projectRoot } = options;
+  const { pod, podPath, projectRoot } = options;
 
   const filePaths = findFiles(
-    join('app', podPath, '!(components)', '**', 'styles.{css,scss}'),
+    join('app', podPath, pod, '!(components)', '**', 'styles.{css,scss}'),
     {
       projectRoot,
     },

--- a/src/migration/ember-app/steps/create-file-path-maps/app/map-route-stylesheets.ts
+++ b/src/migration/ember-app/steps/create-file-path-maps/app/map-route-stylesheets.ts
@@ -14,7 +14,7 @@ export function mapRouteStylesheets(options: Options): FilePathMapEntries {
   const filePaths = findFiles(
     join('app', podPath, pod, '**', 'styles.{css,scss}'),
     {
-      ignoreList: [join('app', podPath, pod, 'components', '**')],
+      ignoreList: [join('app', podPath, 'components', pod, '**')],
       projectRoot,
     },
   );

--- a/src/migration/ember-app/steps/create-file-path-maps/app/map-route-stylesheets.ts
+++ b/src/migration/ember-app/steps/create-file-path-maps/app/map-route-stylesheets.ts
@@ -12,8 +12,9 @@ export function mapRouteStylesheets(options: Options): FilePathMapEntries {
   const { pod, podPath, projectRoot } = options;
 
   const filePaths = findFiles(
-    join('app', podPath, pod, '!(components)', '**', 'styles.{css,scss}'),
+    join('app', podPath, pod, '**', 'styles.{css,scss}'),
     {
+      ignoreList: [join('app', podPath, pod, 'components', '**')],
       projectRoot,
     },
   );

--- a/src/migration/ember-app/steps/create-file-path-maps/app/map-route-templates.ts
+++ b/src/migration/ember-app/steps/create-file-path-maps/app/map-route-templates.ts
@@ -11,12 +11,10 @@ import { renamePodPath } from '../../../../../utils/files/index.js';
 export function mapRouteTemplates(options: Options): FilePathMapEntries {
   const { pod, podPath, projectRoot } = options;
 
-  const filePaths = findFiles(
-    join('app', podPath, pod, '!(components)', '**', 'template.hbs'),
-    {
-      projectRoot,
-    },
-  );
+  const filePaths = findFiles(join('app', podPath, pod, '**', 'template.hbs'), {
+    ignoreList: [join('app', podPath, pod, 'components', '**')],
+    projectRoot,
+  });
 
   return filePaths.map((oldFilePath) => {
     const newFilePath = renamePodPath(oldFilePath, {

--- a/src/migration/ember-app/steps/create-file-path-maps/app/map-route-templates.ts
+++ b/src/migration/ember-app/steps/create-file-path-maps/app/map-route-templates.ts
@@ -12,7 +12,7 @@ export function mapRouteTemplates(options: Options): FilePathMapEntries {
   const { pod, podPath, projectRoot } = options;
 
   const filePaths = findFiles(join('app', podPath, pod, '**', 'template.hbs'), {
-    ignoreList: [join('app', podPath, pod, 'components', '**')],
+    ignoreList: [join('app', podPath, 'components', pod, '**')],
     projectRoot,
   });
 

--- a/src/migration/ember-app/steps/create-file-path-maps/app/map-route-templates.ts
+++ b/src/migration/ember-app/steps/create-file-path-maps/app/map-route-templates.ts
@@ -9,10 +9,10 @@ import type {
 import { renamePodPath } from '../../../../../utils/files/index.js';
 
 export function mapRouteTemplates(options: Options): FilePathMapEntries {
-  const { podPath, projectRoot } = options;
+  const { pod, podPath, projectRoot } = options;
 
   const filePaths = findFiles(
-    join('app', podPath, '!(components)', '**', 'template.hbs'),
+    join('app', podPath, pod, '!(components)', '**', 'template.hbs'),
     {
       projectRoot,
     },

--- a/src/migration/ember-app/steps/create-file-path-maps/app/map-services.ts
+++ b/src/migration/ember-app/steps/create-file-path-maps/app/map-services.ts
@@ -11,9 +11,12 @@ import { renamePodPath } from '../../../../../utils/files/index.js';
 export function mapServices(options: Options): FilePathMapEntries {
   const { pod, podPath, projectRoot } = options;
 
-  const filePaths = findFiles(join('app', podPath, pod, '**', 'service.{js,ts}'), {
-    projectRoot,
-  });
+  const filePaths = findFiles(
+    join('app', podPath, pod, '**', 'service.{js,ts}'),
+    {
+      projectRoot,
+    },
+  );
 
   return filePaths.map((oldFilePath) => {
     const newFilePath = renamePodPath(oldFilePath, {

--- a/src/migration/ember-app/steps/create-file-path-maps/app/map-services.ts
+++ b/src/migration/ember-app/steps/create-file-path-maps/app/map-services.ts
@@ -9,9 +9,9 @@ import type {
 import { renamePodPath } from '../../../../../utils/files/index.js';
 
 export function mapServices(options: Options): FilePathMapEntries {
-  const { podPath, projectRoot } = options;
+  const { pod, podPath, projectRoot } = options;
 
-  const filePaths = findFiles(join('app', podPath, '**', 'service.{js,ts}'), {
+  const filePaths = findFiles(join('app', podPath, pod, '**', 'service.{js,ts}'), {
     projectRoot,
   });
 

--- a/src/migration/ember-app/steps/create-file-path-maps/tests/map-components.ts
+++ b/src/migration/ember-app/steps/create-file-path-maps/tests/map-components.ts
@@ -9,12 +9,13 @@ import type {
 import { renamePodPath } from '../../../../../utils/files/index.js';
 
 export function mapComponents(options: Options): FilePathMapEntries {
-  const { podPath, projectRoot } = options;
+  const { pod, podPath, projectRoot } = options;
 
   const filePaths = findFiles(
     join(
       'tests/integration',
       podPath,
+      pod,
       'components',
       '**',
       'component-test.{js,ts}',

--- a/src/migration/ember-app/steps/create-file-path-maps/tests/map-components.ts
+++ b/src/migration/ember-app/steps/create-file-path-maps/tests/map-components.ts
@@ -11,12 +11,37 @@ import { renamePodPath } from '../../../../../utils/files/index.js';
 export function mapComponents(options: Options): FilePathMapEntries {
   const { pod, podPath, projectRoot } = options;
 
-  const filePaths = findFiles(
+  /*
+    Case 1: Didn't pass the --pod flag, but configured { usePods: true } in .ember-cli
+  */
+  const filePaths1 = findFiles(
+    join('tests/integration', podPath, pod, '**', 'component-test.{js,ts}'),
+    {
+      ignoreList: [join('tests/integration', podPath, 'components', pod, '**')],
+      projectRoot,
+    },
+  );
+
+  const filePathMap1 = filePaths1.map((oldFilePath) => {
+    const newFilePath = renamePodPath(oldFilePath, {
+      entityDir: join('tests/integration', podPath),
+      replace: (key: string) => {
+        return `tests/integration/components/${key}-test`;
+      },
+    });
+
+    return [oldFilePath, newFilePath];
+  });
+
+  /*
+    Case 2: Passed the --pod flag to Ember CLI
+  */
+  const filePaths2 = findFiles(
     join(
       'tests/integration',
       podPath,
-      pod,
       'components',
+      pod,
       '**',
       'component-test.{js,ts}',
     ),
@@ -25,7 +50,7 @@ export function mapComponents(options: Options): FilePathMapEntries {
     },
   );
 
-  return filePaths.map((oldFilePath) => {
+  const filePathMap2 = filePaths2.map((oldFilePath) => {
     const newFilePath = renamePodPath(oldFilePath, {
       entityDir: join('tests/integration', podPath, 'components'),
       replace: (key: string) => {
@@ -35,4 +60,6 @@ export function mapComponents(options: Options): FilePathMapEntries {
 
     return [oldFilePath, newFilePath];
   });
+
+  return [...filePathMap1, ...filePathMap2] as FilePathMapEntries;
 }

--- a/src/migration/ember-app/steps/create-file-path-maps/tests/map-route-controllers.ts
+++ b/src/migration/ember-app/steps/create-file-path-maps/tests/map-route-controllers.ts
@@ -9,7 +9,7 @@ import type {
 import { renamePodPath } from '../../../../../utils/files/index.js';
 
 export function mapRouteControllers(options: Options): FilePathMapEntries {
-  const { podPath, projectRoot } = options;
+  const { pod, podPath, projectRoot } = options;
 
   /*
     Case 1: Didn't pass the --pod flag, but configured { usePods: true } in .ember-cli
@@ -18,6 +18,7 @@ export function mapRouteControllers(options: Options): FilePathMapEntries {
     join(
       'tests/unit',
       podPath,
+      pod,
       '!(controllers)',
       '**',
       'controller-test.{js,ts}',
@@ -42,7 +43,7 @@ export function mapRouteControllers(options: Options): FilePathMapEntries {
     Case 2: Passed the --pod flag to Ember CLI
   */
   const filePaths2 = findFiles(
-    join('tests/unit', podPath, 'controllers/**/controller-test.{js,ts}'),
+    join('tests/unit', podPath, pod, 'controllers/**/controller-test.{js,ts}'),
     {
       projectRoot,
     },

--- a/src/migration/ember-app/steps/create-file-path-maps/tests/map-route-controllers.ts
+++ b/src/migration/ember-app/steps/create-file-path-maps/tests/map-route-controllers.ts
@@ -15,15 +15,9 @@ export function mapRouteControllers(options: Options): FilePathMapEntries {
     Case 1: Didn't pass the --pod flag, but configured { usePods: true } in .ember-cli
   */
   const filePaths1 = findFiles(
-    join(
-      'tests/unit',
-      podPath,
-      pod,
-      '!(controllers)',
-      '**',
-      'controller-test.{js,ts}',
-    ),
+    join('tests/unit', podPath, pod, '**', 'controller-test.{js,ts}'),
     {
+      ignoreList: [join('tests/unit', podPath, 'controllers', pod, '**')],
       projectRoot,
     },
   );
@@ -43,7 +37,13 @@ export function mapRouteControllers(options: Options): FilePathMapEntries {
     Case 2: Passed the --pod flag to Ember CLI
   */
   const filePaths2 = findFiles(
-    join('tests/unit', podPath, pod, 'controllers/**/controller-test.{js,ts}'),
+    join(
+      'tests/unit',
+      podPath,
+      'controllers',
+      pod,
+      '**/controller-test.{js,ts}',
+    ),
     {
       projectRoot,
     },

--- a/src/migration/ember-app/steps/create-file-path-maps/tests/map-route-routes.ts
+++ b/src/migration/ember-app/steps/create-file-path-maps/tests/map-route-routes.ts
@@ -15,8 +15,9 @@ export function mapRouteRoutes(options: Options): FilePathMapEntries {
     Case 1: Didn't pass the --pod flag, but configured { usePods: true } in .ember-cli
   */
   const filePaths1 = findFiles(
-    join('tests/unit', podPath, pod, '!(routes)', '**', 'route-test.{js,ts}'),
+    join('tests/unit', podPath, pod, '**', 'route-test.{js,ts}'),
     {
+      ignoreList: [join('tests/unit', podPath, 'routes', pod, '**')],
       projectRoot,
     },
   );
@@ -36,7 +37,7 @@ export function mapRouteRoutes(options: Options): FilePathMapEntries {
     Case 2: Passed the --pod flag to Ember CLI
   */
   const filePaths2 = findFiles(
-    join('tests/unit', podPath, 'routes/**/route-test.{js,ts}'),
+    join('tests/unit', podPath, 'routes', pod, '**/route-test.{js,ts}'),
     {
       projectRoot,
     },

--- a/src/migration/ember-app/steps/create-file-path-maps/tests/map-route-routes.ts
+++ b/src/migration/ember-app/steps/create-file-path-maps/tests/map-route-routes.ts
@@ -9,13 +9,13 @@ import type {
 import { renamePodPath } from '../../../../../utils/files/index.js';
 
 export function mapRouteRoutes(options: Options): FilePathMapEntries {
-  const { podPath, projectRoot } = options;
+  const { pod, podPath, projectRoot } = options;
 
   /*
     Case 1: Didn't pass the --pod flag, but configured { usePods: true } in .ember-cli
   */
   const filePaths1 = findFiles(
-    join('tests/unit', podPath, '!(routes)', '**', 'route-test.{js,ts}'),
+    join('tests/unit', podPath, pod, '!(routes)', '**', 'route-test.{js,ts}'),
     {
       projectRoot,
     },

--- a/src/migration/ember-app/steps/create-file-path-maps/tests/map-services.ts
+++ b/src/migration/ember-app/steps/create-file-path-maps/tests/map-services.ts
@@ -9,10 +9,10 @@ import type {
 import { renamePodPath } from '../../../../../utils/files/index.js';
 
 export function mapServices(options: Options): FilePathMapEntries {
-  const { podPath, projectRoot } = options;
+  const { pod, podPath, projectRoot } = options;
 
   const filePaths = findFiles(
-    join('tests/unit', podPath, '!(services)', '**', 'service-test.{js,ts}'),
+    join('tests/unit', podPath, pod, '!(services)', '**', 'service-test.{js,ts}'),
     {
       projectRoot,
     },

--- a/src/migration/ember-app/steps/create-file-path-maps/tests/map-services.ts
+++ b/src/migration/ember-app/steps/create-file-path-maps/tests/map-services.ts
@@ -11,14 +11,18 @@ import { renamePodPath } from '../../../../../utils/files/index.js';
 export function mapServices(options: Options): FilePathMapEntries {
   const { pod, podPath, projectRoot } = options;
 
-  const filePaths = findFiles(
-    join('tests/unit', podPath, pod, '!(services)', '**', 'service-test.{js,ts}'),
+  /*
+    Case 1: Didn't pass the --pod flag, but configured { usePods: true } in .ember-cli
+  */
+  const filePaths1 = findFiles(
+    join('tests/unit', podPath, pod, '**', 'service-test.{js,ts}'),
     {
+      ignoreList: [join('tests/unit', podPath, 'services', pod, '**')],
       projectRoot,
     },
   );
 
-  return filePaths.map((oldFilePath) => {
+  const filePathMap1 = filePaths1.map((oldFilePath) => {
     const newFilePath = renamePodPath(oldFilePath, {
       entityDir: join('tests/unit', podPath),
       replace: (key: string) => {
@@ -28,4 +32,27 @@ export function mapServices(options: Options): FilePathMapEntries {
 
     return [oldFilePath, newFilePath];
   });
+
+  /*
+    Case 2: Passed the --pod flag to Ember CLI
+  */
+  const filePaths2 = findFiles(
+    join('tests/unit', podPath, 'services', pod, '**/service-test.{js,ts}'),
+    {
+      projectRoot,
+    },
+  );
+
+  const filePathMap2 = filePaths2.map((oldFilePath) => {
+    const newFilePath = renamePodPath(oldFilePath, {
+      entityDir: join('tests/unit', podPath, 'services'),
+      replace: (key: string) => {
+        return `tests/unit/services/${key}-test`;
+      },
+    });
+
+    return [oldFilePath, newFilePath];
+  });
+
+  return [...filePathMap1, ...filePathMap2] as FilePathMapEntries;
 }

--- a/src/migration/ember-app/steps/create-options.ts
+++ b/src/migration/ember-app/steps/create-options.ts
@@ -2,6 +2,7 @@ import type { CodemodOptions, Options } from '../../../types/index.js';
 
 export function createOptions(codemodOptions: CodemodOptions): Options {
   return {
+    pod: codemodOptions.pod,
     podPath: codemodOptions.podPath,
     projectRoot: codemodOptions.projectRoot,
     projectType: codemodOptions.projectType,

--- a/src/migration/ember-engine/steps/create-options.ts
+++ b/src/migration/ember-engine/steps/create-options.ts
@@ -2,6 +2,7 @@ import type { CodemodOptions, Options } from '../../../types/index.js';
 
 export function createOptions(codemodOptions: CodemodOptions): Options {
   return {
+    pod: codemodOptions.pod,
     podPath: codemodOptions.podPath,
     projectRoot: codemodOptions.projectRoot,
     projectType: codemodOptions.projectType,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,6 +1,7 @@
 import type { FilePath, FilePathMap } from '@codemod-utils/files';
 
 type CodemodOptions = {
+  pod: string;
   podPath: string;
   projectRoot: string;
   projectType: 'addon' | 'app' | 'engine';
@@ -10,6 +11,7 @@ type CodemodOptions = {
 type FilePathMapEntries = [FilePath, FilePath][];
 
 type Options = {
+  pod: string;
   podPath: string;
   projectRoot: string;
   projectType: 'addon' | 'app' | 'engine';


### PR DESCRIPTION
Closes #61.

This PR isn't finished yet, it contains a POC that only supports Ember apps.

Open questions
- Is `--pod` the right flag name?
- Is the new flag composing correctly with `--podPath`?

TODO
- [ ] support Ember addons
- [ ] support Ember engines
- [ ] add documentation for new flag
- [ ] tests
