### PR TITLE
Removed unnecessary joins

### DIFF
--- a/src/migration/app/steps/create-file-path-maps/app/map-component-classes.ts
+++ b/src/migration/app/steps/create-file-path-maps/app/map-component-classes.ts
@@ -12,7 +12,7 @@ export function mapComponentClasses(options: Options): FilePathMapEntries {
   const { podPath, projectRoot } = options;
 
   const filePaths = findFiles(
-    join('app', podPath, 'components', '**', 'component.{d.ts,js,ts}'),
+    join('app', podPath, 'components/**/component.{d.ts,js,ts}'),
     {
       projectRoot,
     },

--- a/src/migration/app/steps/create-file-path-maps/app/map-component-stylesheets.ts
+++ b/src/migration/app/steps/create-file-path-maps/app/map-component-stylesheets.ts
@@ -12,7 +12,7 @@ export function mapComponentStylesheets(options: Options): FilePathMapEntries {
   const { podPath, projectRoot } = options;
 
   const filePaths = findFiles(
-    join('app', podPath, 'components', '**', 'styles.{css,scss}'),
+    join('app', podPath, 'components/**/styles.{css,scss}'),
     {
       projectRoot,
     },

--- a/src/migration/app/steps/create-file-path-maps/app/map-component-templates.ts
+++ b/src/migration/app/steps/create-file-path-maps/app/map-component-templates.ts
@@ -12,7 +12,7 @@ export function mapComponentTemplates(options: Options): FilePathMapEntries {
   const { podPath, projectRoot } = options;
 
   const filePaths = findFiles(
-    join('app', podPath, 'components', '**', 'template.hbs'),
+    join('app', podPath, 'components/**/template.hbs'),
     {
       projectRoot,
     },

--- a/src/migration/app/steps/create-file-path-maps/app/map-route-adapters.ts
+++ b/src/migration/app/steps/create-file-path-maps/app/map-route-adapters.ts
@@ -11,7 +11,7 @@ import { renamePodPath } from '../../../../../utils/files/index.js';
 export function mapRouteAdapters(options: Options): FilePathMapEntries {
   const { podPath, projectRoot } = options;
 
-  const filePaths = findFiles(join('app', podPath, '**', 'adapter.{js,ts}'), {
+  const filePaths = findFiles(join('app', podPath, '**/adapter.{js,ts}'), {
     projectRoot,
   });
 

--- a/src/migration/app/steps/create-file-path-maps/app/map-route-controllers.ts
+++ b/src/migration/app/steps/create-file-path-maps/app/map-route-controllers.ts
@@ -11,12 +11,9 @@ import { renamePodPath } from '../../../../../utils/files/index.js';
 export function mapRouteControllers(options: Options): FilePathMapEntries {
   const { podPath, projectRoot } = options;
 
-  const filePaths = findFiles(
-    join('app', podPath, '**', 'controller.{js,ts}'),
-    {
-      projectRoot,
-    },
-  );
+  const filePaths = findFiles(join('app', podPath, '**/controller.{js,ts}'), {
+    projectRoot,
+  });
 
   return filePaths.map((oldFilePath) => {
     const newFilePath = renamePodPath(oldFilePath, {

--- a/src/migration/app/steps/create-file-path-maps/app/map-route-models.ts
+++ b/src/migration/app/steps/create-file-path-maps/app/map-route-models.ts
@@ -11,7 +11,7 @@ import { renamePodPath } from '../../../../../utils/files/index.js';
 export function mapRouteModels(options: Options): FilePathMapEntries {
   const { podPath, projectRoot } = options;
 
-  const filePaths = findFiles(join('app', podPath, '**', 'model.{js,ts}'), {
+  const filePaths = findFiles(join('app', podPath, '**/model.{js,ts}'), {
     projectRoot,
   });
 

--- a/src/migration/app/steps/create-file-path-maps/app/map-route-routes.ts
+++ b/src/migration/app/steps/create-file-path-maps/app/map-route-routes.ts
@@ -11,7 +11,7 @@ import { renamePodPath } from '../../../../../utils/files/index.js';
 export function mapRouteRoutes(options: Options): FilePathMapEntries {
   const { podPath, projectRoot } = options;
 
-  const filePaths = findFiles(join('app', podPath, '**', 'route.{js,ts}'), {
+  const filePaths = findFiles(join('app', podPath, '**/route.{js,ts}'), {
     projectRoot,
   });
 

--- a/src/migration/app/steps/create-file-path-maps/app/map-route-serializers.ts
+++ b/src/migration/app/steps/create-file-path-maps/app/map-route-serializers.ts
@@ -11,12 +11,9 @@ import { renamePodPath } from '../../../../../utils/files/index.js';
 export function mapRouteSerializers(options: Options): FilePathMapEntries {
   const { podPath, projectRoot } = options;
 
-  const filePaths = findFiles(
-    join('app', podPath, '**', 'serializer.{js,ts}'),
-    {
-      projectRoot,
-    },
-  );
+  const filePaths = findFiles(join('app', podPath, '**/serializer.{js,ts}'), {
+    projectRoot,
+  });
 
   return filePaths.map((oldFilePath) => {
     const newFilePath = renamePodPath(oldFilePath, {

--- a/src/migration/app/steps/create-file-path-maps/app/map-route-stylesheets.ts
+++ b/src/migration/app/steps/create-file-path-maps/app/map-route-stylesheets.ts
@@ -12,7 +12,7 @@ export function mapRouteStylesheets(options: Options): FilePathMapEntries {
   const { podPath, projectRoot } = options;
 
   const filePaths = findFiles(
-    join('app', podPath, '!(components)', '**', 'styles.{css,scss}'),
+    join('app', podPath, '!(components)/**/styles.{css,scss}'),
     {
       projectRoot,
     },

--- a/src/migration/app/steps/create-file-path-maps/app/map-route-templates.ts
+++ b/src/migration/app/steps/create-file-path-maps/app/map-route-templates.ts
@@ -12,7 +12,7 @@ export function mapRouteTemplates(options: Options): FilePathMapEntries {
   const { podPath, projectRoot } = options;
 
   const filePaths = findFiles(
-    join('app', podPath, '!(components)', '**', 'template.hbs'),
+    join('app', podPath, '!(components)/**/template.hbs'),
     {
       projectRoot,
     },

--- a/src/migration/app/steps/create-file-path-maps/app/map-services.ts
+++ b/src/migration/app/steps/create-file-path-maps/app/map-services.ts
@@ -11,7 +11,7 @@ import { renamePodPath } from '../../../../../utils/files/index.js';
 export function mapServices(options: Options): FilePathMapEntries {
   const { podPath, projectRoot } = options;
 
-  const filePaths = findFiles(join('app', podPath, '**', 'service.{js,ts}'), {
+  const filePaths = findFiles(join('app', podPath, '**/service.{js,ts}'), {
     projectRoot,
   });
 

--- a/src/migration/app/steps/create-file-path-maps/tests/map-components.ts
+++ b/src/migration/app/steps/create-file-path-maps/tests/map-components.ts
@@ -12,13 +12,7 @@ export function mapComponents(options: Options): FilePathMapEntries {
   const { podPath, projectRoot } = options;
 
   const filePaths = findFiles(
-    join(
-      'tests/integration',
-      podPath,
-      'components',
-      '**',
-      'component-test.{js,ts}',
-    ),
+    join('tests/integration', podPath, 'components/**/component-test.{js,ts}'),
     {
       projectRoot,
     },

--- a/src/migration/app/steps/create-file-path-maps/tests/map-route-controllers.ts
+++ b/src/migration/app/steps/create-file-path-maps/tests/map-route-controllers.ts
@@ -15,13 +15,7 @@ export function mapRouteControllers(options: Options): FilePathMapEntries {
     Case 1: Didn't pass the --pod flag, but configured { usePods: true } in .ember-cli
   */
   const filePaths1 = findFiles(
-    join(
-      'tests/unit',
-      podPath,
-      '!(controllers)',
-      '**',
-      'controller-test.{js,ts}',
-    ),
+    join('tests/unit', podPath, '!(controllers)/**/controller-test.{js,ts}'),
     {
       projectRoot,
     },

--- a/src/migration/app/steps/create-file-path-maps/tests/map-route-routes.ts
+++ b/src/migration/app/steps/create-file-path-maps/tests/map-route-routes.ts
@@ -15,7 +15,7 @@ export function mapRouteRoutes(options: Options): FilePathMapEntries {
     Case 1: Didn't pass the --pod flag, but configured { usePods: true } in .ember-cli
   */
   const filePaths1 = findFiles(
-    join('tests/unit', podPath, '!(routes)', '**', 'route-test.{js,ts}'),
+    join('tests/unit', podPath, '!(routes)/**/route-test.{js,ts}'),
     {
       projectRoot,
     },

--- a/src/migration/app/steps/create-file-path-maps/tests/map-services.ts
+++ b/src/migration/app/steps/create-file-path-maps/tests/map-services.ts
@@ -12,7 +12,7 @@ export function mapServices(options: Options): FilePathMapEntries {
   const { podPath, projectRoot } = options;
 
   const filePaths = findFiles(
-    join('tests/unit', podPath, '!(services)', '**', 'service-test.{js,ts}'),
+    join('tests/unit', podPath, '!(services)/**/service-test.{js,ts}'),
     {
       projectRoot,
     },

--- a/src/migration/v1-addon/steps/create-file-path-maps/tests/map-services.ts
+++ b/src/migration/v1-addon/steps/create-file-path-maps/tests/map-services.ts
@@ -1,5 +1,3 @@
-import { join } from 'node:path';
-
 import { findFiles } from '@codemod-utils/files';
 
 import type {
@@ -12,7 +10,7 @@ export function mapServices(options: Options): FilePathMapEntries {
   const { projectRoot } = options;
 
   const filePaths = findFiles(
-    join('tests/unit/!(services)/**/service-test.{js,ts}'),
+    'tests/unit/!(services)/**/service-test.{js,ts}',
     {
       projectRoot,
     },


### PR DESCRIPTION
## Background

By removing unnecessary uses of `join()`, we can make the code used in the `app` and `v1-addon` cases more similar to one another.