### PR TITLE
move glob exclude patterns to ignoreList

### DIFF
--- a/src/migration/app/steps/create-file-path-maps/app/map-route-stylesheets.ts
+++ b/src/migration/app/steps/create-file-path-maps/app/map-route-stylesheets.ts
@@ -11,12 +11,10 @@ import { renamePodPath } from '../../../../../utils/files/index.js';
 export function mapRouteStylesheets(options: Options): FilePathMapEntries {
   const { podPath, projectRoot } = options;
 
-  const filePaths = findFiles(
-    join('app', podPath, '!(components)/**/styles.{css,scss}'),
-    {
-      projectRoot,
-    },
-  );
+  const filePaths = findFiles(join('app', podPath, '**/styles.{css,scss}'), {
+    ignoreList: [join('app', podPath, 'components', '**')],
+    projectRoot,
+  });
 
   return filePaths.map((oldFilePath) => {
     const newFilePath = renamePodPath(oldFilePath, {

--- a/src/migration/app/steps/create-file-path-maps/app/map-route-templates.ts
+++ b/src/migration/app/steps/create-file-path-maps/app/map-route-templates.ts
@@ -11,12 +11,10 @@ import { renamePodPath } from '../../../../../utils/files/index.js';
 export function mapRouteTemplates(options: Options): FilePathMapEntries {
   const { podPath, projectRoot } = options;
 
-  const filePaths = findFiles(
-    join('app', podPath, '!(components)/**/template.hbs'),
-    {
-      projectRoot,
-    },
-  );
+  const filePaths = findFiles(join('app', podPath, '**/template.hbs'), {
+    ignoreList: [join('app', podPath, 'components', '**')],
+    projectRoot,
+  });
 
   return filePaths.map((oldFilePath) => {
     const newFilePath = renamePodPath(oldFilePath, {

--- a/src/migration/app/steps/create-file-path-maps/tests/map-route-controllers.ts
+++ b/src/migration/app/steps/create-file-path-maps/tests/map-route-controllers.ts
@@ -15,8 +15,9 @@ export function mapRouteControllers(options: Options): FilePathMapEntries {
     Case 1: Didn't pass the --pod flag, but configured { usePods: true } in .ember-cli
   */
   const filePaths1 = findFiles(
-    join('tests/unit', podPath, '!(controllers)/**/controller-test.{js,ts}'),
+    join('tests/unit', podPath, '**/controller-test.{js,ts}'),
     {
+      ignoreList: [join('tests/unit', podPath, 'controllers', '**')],
       projectRoot,
     },
   );

--- a/src/migration/app/steps/create-file-path-maps/tests/map-route-routes.ts
+++ b/src/migration/app/steps/create-file-path-maps/tests/map-route-routes.ts
@@ -15,8 +15,9 @@ export function mapRouteRoutes(options: Options): FilePathMapEntries {
     Case 1: Didn't pass the --pod flag, but configured { usePods: true } in .ember-cli
   */
   const filePaths1 = findFiles(
-    join('tests/unit', podPath, '!(routes)/**/route-test.{js,ts}'),
+    join('tests/unit', podPath, '**/route-test.{js,ts}'),
     {
+      ignoreList: [join('tests/unit', podPath, 'routes', '**')],
       projectRoot,
     },
   );

--- a/src/migration/app/steps/create-file-path-maps/tests/map-services.ts
+++ b/src/migration/app/steps/create-file-path-maps/tests/map-services.ts
@@ -12,8 +12,9 @@ export function mapServices(options: Options): FilePathMapEntries {
   const { podPath, projectRoot } = options;
 
   const filePaths = findFiles(
-    join('tests/unit', podPath, '!(services)/**/service-test.{js,ts}'),
+    join('tests/unit', podPath, '**/service-test.{js,ts}'),
     {
+      ignoreList: [join('tests/unit', podPath, 'services', '**')],
       projectRoot,
     },
   );

--- a/src/migration/v1-addon/steps/create-file-path-maps/addon/map-route-stylesheets.ts
+++ b/src/migration/v1-addon/steps/create-file-path-maps/addon/map-route-stylesheets.ts
@@ -9,7 +9,8 @@ import { renamePodPath } from '../../../../../utils/files/index.js';
 export function mapRouteStylesheets(options: Options): FilePathMapEntries {
   const { projectRoot } = options;
 
-  const filePaths = findFiles('addon/!(components)/**/styles.{css,scss}', {
+  const filePaths = findFiles('addon/**/styles.{css,scss}', {
+    ignoreList: ['addon/components/**'],
     projectRoot,
   });
 

--- a/src/migration/v1-addon/steps/create-file-path-maps/addon/map-route-templates.ts
+++ b/src/migration/v1-addon/steps/create-file-path-maps/addon/map-route-templates.ts
@@ -9,7 +9,8 @@ import { renamePodPath } from '../../../../../utils/files/index.js';
 export function mapRouteTemplates(options: Options): FilePathMapEntries {
   const { projectRoot } = options;
 
-  const filePaths = findFiles('addon/!(components)/**/template.hbs', {
+  const filePaths = findFiles('addon/**/template.hbs', {
+    ignoreList: ['addon/components/**'],
     projectRoot,
   });
 

--- a/src/migration/v1-addon/steps/create-file-path-maps/app/map-route-templates.ts
+++ b/src/migration/v1-addon/steps/create-file-path-maps/app/map-route-templates.ts
@@ -9,7 +9,8 @@ import { renamePodPath } from '../../../../../utils/files/index.js';
 export function mapRouteTemplates(options: Options): FilePathMapEntries {
   const { projectRoot } = options;
 
-  const filePaths = findFiles('app/!(components)/**/template.js', {
+  const filePaths = findFiles('app/**/template.js', {
+    ignoreList: ['app/components/**'],
     projectRoot,
   });
 

--- a/src/migration/v1-addon/steps/create-file-path-maps/tests/map-route-controllers.ts
+++ b/src/migration/v1-addon/steps/create-file-path-maps/tests/map-route-controllers.ts
@@ -12,12 +12,10 @@ export function mapRouteControllers(options: Options): FilePathMapEntries {
   /*
     Case 1: Didn't pass the --pod flag, but configured { usePods: true } in .ember-cli
   */
-  const filePaths1 = findFiles(
-    'tests/unit/!(controllers)/**/controller-test.{js,ts}',
-    {
-      projectRoot,
-    },
-  );
+  const filePaths1 = findFiles('tests/unit/**/controller-test.{js,ts}', {
+    ignoreList: ['tests/unit/controllers/**'],
+    projectRoot,
+  });
 
   const filePathMap1 = filePaths1.map((oldFilePath) => {
     const newFilePath = renamePodPath(oldFilePath, {

--- a/src/migration/v1-addon/steps/create-file-path-maps/tests/map-route-routes.ts
+++ b/src/migration/v1-addon/steps/create-file-path-maps/tests/map-route-routes.ts
@@ -12,7 +12,8 @@ export function mapRouteRoutes(options: Options): FilePathMapEntries {
   /*
     Case 1: Didn't pass the --pod flag, but configured { usePods: true } in .ember-cli
   */
-  const filePaths1 = findFiles('tests/unit/!(routes)/**/route-test.{js,ts}', {
+  const filePaths1 = findFiles('tests/unit/**/route-test.{js,ts}', {
+    ignoreList: ['tests/unit/routes/**'],
     projectRoot,
   });
 

--- a/src/migration/v1-addon/steps/create-file-path-maps/tests/map-services.ts
+++ b/src/migration/v1-addon/steps/create-file-path-maps/tests/map-services.ts
@@ -9,12 +9,10 @@ import { renamePodPath } from '../../../../../utils/files/index.js';
 export function mapServices(options: Options): FilePathMapEntries {
   const { projectRoot } = options;
 
-  const filePaths = findFiles(
-    'tests/unit/!(services)/**/service-test.{js,ts}',
-    {
-      projectRoot,
-    },
-  );
+  const filePaths = findFiles('tests/unit/**/service-test.{js,ts}', {
+    ignoreList: ['tests/unit/services/**'],
+    projectRoot,
+  });
 
   return filePaths.map((oldFilePath) => {
     const newFilePath = renamePodPath(oldFilePath, {


### PR DESCRIPTION
`!(foo)` style clauses don't work if the codemod is extended to support incremental pod conversion. Take #61 where a `--pod` flag is desired. Running `--pods my-pod-a` would generate a search path like:

`app/my-pod-a/!(components)/**/template.hbs`

but this is incorrect if you have a file structure like
```
my-project/
  app/
    my-pod-a/
      route.js
      template.hbs
```
since there's no folder in between `my-pod-a` and `**` which matches `!(components)`.

The exclusion can be expressed instead with `ignoreList` so that there's no additional folders required by `/!(foo)/`. This makes the codemod more extensible.

I wasn't able to reproduce the issue with `--pod-path` alone like originally theorized in #61. This is because there will always be a pod-name folder to match `/!(foo)/`.