### PR TITLE
Documented how to use linters and incrementally migrate code

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,28 @@ cd <path/to/your/project>
 npx ember-codemod-pod-to-octane <arguments>
 ```
 
+> [!NOTE]
+>
+> By default, Octane assumes the **flat component structure**. So does this codemod to help different Ember projects converge to one layout. If you want the **nested component structure** (also supported by Octane), you can run [`ember-flat-to-nested`](https://github.com/bertdeblock/ember-flat-to-nested) afterwards.
+
 Step 2. Remove `podModulePrefix` from `config/environment.js` and `usePods` from `.ember-cli`.
 
 Step 3. Update references originating from, as well as pointing to, the moved files. These can include `import` statement, `composes` property from `ember-css-modules`, etc.
 
-<sup>1. By default, Octane assumes the **flat component structure**. So does this codemod to help different Ember projects converge to one layout. If you want the **nested component structure** (also supported by Octane), you can run [`ember-flat-to-nested`](https://github.com/bertdeblock/ember-flat-to-nested) afterwards.</sup>
+> [!TIP]
+>
+> Linters can help you find the files that need to be updated.
+>
+> ```sh
+> # With eslint-plugin-import
+> [lint:js] /my-v1-addon/addon/index.ts
+> [lint:js]   1:49  error  Unable to resolve path to module './components/navigation-menu/component'  import/no-unresolved
+> 
+> # With typescript
+> [lint:types] addon/index.ts:1:49 - error TS2307: Cannot find module './components/navigation-menu/component' or its corresponding type declarations.
+> [lint:types] 
+> [lint:types] 1 export { default as NavigationMenu } from './components/navigation-menu/component';
+> ```
 
 
 ### Arguments

--- a/README.md
+++ b/README.md
@@ -139,6 +139,25 @@ pnpm build
 ./dist/bin/ember-codemod-pod-to-octane.js --root <path/to/your/project>
 ```
 
+> [!TIP]
+>
+> You might clone the repo to migrate the project one component or one route at a time. For example, to migrate only the `<NavigationMenu>` component (and its subcomponents, if they exist), update the related file(s) in the `src` folder like this:
+>
+> ```diff
+> export function mapComponentClasses(options: Options): FilePathMapEntries {
+>   const { podPath, projectRoot } = options;
+> 
+>   const podDir = join('app', podPath, 'components');
+> 
+> -   const filePaths = findFiles(`${podDir}/**/component.{d.ts,js,ts}`, {
+> +   const filePaths = findFiles(`${podDir}/navigation-menu/**/component.{d.ts,js,ts}`, {
+> 
+>   // ...
+> }
+> ```
+>
+> That is, look for `findFiles(`, then insert the component or route name between `podDir` and `**`.
+
 
 ## Compatibility
 

--- a/src/migration/app/steps/create-file-path-maps/app/map-component-classes.ts
+++ b/src/migration/app/steps/create-file-path-maps/app/map-component-classes.ts
@@ -11,16 +11,15 @@ import { renamePodPath } from '../../../../../utils/files/index.js';
 export function mapComponentClasses(options: Options): FilePathMapEntries {
   const { podPath, projectRoot } = options;
 
-  const filePaths = findFiles(
-    join('app', podPath, 'components/**/component.{d.ts,js,ts}'),
-    {
-      projectRoot,
-    },
-  );
+  const podDir = join('app', podPath, 'components');
+
+  const filePaths = findFiles(`${podDir}/**/component.{d.ts,js,ts}`, {
+    projectRoot,
+  });
 
   return filePaths.map((oldFilePath) => {
     const newFilePath = renamePodPath(oldFilePath, {
-      entityDir: join('app', podPath, 'components'),
+      entityDir: podDir,
       replace: (key: string) => {
         return `app/components/${key}`;
       },

--- a/src/migration/app/steps/create-file-path-maps/app/map-component-classes.ts
+++ b/src/migration/app/steps/create-file-path-maps/app/map-component-classes.ts
@@ -19,7 +19,7 @@ export function mapComponentClasses(options: Options): FilePathMapEntries {
 
   return filePaths.map((oldFilePath) => {
     const newFilePath = renamePodPath(oldFilePath, {
-      entityDir: podDir,
+      podDir,
       replace: (key: string) => {
         return `app/components/${key}`;
       },

--- a/src/migration/app/steps/create-file-path-maps/app/map-component-stylesheets.ts
+++ b/src/migration/app/steps/create-file-path-maps/app/map-component-stylesheets.ts
@@ -19,7 +19,7 @@ export function mapComponentStylesheets(options: Options): FilePathMapEntries {
 
   return filePaths.map((oldFilePath) => {
     const newFilePath = renamePodPath(oldFilePath, {
-      entityDir: podDir,
+      podDir,
       replace: (key: string) => {
         return `app/components/${key}`;
       },

--- a/src/migration/app/steps/create-file-path-maps/app/map-component-stylesheets.ts
+++ b/src/migration/app/steps/create-file-path-maps/app/map-component-stylesheets.ts
@@ -11,16 +11,15 @@ import { renamePodPath } from '../../../../../utils/files/index.js';
 export function mapComponentStylesheets(options: Options): FilePathMapEntries {
   const { podPath, projectRoot } = options;
 
-  const filePaths = findFiles(
-    join('app', podPath, 'components/**/styles.{css,scss}'),
-    {
-      projectRoot,
-    },
-  );
+  const podDir = join('app', podPath, 'components');
+
+  const filePaths = findFiles(`${podDir}/**/styles.{css,scss}`, {
+    projectRoot,
+  });
 
   return filePaths.map((oldFilePath) => {
     const newFilePath = renamePodPath(oldFilePath, {
-      entityDir: join('app', podPath, 'components'),
+      entityDir: podDir,
       replace: (key: string) => {
         return `app/components/${key}`;
       },

--- a/src/migration/app/steps/create-file-path-maps/app/map-component-templates.ts
+++ b/src/migration/app/steps/create-file-path-maps/app/map-component-templates.ts
@@ -19,7 +19,7 @@ export function mapComponentTemplates(options: Options): FilePathMapEntries {
 
   return filePaths.map((oldFilePath) => {
     const newFilePath = renamePodPath(oldFilePath, {
-      entityDir: podDir,
+      podDir,
       replace: (key: string) => {
         return `app/components/${key}`;
       },

--- a/src/migration/app/steps/create-file-path-maps/app/map-component-templates.ts
+++ b/src/migration/app/steps/create-file-path-maps/app/map-component-templates.ts
@@ -11,16 +11,15 @@ import { renamePodPath } from '../../../../../utils/files/index.js';
 export function mapComponentTemplates(options: Options): FilePathMapEntries {
   const { podPath, projectRoot } = options;
 
-  const filePaths = findFiles(
-    join('app', podPath, 'components/**/template.hbs'),
-    {
-      projectRoot,
-    },
-  );
+  const podDir = join('app', podPath, 'components');
+
+  const filePaths = findFiles(`${podDir}/**/template.hbs`, {
+    projectRoot,
+  });
 
   return filePaths.map((oldFilePath) => {
     const newFilePath = renamePodPath(oldFilePath, {
-      entityDir: join('app', podPath, 'components'),
+      entityDir: podDir,
       replace: (key: string) => {
         return `app/components/${key}`;
       },

--- a/src/migration/app/steps/create-file-path-maps/app/map-route-adapters.ts
+++ b/src/migration/app/steps/create-file-path-maps/app/map-route-adapters.ts
@@ -19,7 +19,7 @@ export function mapRouteAdapters(options: Options): FilePathMapEntries {
 
   return filePaths.map((oldFilePath) => {
     const newFilePath = renamePodPath(oldFilePath, {
-      entityDir: podDir,
+      podDir,
       replace: (key: string) => {
         return `app/adapters/${key}`;
       },

--- a/src/migration/app/steps/create-file-path-maps/app/map-route-adapters.ts
+++ b/src/migration/app/steps/create-file-path-maps/app/map-route-adapters.ts
@@ -11,13 +11,15 @@ import { renamePodPath } from '../../../../../utils/files/index.js';
 export function mapRouteAdapters(options: Options): FilePathMapEntries {
   const { podPath, projectRoot } = options;
 
-  const filePaths = findFiles(join('app', podPath, '**/adapter.{js,ts}'), {
+  const podDir = join('app', podPath);
+
+  const filePaths = findFiles(`${podDir}/**/adapter.{js,ts}`, {
     projectRoot,
   });
 
   return filePaths.map((oldFilePath) => {
     const newFilePath = renamePodPath(oldFilePath, {
-      entityDir: join('app', podPath),
+      entityDir: podDir,
       replace: (key: string) => {
         return `app/adapters/${key}`;
       },

--- a/src/migration/app/steps/create-file-path-maps/app/map-route-controllers.ts
+++ b/src/migration/app/steps/create-file-path-maps/app/map-route-controllers.ts
@@ -11,13 +11,15 @@ import { renamePodPath } from '../../../../../utils/files/index.js';
 export function mapRouteControllers(options: Options): FilePathMapEntries {
   const { podPath, projectRoot } = options;
 
-  const filePaths = findFiles(join('app', podPath, '**/controller.{js,ts}'), {
+  const podDir = join('app', podPath);
+
+  const filePaths = findFiles(`${podDir}/**/controller.{js,ts}`, {
     projectRoot,
   });
 
   return filePaths.map((oldFilePath) => {
     const newFilePath = renamePodPath(oldFilePath, {
-      entityDir: join('app', podPath),
+      entityDir: podDir,
       replace: (key: string) => {
         return `app/controllers/${key}`;
       },

--- a/src/migration/app/steps/create-file-path-maps/app/map-route-controllers.ts
+++ b/src/migration/app/steps/create-file-path-maps/app/map-route-controllers.ts
@@ -19,7 +19,7 @@ export function mapRouteControllers(options: Options): FilePathMapEntries {
 
   return filePaths.map((oldFilePath) => {
     const newFilePath = renamePodPath(oldFilePath, {
-      entityDir: podDir,
+      podDir,
       replace: (key: string) => {
         return `app/controllers/${key}`;
       },

--- a/src/migration/app/steps/create-file-path-maps/app/map-route-models.ts
+++ b/src/migration/app/steps/create-file-path-maps/app/map-route-models.ts
@@ -19,7 +19,7 @@ export function mapRouteModels(options: Options): FilePathMapEntries {
 
   return filePaths.map((oldFilePath) => {
     const newFilePath = renamePodPath(oldFilePath, {
-      entityDir: podDir,
+      podDir,
       replace: (key: string) => {
         return `app/models/${key}`;
       },

--- a/src/migration/app/steps/create-file-path-maps/app/map-route-models.ts
+++ b/src/migration/app/steps/create-file-path-maps/app/map-route-models.ts
@@ -11,13 +11,15 @@ import { renamePodPath } from '../../../../../utils/files/index.js';
 export function mapRouteModels(options: Options): FilePathMapEntries {
   const { podPath, projectRoot } = options;
 
-  const filePaths = findFiles(join('app', podPath, '**/model.{js,ts}'), {
+  const podDir = join('app', podPath);
+
+  const filePaths = findFiles(`${podDir}/**/model.{js,ts}`, {
     projectRoot,
   });
 
   return filePaths.map((oldFilePath) => {
     const newFilePath = renamePodPath(oldFilePath, {
-      entityDir: join('app', podPath),
+      entityDir: podDir,
       replace: (key: string) => {
         return `app/models/${key}`;
       },

--- a/src/migration/app/steps/create-file-path-maps/app/map-route-routes.ts
+++ b/src/migration/app/steps/create-file-path-maps/app/map-route-routes.ts
@@ -11,13 +11,15 @@ import { renamePodPath } from '../../../../../utils/files/index.js';
 export function mapRouteRoutes(options: Options): FilePathMapEntries {
   const { podPath, projectRoot } = options;
 
-  const filePaths = findFiles(join('app', podPath, '**/route.{js,ts}'), {
+  const podDir = join('app', podPath);
+
+  const filePaths = findFiles(`${podDir}/**/route.{js,ts}`, {
     projectRoot,
   });
 
   return filePaths.map((oldFilePath) => {
     const newFilePath = renamePodPath(oldFilePath, {
-      entityDir: join('app', podPath),
+      entityDir: podDir,
       replace: (key: string) => {
         return `app/routes/${key}`;
       },

--- a/src/migration/app/steps/create-file-path-maps/app/map-route-routes.ts
+++ b/src/migration/app/steps/create-file-path-maps/app/map-route-routes.ts
@@ -19,7 +19,7 @@ export function mapRouteRoutes(options: Options): FilePathMapEntries {
 
   return filePaths.map((oldFilePath) => {
     const newFilePath = renamePodPath(oldFilePath, {
-      entityDir: podDir,
+      podDir,
       replace: (key: string) => {
         return `app/routes/${key}`;
       },

--- a/src/migration/app/steps/create-file-path-maps/app/map-route-serializers.ts
+++ b/src/migration/app/steps/create-file-path-maps/app/map-route-serializers.ts
@@ -19,7 +19,7 @@ export function mapRouteSerializers(options: Options): FilePathMapEntries {
 
   return filePaths.map((oldFilePath) => {
     const newFilePath = renamePodPath(oldFilePath, {
-      entityDir: podDir,
+      podDir,
       replace: (key: string) => {
         return `app/serializers/${key}`;
       },

--- a/src/migration/app/steps/create-file-path-maps/app/map-route-serializers.ts
+++ b/src/migration/app/steps/create-file-path-maps/app/map-route-serializers.ts
@@ -11,13 +11,15 @@ import { renamePodPath } from '../../../../../utils/files/index.js';
 export function mapRouteSerializers(options: Options): FilePathMapEntries {
   const { podPath, projectRoot } = options;
 
-  const filePaths = findFiles(join('app', podPath, '**/serializer.{js,ts}'), {
+  const podDir = join('app', podPath);
+
+  const filePaths = findFiles(`${podDir}/**/serializer.{js,ts}`, {
     projectRoot,
   });
 
   return filePaths.map((oldFilePath) => {
     const newFilePath = renamePodPath(oldFilePath, {
-      entityDir: join('app', podPath),
+      entityDir: podDir,
       replace: (key: string) => {
         return `app/serializers/${key}`;
       },

--- a/src/migration/app/steps/create-file-path-maps/app/map-route-stylesheets.ts
+++ b/src/migration/app/steps/create-file-path-maps/app/map-route-stylesheets.ts
@@ -12,7 +12,7 @@ export function mapRouteStylesheets(options: Options): FilePathMapEntries {
   const { podPath, projectRoot } = options;
 
   const filePaths = findFiles(join('app', podPath, '**/styles.{css,scss}'), {
-    ignoreList: [join('app', podPath, 'components', '**')],
+    ignoreList: [join('app', podPath, 'components/**')],
     projectRoot,
   });
 

--- a/src/migration/app/steps/create-file-path-maps/app/map-route-stylesheets.ts
+++ b/src/migration/app/steps/create-file-path-maps/app/map-route-stylesheets.ts
@@ -11,14 +11,16 @@ import { renamePodPath } from '../../../../../utils/files/index.js';
 export function mapRouteStylesheets(options: Options): FilePathMapEntries {
   const { podPath, projectRoot } = options;
 
-  const filePaths = findFiles(join('app', podPath, '**/styles.{css,scss}'), {
+  const podDir = join('app', podPath);
+
+  const filePaths = findFiles(`${podDir}/**/styles.{css,scss}`, {
     ignoreList: [join('app', podPath, 'components/**')],
     projectRoot,
   });
 
   return filePaths.map((oldFilePath) => {
     const newFilePath = renamePodPath(oldFilePath, {
-      entityDir: join('app', podPath),
+      entityDir: podDir,
       replace: (key: string) => {
         return `app/styles/${key}`;
       },

--- a/src/migration/app/steps/create-file-path-maps/app/map-route-stylesheets.ts
+++ b/src/migration/app/steps/create-file-path-maps/app/map-route-stylesheets.ts
@@ -20,7 +20,7 @@ export function mapRouteStylesheets(options: Options): FilePathMapEntries {
 
   return filePaths.map((oldFilePath) => {
     const newFilePath = renamePodPath(oldFilePath, {
-      entityDir: podDir,
+      podDir,
       replace: (key: string) => {
         return `app/styles/${key}`;
       },

--- a/src/migration/app/steps/create-file-path-maps/app/map-route-templates.ts
+++ b/src/migration/app/steps/create-file-path-maps/app/map-route-templates.ts
@@ -11,14 +11,16 @@ import { renamePodPath } from '../../../../../utils/files/index.js';
 export function mapRouteTemplates(options: Options): FilePathMapEntries {
   const { podPath, projectRoot } = options;
 
-  const filePaths = findFiles(join('app', podPath, '**/template.hbs'), {
+  const podDir = join('app', podPath);
+
+  const filePaths = findFiles(`${podDir}/**/template.hbs`, {
     ignoreList: [join('app', podPath, 'components/**')],
     projectRoot,
   });
 
   return filePaths.map((oldFilePath) => {
     const newFilePath = renamePodPath(oldFilePath, {
-      entityDir: join('app', podPath),
+      entityDir: podDir,
       replace: (key: string) => {
         return `app/templates/${key}`;
       },

--- a/src/migration/app/steps/create-file-path-maps/app/map-route-templates.ts
+++ b/src/migration/app/steps/create-file-path-maps/app/map-route-templates.ts
@@ -20,7 +20,7 @@ export function mapRouteTemplates(options: Options): FilePathMapEntries {
 
   return filePaths.map((oldFilePath) => {
     const newFilePath = renamePodPath(oldFilePath, {
-      entityDir: podDir,
+      podDir,
       replace: (key: string) => {
         return `app/templates/${key}`;
       },

--- a/src/migration/app/steps/create-file-path-maps/app/map-route-templates.ts
+++ b/src/migration/app/steps/create-file-path-maps/app/map-route-templates.ts
@@ -12,7 +12,7 @@ export function mapRouteTemplates(options: Options): FilePathMapEntries {
   const { podPath, projectRoot } = options;
 
   const filePaths = findFiles(join('app', podPath, '**/template.hbs'), {
-    ignoreList: [join('app', podPath, 'components', '**')],
+    ignoreList: [join('app', podPath, 'components/**')],
     projectRoot,
   });
 

--- a/src/migration/app/steps/create-file-path-maps/app/map-services.ts
+++ b/src/migration/app/steps/create-file-path-maps/app/map-services.ts
@@ -19,7 +19,7 @@ export function mapServices(options: Options): FilePathMapEntries {
 
   return filePaths.map((oldFilePath) => {
     const newFilePath = renamePodPath(oldFilePath, {
-      entityDir: podDir,
+      podDir,
       replace: (key: string) => {
         return `app/services/${key}`;
       },

--- a/src/migration/app/steps/create-file-path-maps/app/map-services.ts
+++ b/src/migration/app/steps/create-file-path-maps/app/map-services.ts
@@ -11,13 +11,15 @@ import { renamePodPath } from '../../../../../utils/files/index.js';
 export function mapServices(options: Options): FilePathMapEntries {
   const { podPath, projectRoot } = options;
 
-  const filePaths = findFiles(join('app', podPath, '**/service.{js,ts}'), {
+  const podDir = join('app', podPath);
+
+  const filePaths = findFiles(`${podDir}/**/service.{js,ts}`, {
     projectRoot,
   });
 
   return filePaths.map((oldFilePath) => {
     const newFilePath = renamePodPath(oldFilePath, {
-      entityDir: join('app', podPath),
+      entityDir: podDir,
       replace: (key: string) => {
         return `app/services/${key}`;
       },

--- a/src/migration/app/steps/create-file-path-maps/tests/map-components.ts
+++ b/src/migration/app/steps/create-file-path-maps/tests/map-components.ts
@@ -19,7 +19,7 @@ export function mapComponents(options: Options): FilePathMapEntries {
 
   return filePaths.map((oldFilePath) => {
     const newFilePath = renamePodPath(oldFilePath, {
-      entityDir: podDir,
+      podDir,
       replace: (key: string) => {
         return `tests/integration/components/${key}-test`;
       },

--- a/src/migration/app/steps/create-file-path-maps/tests/map-components.ts
+++ b/src/migration/app/steps/create-file-path-maps/tests/map-components.ts
@@ -11,16 +11,15 @@ import { renamePodPath } from '../../../../../utils/files/index.js';
 export function mapComponents(options: Options): FilePathMapEntries {
   const { podPath, projectRoot } = options;
 
-  const filePaths = findFiles(
-    join('tests/integration', podPath, 'components/**/component-test.{js,ts}'),
-    {
-      projectRoot,
-    },
-  );
+  const podDir = join('tests/integration', podPath, 'components');
+
+  const filePaths = findFiles(`${podDir}/**/component-test.{js,ts}`, {
+    projectRoot,
+  });
 
   return filePaths.map((oldFilePath) => {
     const newFilePath = renamePodPath(oldFilePath, {
-      entityDir: join('tests/integration', podPath, 'components'),
+      entityDir: podDir,
       replace: (key: string) => {
         return `tests/integration/components/${key}-test`;
       },

--- a/src/migration/app/steps/create-file-path-maps/tests/map-route-controllers.ts
+++ b/src/migration/app/steps/create-file-path-maps/tests/map-route-controllers.ts
@@ -17,7 +17,7 @@ export function mapRouteControllers(options: Options): FilePathMapEntries {
   const filePaths1 = findFiles(
     join('tests/unit', podPath, '**/controller-test.{js,ts}'),
     {
-      ignoreList: [join('tests/unit', podPath, 'controllers', '**')],
+      ignoreList: [join('tests/unit', podPath, 'controllers/**')],
       projectRoot,
     },
   );

--- a/src/migration/app/steps/create-file-path-maps/tests/map-route-controllers.ts
+++ b/src/migration/app/steps/create-file-path-maps/tests/map-route-controllers.ts
@@ -23,7 +23,7 @@ export function mapRouteControllers(options: Options): FilePathMapEntries {
 
   const filePathMap1 = filePaths1.map((oldFilePath) => {
     const newFilePath = renamePodPath(oldFilePath, {
-      entityDir: podDir1,
+      podDir: podDir1,
       replace: (key: string) => {
         return `tests/unit/controllers/${key}-test`;
       },
@@ -43,7 +43,7 @@ export function mapRouteControllers(options: Options): FilePathMapEntries {
 
   const filePathMap2 = filePaths2.map((oldFilePath) => {
     const newFilePath = renamePodPath(oldFilePath, {
-      entityDir: podDir2,
+      podDir: podDir2,
       replace: (key: string) => {
         return `tests/unit/controllers/${key}-test`;
       },

--- a/src/migration/app/steps/create-file-path-maps/tests/map-route-controllers.ts
+++ b/src/migration/app/steps/create-file-path-maps/tests/map-route-controllers.ts
@@ -14,17 +14,16 @@ export function mapRouteControllers(options: Options): FilePathMapEntries {
   /*
     Case 1: Didn't pass the --pod flag, but configured { usePods: true } in .ember-cli
   */
-  const filePaths1 = findFiles(
-    join('tests/unit', podPath, '**/controller-test.{js,ts}'),
-    {
-      ignoreList: [join('tests/unit', podPath, 'controllers/**')],
-      projectRoot,
-    },
-  );
+  const podDir1 = join('tests/unit', podPath);
+
+  const filePaths1 = findFiles(`${podDir1}/**/controller-test.{js,ts}`, {
+    ignoreList: [join('tests/unit', podPath, 'controllers/**')],
+    projectRoot,
+  });
 
   const filePathMap1 = filePaths1.map((oldFilePath) => {
     const newFilePath = renamePodPath(oldFilePath, {
-      entityDir: join('tests/unit', podPath),
+      entityDir: podDir1,
       replace: (key: string) => {
         return `tests/unit/controllers/${key}-test`;
       },
@@ -36,16 +35,15 @@ export function mapRouteControllers(options: Options): FilePathMapEntries {
   /*
     Case 2: Passed the --pod flag to Ember CLI
   */
-  const filePaths2 = findFiles(
-    join('tests/unit', podPath, 'controllers/**/controller-test.{js,ts}'),
-    {
-      projectRoot,
-    },
-  );
+  const podDir2 = join('tests/unit', podPath, 'controllers');
+
+  const filePaths2 = findFiles(`${podDir2}/**/controller-test.{js,ts}`, {
+    projectRoot,
+  });
 
   const filePathMap2 = filePaths2.map((oldFilePath) => {
     const newFilePath = renamePodPath(oldFilePath, {
-      entityDir: join('tests/unit', podPath, 'controllers'),
+      entityDir: podDir2,
       replace: (key: string) => {
         return `tests/unit/controllers/${key}-test`;
       },

--- a/src/migration/app/steps/create-file-path-maps/tests/map-route-routes.ts
+++ b/src/migration/app/steps/create-file-path-maps/tests/map-route-routes.ts
@@ -17,7 +17,7 @@ export function mapRouteRoutes(options: Options): FilePathMapEntries {
   const filePaths1 = findFiles(
     join('tests/unit', podPath, '**/route-test.{js,ts}'),
     {
-      ignoreList: [join('tests/unit', podPath, 'routes', '**')],
+      ignoreList: [join('tests/unit', podPath, 'routes/**')],
       projectRoot,
     },
   );

--- a/src/migration/app/steps/create-file-path-maps/tests/map-route-routes.ts
+++ b/src/migration/app/steps/create-file-path-maps/tests/map-route-routes.ts
@@ -23,7 +23,7 @@ export function mapRouteRoutes(options: Options): FilePathMapEntries {
 
   const filePathMap1 = filePaths1.map((oldFilePath) => {
     const newFilePath = renamePodPath(oldFilePath, {
-      entityDir: podDir1,
+      podDir: podDir1,
       replace: (key: string) => {
         return `tests/unit/routes/${key}-test`;
       },
@@ -43,7 +43,7 @@ export function mapRouteRoutes(options: Options): FilePathMapEntries {
 
   const filePathMap2 = filePaths2.map((oldFilePath) => {
     const newFilePath = renamePodPath(oldFilePath, {
-      entityDir: podDir2,
+      podDir: podDir2,
       replace: (key: string) => {
         return `tests/unit/routes/${key}-test`;
       },

--- a/src/migration/app/steps/create-file-path-maps/tests/map-route-routes.ts
+++ b/src/migration/app/steps/create-file-path-maps/tests/map-route-routes.ts
@@ -14,17 +14,16 @@ export function mapRouteRoutes(options: Options): FilePathMapEntries {
   /*
     Case 1: Didn't pass the --pod flag, but configured { usePods: true } in .ember-cli
   */
-  const filePaths1 = findFiles(
-    join('tests/unit', podPath, '**/route-test.{js,ts}'),
-    {
-      ignoreList: [join('tests/unit', podPath, 'routes/**')],
-      projectRoot,
-    },
-  );
+  const podDir1 = join('tests/unit', podPath);
+
+  const filePaths1 = findFiles(`${podDir1}/**/route-test.{js,ts}`, {
+    ignoreList: [join('tests/unit', podPath, 'routes/**')],
+    projectRoot,
+  });
 
   const filePathMap1 = filePaths1.map((oldFilePath) => {
     const newFilePath = renamePodPath(oldFilePath, {
-      entityDir: join('tests/unit', podPath),
+      entityDir: podDir1,
       replace: (key: string) => {
         return `tests/unit/routes/${key}-test`;
       },
@@ -36,16 +35,15 @@ export function mapRouteRoutes(options: Options): FilePathMapEntries {
   /*
     Case 2: Passed the --pod flag to Ember CLI
   */
-  const filePaths2 = findFiles(
-    join('tests/unit', podPath, 'routes/**/route-test.{js,ts}'),
-    {
-      projectRoot,
-    },
-  );
+  const podDir2 = join('tests/unit', podPath, 'routes');
+
+  const filePaths2 = findFiles(`${podDir2}/**/route-test.{js,ts}`, {
+    projectRoot,
+  });
 
   const filePathMap2 = filePaths2.map((oldFilePath) => {
     const newFilePath = renamePodPath(oldFilePath, {
-      entityDir: join('tests/unit', podPath, 'routes'),
+      entityDir: podDir2,
       replace: (key: string) => {
         return `tests/unit/routes/${key}-test`;
       },

--- a/src/migration/app/steps/create-file-path-maps/tests/map-services.ts
+++ b/src/migration/app/steps/create-file-path-maps/tests/map-services.ts
@@ -11,17 +11,16 @@ import { renamePodPath } from '../../../../../utils/files/index.js';
 export function mapServices(options: Options): FilePathMapEntries {
   const { podPath, projectRoot } = options;
 
-  const filePaths = findFiles(
-    join('tests/unit', podPath, '**/service-test.{js,ts}'),
-    {
-      ignoreList: [join('tests/unit', podPath, 'services/**')],
-      projectRoot,
-    },
-  );
+  const podDir = join('tests/unit', podPath);
+
+  const filePaths = findFiles(`${podDir}/**/service-test.{js,ts}`, {
+    ignoreList: [join('tests/unit', podPath, 'services/**')],
+    projectRoot,
+  });
 
   return filePaths.map((oldFilePath) => {
     const newFilePath = renamePodPath(oldFilePath, {
-      entityDir: join('tests/unit', podPath),
+      entityDir: podDir,
       replace: (key: string) => {
         return `tests/unit/services/${key}-test`;
       },

--- a/src/migration/app/steps/create-file-path-maps/tests/map-services.ts
+++ b/src/migration/app/steps/create-file-path-maps/tests/map-services.ts
@@ -20,7 +20,7 @@ export function mapServices(options: Options): FilePathMapEntries {
 
   return filePaths.map((oldFilePath) => {
     const newFilePath = renamePodPath(oldFilePath, {
-      entityDir: podDir,
+      podDir,
       replace: (key: string) => {
         return `tests/unit/services/${key}-test`;
       },

--- a/src/migration/app/steps/create-file-path-maps/tests/map-services.ts
+++ b/src/migration/app/steps/create-file-path-maps/tests/map-services.ts
@@ -14,7 +14,7 @@ export function mapServices(options: Options): FilePathMapEntries {
   const filePaths = findFiles(
     join('tests/unit', podPath, '**/service-test.{js,ts}'),
     {
-      ignoreList: [join('tests/unit', podPath, 'services', '**')],
+      ignoreList: [join('tests/unit', podPath, 'services/**')],
       projectRoot,
     },
   );

--- a/src/migration/v1-addon/steps/create-file-path-maps/addon/map-component-classes.ts
+++ b/src/migration/v1-addon/steps/create-file-path-maps/addon/map-component-classes.ts
@@ -17,7 +17,7 @@ export function mapComponentClasses(options: Options): FilePathMapEntries {
 
   return filePaths.map((oldFilePath) => {
     const newFilePath = renamePodPath(oldFilePath, {
-      entityDir: podDir,
+      podDir,
       replace: (key: string) => {
         return `addon/components/${key}`;
       },

--- a/src/migration/v1-addon/steps/create-file-path-maps/addon/map-component-classes.ts
+++ b/src/migration/v1-addon/steps/create-file-path-maps/addon/map-component-classes.ts
@@ -9,13 +9,15 @@ import { renamePodPath } from '../../../../../utils/files/index.js';
 export function mapComponentClasses(options: Options): FilePathMapEntries {
   const { projectRoot } = options;
 
-  const filePaths = findFiles('addon/components/**/component.{d.ts,js,ts}', {
+  const podDir = 'addon/components';
+
+  const filePaths = findFiles(`${podDir}/**/component.{d.ts,js,ts}`, {
     projectRoot,
   });
 
   return filePaths.map((oldFilePath) => {
     const newFilePath = renamePodPath(oldFilePath, {
-      entityDir: 'addon/components',
+      entityDir: podDir,
       replace: (key: string) => {
         return `addon/components/${key}`;
       },

--- a/src/migration/v1-addon/steps/create-file-path-maps/addon/map-component-stylesheets.ts
+++ b/src/migration/v1-addon/steps/create-file-path-maps/addon/map-component-stylesheets.ts
@@ -17,7 +17,7 @@ export function mapComponentStylesheets(options: Options): FilePathMapEntries {
 
   return filePaths.map((oldFilePath) => {
     const newFilePath = renamePodPath(oldFilePath, {
-      entityDir: podDir,
+      podDir,
       replace: (key: string) => {
         return `addon/components/${key}`;
       },

--- a/src/migration/v1-addon/steps/create-file-path-maps/addon/map-component-stylesheets.ts
+++ b/src/migration/v1-addon/steps/create-file-path-maps/addon/map-component-stylesheets.ts
@@ -9,13 +9,15 @@ import { renamePodPath } from '../../../../../utils/files/index.js';
 export function mapComponentStylesheets(options: Options): FilePathMapEntries {
   const { projectRoot } = options;
 
-  const filePaths = findFiles('addon/components/**/styles.{css,scss}', {
+  const podDir = 'addon/components';
+
+  const filePaths = findFiles(`${podDir}/**/styles.{css,scss}`, {
     projectRoot,
   });
 
   return filePaths.map((oldFilePath) => {
     const newFilePath = renamePodPath(oldFilePath, {
-      entityDir: 'addon/components',
+      entityDir: podDir,
       replace: (key: string) => {
         return `addon/components/${key}`;
       },

--- a/src/migration/v1-addon/steps/create-file-path-maps/addon/map-component-templates.ts
+++ b/src/migration/v1-addon/steps/create-file-path-maps/addon/map-component-templates.ts
@@ -9,13 +9,15 @@ import { renamePodPath } from '../../../../../utils/files/index.js';
 export function mapComponentTemplates(options: Options): FilePathMapEntries {
   const { projectRoot } = options;
 
-  const filePaths = findFiles('addon/components/**/template.hbs', {
+  const podDir = 'addon/components';
+
+  const filePaths = findFiles(`${podDir}/**/template.hbs`, {
     projectRoot,
   });
 
   return filePaths.map((oldFilePath) => {
     const newFilePath = renamePodPath(oldFilePath, {
-      entityDir: 'addon/components',
+      entityDir: podDir,
       replace: (key: string) => {
         return `addon/components/${key}`;
       },

--- a/src/migration/v1-addon/steps/create-file-path-maps/addon/map-component-templates.ts
+++ b/src/migration/v1-addon/steps/create-file-path-maps/addon/map-component-templates.ts
@@ -17,7 +17,7 @@ export function mapComponentTemplates(options: Options): FilePathMapEntries {
 
   return filePaths.map((oldFilePath) => {
     const newFilePath = renamePodPath(oldFilePath, {
-      entityDir: podDir,
+      podDir,
       replace: (key: string) => {
         return `addon/components/${key}`;
       },

--- a/src/migration/v1-addon/steps/create-file-path-maps/addon/map-route-controllers.ts
+++ b/src/migration/v1-addon/steps/create-file-path-maps/addon/map-route-controllers.ts
@@ -17,7 +17,7 @@ export function mapRouteControllers(options: Options): FilePathMapEntries {
 
   return filePaths.map((oldFilePath) => {
     const newFilePath = renamePodPath(oldFilePath, {
-      entityDir: podDir,
+      podDir,
       replace: (key: string) => {
         return `addon/controllers/${key}`;
       },

--- a/src/migration/v1-addon/steps/create-file-path-maps/addon/map-route-controllers.ts
+++ b/src/migration/v1-addon/steps/create-file-path-maps/addon/map-route-controllers.ts
@@ -9,13 +9,15 @@ import { renamePodPath } from '../../../../../utils/files/index.js';
 export function mapRouteControllers(options: Options): FilePathMapEntries {
   const { projectRoot } = options;
 
-  const filePaths = findFiles('addon/**/controller.{js,ts}', {
+  const podDir = 'addon';
+
+  const filePaths = findFiles(`${podDir}/**/controller.{js,ts}`, {
     projectRoot,
   });
 
   return filePaths.map((oldFilePath) => {
     const newFilePath = renamePodPath(oldFilePath, {
-      entityDir: 'addon',
+      entityDir: podDir,
       replace: (key: string) => {
         return `addon/controllers/${key}`;
       },

--- a/src/migration/v1-addon/steps/create-file-path-maps/addon/map-route-routes.ts
+++ b/src/migration/v1-addon/steps/create-file-path-maps/addon/map-route-routes.ts
@@ -17,7 +17,7 @@ export function mapRouteRoutes(options: Options): FilePathMapEntries {
 
   return filePaths.map((oldFilePath) => {
     const newFilePath = renamePodPath(oldFilePath, {
-      entityDir: podDir,
+      podDir,
       replace: (key: string) => {
         return `addon/routes/${key}`;
       },

--- a/src/migration/v1-addon/steps/create-file-path-maps/addon/map-route-routes.ts
+++ b/src/migration/v1-addon/steps/create-file-path-maps/addon/map-route-routes.ts
@@ -9,13 +9,15 @@ import { renamePodPath } from '../../../../../utils/files/index.js';
 export function mapRouteRoutes(options: Options): FilePathMapEntries {
   const { projectRoot } = options;
 
-  const filePaths = findFiles('addon/**/route.{js,ts}', {
+  const podDir = 'addon';
+
+  const filePaths = findFiles(`${podDir}/**/route.{js,ts}`, {
     projectRoot,
   });
 
   return filePaths.map((oldFilePath) => {
     const newFilePath = renamePodPath(oldFilePath, {
-      entityDir: 'addon',
+      entityDir: podDir,
       replace: (key: string) => {
         return `addon/routes/${key}`;
       },

--- a/src/migration/v1-addon/steps/create-file-path-maps/addon/map-route-stylesheets.ts
+++ b/src/migration/v1-addon/steps/create-file-path-maps/addon/map-route-stylesheets.ts
@@ -9,14 +9,16 @@ import { renamePodPath } from '../../../../../utils/files/index.js';
 export function mapRouteStylesheets(options: Options): FilePathMapEntries {
   const { projectRoot } = options;
 
-  const filePaths = findFiles('addon/**/styles.{css,scss}', {
+  const podDir = 'addon';
+
+  const filePaths = findFiles(`${podDir}/**/styles.{css,scss}`, {
     ignoreList: ['addon/components/**'],
     projectRoot,
   });
 
   return filePaths.map((oldFilePath) => {
     const newFilePath = renamePodPath(oldFilePath, {
-      entityDir: 'addon',
+      entityDir: podDir,
       replace: (key: string) => {
         return `addon/styles/${key}`;
       },

--- a/src/migration/v1-addon/steps/create-file-path-maps/addon/map-route-stylesheets.ts
+++ b/src/migration/v1-addon/steps/create-file-path-maps/addon/map-route-stylesheets.ts
@@ -18,7 +18,7 @@ export function mapRouteStylesheets(options: Options): FilePathMapEntries {
 
   return filePaths.map((oldFilePath) => {
     const newFilePath = renamePodPath(oldFilePath, {
-      entityDir: podDir,
+      podDir,
       replace: (key: string) => {
         return `addon/styles/${key}`;
       },

--- a/src/migration/v1-addon/steps/create-file-path-maps/addon/map-route-templates.ts
+++ b/src/migration/v1-addon/steps/create-file-path-maps/addon/map-route-templates.ts
@@ -9,14 +9,16 @@ import { renamePodPath } from '../../../../../utils/files/index.js';
 export function mapRouteTemplates(options: Options): FilePathMapEntries {
   const { projectRoot } = options;
 
-  const filePaths = findFiles('addon/**/template.hbs', {
+  const podDir = 'addon';
+
+  const filePaths = findFiles(`${podDir}/**/template.hbs`, {
     ignoreList: ['addon/components/**'],
     projectRoot,
   });
 
   return filePaths.map((oldFilePath) => {
     const newFilePath = renamePodPath(oldFilePath, {
-      entityDir: 'addon',
+      entityDir: podDir,
       replace: (key: string) => {
         return `addon/templates/${key}`;
       },

--- a/src/migration/v1-addon/steps/create-file-path-maps/addon/map-route-templates.ts
+++ b/src/migration/v1-addon/steps/create-file-path-maps/addon/map-route-templates.ts
@@ -18,7 +18,7 @@ export function mapRouteTemplates(options: Options): FilePathMapEntries {
 
   return filePaths.map((oldFilePath) => {
     const newFilePath = renamePodPath(oldFilePath, {
-      entityDir: podDir,
+      podDir,
       replace: (key: string) => {
         return `addon/templates/${key}`;
       },

--- a/src/migration/v1-addon/steps/create-file-path-maps/addon/map-services.ts
+++ b/src/migration/v1-addon/steps/create-file-path-maps/addon/map-services.ts
@@ -9,13 +9,15 @@ import { renamePodPath } from '../../../../../utils/files/index.js';
 export function mapServices(options: Options): FilePathMapEntries {
   const { projectRoot } = options;
 
-  const filePaths = findFiles('addon/**/service.{js,ts}', {
+  const podDir = 'addon';
+
+  const filePaths = findFiles(`${podDir}/**/service.{js,ts}`, {
     projectRoot,
   });
 
   return filePaths.map((oldFilePath) => {
     const newFilePath = renamePodPath(oldFilePath, {
-      entityDir: 'addon',
+      entityDir: podDir,
       replace: (key: string) => {
         return `addon/services/${key}`;
       },

--- a/src/migration/v1-addon/steps/create-file-path-maps/addon/map-services.ts
+++ b/src/migration/v1-addon/steps/create-file-path-maps/addon/map-services.ts
@@ -17,7 +17,7 @@ export function mapServices(options: Options): FilePathMapEntries {
 
   return filePaths.map((oldFilePath) => {
     const newFilePath = renamePodPath(oldFilePath, {
-      entityDir: podDir,
+      podDir,
       replace: (key: string) => {
         return `addon/services/${key}`;
       },

--- a/src/migration/v1-addon/steps/create-file-path-maps/app/map-component-classes.ts
+++ b/src/migration/v1-addon/steps/create-file-path-maps/app/map-component-classes.ts
@@ -9,13 +9,15 @@ import { renamePodPath } from '../../../../../utils/files/index.js';
 export function mapComponentClasses(options: Options): FilePathMapEntries {
   const { projectRoot } = options;
 
-  const filePaths = findFiles('app/components/**/component.js', {
+  const podDir = 'app/components';
+
+  const filePaths = findFiles(`${podDir}/**/component.js`, {
     projectRoot,
   });
 
   return filePaths.map((oldFilePath) => {
     const newFilePath = renamePodPath(oldFilePath, {
-      entityDir: 'app/components',
+      entityDir: podDir,
       replace: (key: string) => {
         return `app/components/${key}`;
       },

--- a/src/migration/v1-addon/steps/create-file-path-maps/app/map-component-classes.ts
+++ b/src/migration/v1-addon/steps/create-file-path-maps/app/map-component-classes.ts
@@ -17,7 +17,7 @@ export function mapComponentClasses(options: Options): FilePathMapEntries {
 
   return filePaths.map((oldFilePath) => {
     const newFilePath = renamePodPath(oldFilePath, {
-      entityDir: podDir,
+      podDir,
       replace: (key: string) => {
         return `app/components/${key}`;
       },

--- a/src/migration/v1-addon/steps/create-file-path-maps/app/map-component-templates.ts
+++ b/src/migration/v1-addon/steps/create-file-path-maps/app/map-component-templates.ts
@@ -9,13 +9,15 @@ import { renamePodPath } from '../../../../../utils/files/index.js';
 export function mapComponentTemplates(options: Options): FilePathMapEntries {
   const { projectRoot } = options;
 
-  const filePaths = findFiles('app/components/**/template.js', {
+  const podDir = 'app/components';
+
+  const filePaths = findFiles(`${podDir}/**/template.js`, {
     projectRoot,
   });
 
   return filePaths.map((oldFilePath) => {
     const newFilePath = renamePodPath(oldFilePath, {
-      entityDir: 'app/components',
+      entityDir: podDir,
       replace: (key: string) => {
         return `app/components/${key}`;
       },

--- a/src/migration/v1-addon/steps/create-file-path-maps/app/map-component-templates.ts
+++ b/src/migration/v1-addon/steps/create-file-path-maps/app/map-component-templates.ts
@@ -17,7 +17,7 @@ export function mapComponentTemplates(options: Options): FilePathMapEntries {
 
   return filePaths.map((oldFilePath) => {
     const newFilePath = renamePodPath(oldFilePath, {
-      entityDir: podDir,
+      podDir,
       replace: (key: string) => {
         return `app/components/${key}`;
       },

--- a/src/migration/v1-addon/steps/create-file-path-maps/app/map-route-controllers.ts
+++ b/src/migration/v1-addon/steps/create-file-path-maps/app/map-route-controllers.ts
@@ -17,7 +17,7 @@ export function mapRouteControllers(options: Options): FilePathMapEntries {
 
   return filePaths.map((oldFilePath) => {
     const newFilePath = renamePodPath(oldFilePath, {
-      entityDir: podDir,
+      podDir,
       replace: (key: string) => {
         return `app/controllers/${key}`;
       },

--- a/src/migration/v1-addon/steps/create-file-path-maps/app/map-route-controllers.ts
+++ b/src/migration/v1-addon/steps/create-file-path-maps/app/map-route-controllers.ts
@@ -9,13 +9,15 @@ import { renamePodPath } from '../../../../../utils/files/index.js';
 export function mapRouteControllers(options: Options): FilePathMapEntries {
   const { projectRoot } = options;
 
-  const filePaths = findFiles('app/**/controller.js', {
+  const podDir = 'app';
+
+  const filePaths = findFiles(`${podDir}/**/controller.js`, {
     projectRoot,
   });
 
   return filePaths.map((oldFilePath) => {
     const newFilePath = renamePodPath(oldFilePath, {
-      entityDir: 'app',
+      entityDir: podDir,
       replace: (key: string) => {
         return `app/controllers/${key}`;
       },

--- a/src/migration/v1-addon/steps/create-file-path-maps/app/map-route-routes.ts
+++ b/src/migration/v1-addon/steps/create-file-path-maps/app/map-route-routes.ts
@@ -9,13 +9,15 @@ import { renamePodPath } from '../../../../../utils/files/index.js';
 export function mapRouteRoutes(options: Options): FilePathMapEntries {
   const { projectRoot } = options;
 
-  const filePaths = findFiles('app/**/route.js', {
+  const podDir = 'app';
+
+  const filePaths = findFiles(`${podDir}/**/route.js`, {
     projectRoot,
   });
 
   return filePaths.map((oldFilePath) => {
     const newFilePath = renamePodPath(oldFilePath, {
-      entityDir: 'app',
+      entityDir: podDir,
       replace: (key: string) => {
         return `app/routes/${key}`;
       },

--- a/src/migration/v1-addon/steps/create-file-path-maps/app/map-route-routes.ts
+++ b/src/migration/v1-addon/steps/create-file-path-maps/app/map-route-routes.ts
@@ -17,7 +17,7 @@ export function mapRouteRoutes(options: Options): FilePathMapEntries {
 
   return filePaths.map((oldFilePath) => {
     const newFilePath = renamePodPath(oldFilePath, {
-      entityDir: podDir,
+      podDir,
       replace: (key: string) => {
         return `app/routes/${key}`;
       },

--- a/src/migration/v1-addon/steps/create-file-path-maps/app/map-route-templates.ts
+++ b/src/migration/v1-addon/steps/create-file-path-maps/app/map-route-templates.ts
@@ -9,14 +9,16 @@ import { renamePodPath } from '../../../../../utils/files/index.js';
 export function mapRouteTemplates(options: Options): FilePathMapEntries {
   const { projectRoot } = options;
 
-  const filePaths = findFiles('app/**/template.js', {
+  const podDir = 'app';
+
+  const filePaths = findFiles(`${podDir}/**/template.js`, {
     ignoreList: ['app/components/**'],
     projectRoot,
   });
 
   return filePaths.map((oldFilePath) => {
     const newFilePath = renamePodPath(oldFilePath, {
-      entityDir: 'app',
+      entityDir: podDir,
       replace: (key: string) => {
         return `app/templates/${key}`;
       },

--- a/src/migration/v1-addon/steps/create-file-path-maps/app/map-route-templates.ts
+++ b/src/migration/v1-addon/steps/create-file-path-maps/app/map-route-templates.ts
@@ -18,7 +18,7 @@ export function mapRouteTemplates(options: Options): FilePathMapEntries {
 
   return filePaths.map((oldFilePath) => {
     const newFilePath = renamePodPath(oldFilePath, {
-      entityDir: podDir,
+      podDir,
       replace: (key: string) => {
         return `app/templates/${key}`;
       },

--- a/src/migration/v1-addon/steps/create-file-path-maps/app/map-services.ts
+++ b/src/migration/v1-addon/steps/create-file-path-maps/app/map-services.ts
@@ -9,13 +9,15 @@ import { renamePodPath } from '../../../../../utils/files/index.js';
 export function mapServices(options: Options): FilePathMapEntries {
   const { projectRoot } = options;
 
-  const filePaths = findFiles('app/**/service.js', {
+  const podDir = 'app';
+
+  const filePaths = findFiles(`${podDir}/**/service.js`, {
     projectRoot,
   });
 
   return filePaths.map((oldFilePath) => {
     const newFilePath = renamePodPath(oldFilePath, {
-      entityDir: 'app',
+      entityDir: podDir,
       replace: (key: string) => {
         return `app/services/${key}`;
       },

--- a/src/migration/v1-addon/steps/create-file-path-maps/app/map-services.ts
+++ b/src/migration/v1-addon/steps/create-file-path-maps/app/map-services.ts
@@ -17,7 +17,7 @@ export function mapServices(options: Options): FilePathMapEntries {
 
   return filePaths.map((oldFilePath) => {
     const newFilePath = renamePodPath(oldFilePath, {
-      entityDir: podDir,
+      podDir,
       replace: (key: string) => {
         return `app/services/${key}`;
       },

--- a/src/migration/v1-addon/steps/create-file-path-maps/tests/map-components.ts
+++ b/src/migration/v1-addon/steps/create-file-path-maps/tests/map-components.ts
@@ -17,7 +17,7 @@ export function mapComponents(options: Options): FilePathMapEntries {
 
   return filePaths.map((oldFilePath) => {
     const newFilePath = renamePodPath(oldFilePath, {
-      entityDir: podDir,
+      podDir,
       replace: (key: string) => {
         return `tests/integration/components/${key}-test`;
       },

--- a/src/migration/v1-addon/steps/create-file-path-maps/tests/map-components.ts
+++ b/src/migration/v1-addon/steps/create-file-path-maps/tests/map-components.ts
@@ -9,16 +9,15 @@ import { renamePodPath } from '../../../../../utils/files/index.js';
 export function mapComponents(options: Options): FilePathMapEntries {
   const { projectRoot } = options;
 
-  const filePaths = findFiles(
-    'tests/integration/components/**/component-test.{js,ts}',
-    {
-      projectRoot,
-    },
-  );
+  const podDir = 'tests/integration/components';
+
+  const filePaths = findFiles(`${podDir}/**/component-test.{js,ts}`, {
+    projectRoot,
+  });
 
   return filePaths.map((oldFilePath) => {
     const newFilePath = renamePodPath(oldFilePath, {
-      entityDir: 'tests/integration/components',
+      entityDir: podDir,
       replace: (key: string) => {
         return `tests/integration/components/${key}-test`;
       },

--- a/src/migration/v1-addon/steps/create-file-path-maps/tests/map-route-controllers.ts
+++ b/src/migration/v1-addon/steps/create-file-path-maps/tests/map-route-controllers.ts
@@ -21,7 +21,7 @@ export function mapRouteControllers(options: Options): FilePathMapEntries {
 
   const filePathMap1 = filePaths1.map((oldFilePath) => {
     const newFilePath = renamePodPath(oldFilePath, {
-      entityDir: podDir1,
+      podDir: podDir1,
       replace: (key: string) => {
         return `tests/unit/controllers/${key}-test`;
       },
@@ -41,7 +41,7 @@ export function mapRouteControllers(options: Options): FilePathMapEntries {
 
   const filePathMap2 = filePaths2.map((oldFilePath) => {
     const newFilePath = renamePodPath(oldFilePath, {
-      entityDir: podDir2,
+      podDir: podDir2,
       replace: (key: string) => {
         return `tests/unit/controllers/${key}-test`;
       },

--- a/src/migration/v1-addon/steps/create-file-path-maps/tests/map-route-controllers.ts
+++ b/src/migration/v1-addon/steps/create-file-path-maps/tests/map-route-controllers.ts
@@ -12,14 +12,16 @@ export function mapRouteControllers(options: Options): FilePathMapEntries {
   /*
     Case 1: Didn't pass the --pod flag, but configured { usePods: true } in .ember-cli
   */
-  const filePaths1 = findFiles('tests/unit/**/controller-test.{js,ts}', {
+  const podDir1 = 'tests/unit';
+
+  const filePaths1 = findFiles(`${podDir1}/**/controller-test.{js,ts}`, {
     ignoreList: ['tests/unit/controllers/**'],
     projectRoot,
   });
 
   const filePathMap1 = filePaths1.map((oldFilePath) => {
     const newFilePath = renamePodPath(oldFilePath, {
-      entityDir: 'tests/unit',
+      entityDir: podDir1,
       replace: (key: string) => {
         return `tests/unit/controllers/${key}-test`;
       },
@@ -31,16 +33,15 @@ export function mapRouteControllers(options: Options): FilePathMapEntries {
   /*
     Case 2: Passed the --pod flag to Ember CLI
   */
-  const filePaths2 = findFiles(
-    'tests/unit/controllers/**/controller-test.{js,ts}',
-    {
-      projectRoot,
-    },
-  );
+  const podDir2 = 'tests/unit/controllers';
+
+  const filePaths2 = findFiles(`${podDir2}/**/controller-test.{js,ts}`, {
+    projectRoot,
+  });
 
   const filePathMap2 = filePaths2.map((oldFilePath) => {
     const newFilePath = renamePodPath(oldFilePath, {
-      entityDir: 'tests/unit/controllers',
+      entityDir: podDir2,
       replace: (key: string) => {
         return `tests/unit/controllers/${key}-test`;
       },

--- a/src/migration/v1-addon/steps/create-file-path-maps/tests/map-route-routes.ts
+++ b/src/migration/v1-addon/steps/create-file-path-maps/tests/map-route-routes.ts
@@ -21,7 +21,7 @@ export function mapRouteRoutes(options: Options): FilePathMapEntries {
 
   const filePathMap1 = filePaths1.map((oldFilePath) => {
     const newFilePath = renamePodPath(oldFilePath, {
-      entityDir: podDir1,
+      podDir: podDir1,
       replace: (key: string) => {
         return `tests/unit/routes/${key}-test`;
       },
@@ -41,7 +41,7 @@ export function mapRouteRoutes(options: Options): FilePathMapEntries {
 
   const filePathMap2 = filePaths2.map((oldFilePath) => {
     const newFilePath = renamePodPath(oldFilePath, {
-      entityDir: podDir2,
+      podDir: podDir2,
       replace: (key: string) => {
         return `tests/unit/routes/${key}-test`;
       },

--- a/src/migration/v1-addon/steps/create-file-path-maps/tests/map-route-routes.ts
+++ b/src/migration/v1-addon/steps/create-file-path-maps/tests/map-route-routes.ts
@@ -12,14 +12,16 @@ export function mapRouteRoutes(options: Options): FilePathMapEntries {
   /*
     Case 1: Didn't pass the --pod flag, but configured { usePods: true } in .ember-cli
   */
-  const filePaths1 = findFiles('tests/unit/**/route-test.{js,ts}', {
+  const podDir1 = 'tests/unit';
+
+  const filePaths1 = findFiles(`${podDir1}/**/route-test.{js,ts}`, {
     ignoreList: ['tests/unit/routes/**'],
     projectRoot,
   });
 
   const filePathMap1 = filePaths1.map((oldFilePath) => {
     const newFilePath = renamePodPath(oldFilePath, {
-      entityDir: 'tests/unit',
+      entityDir: podDir1,
       replace: (key: string) => {
         return `tests/unit/routes/${key}-test`;
       },
@@ -31,13 +33,15 @@ export function mapRouteRoutes(options: Options): FilePathMapEntries {
   /*
     Case 2: Passed the --pod flag to Ember CLI
   */
-  const filePaths2 = findFiles('tests/unit/routes/**/route-test.{js,ts}', {
+  const podDir2 = 'tests/unit/routes';
+
+  const filePaths2 = findFiles(`${podDir2}/**/route-test.{js,ts}`, {
     projectRoot,
   });
 
   const filePathMap2 = filePaths2.map((oldFilePath) => {
     const newFilePath = renamePodPath(oldFilePath, {
-      entityDir: 'tests/unit/routes',
+      entityDir: podDir2,
       replace: (key: string) => {
         return `tests/unit/routes/${key}-test`;
       },

--- a/src/migration/v1-addon/steps/create-file-path-maps/tests/map-services.ts
+++ b/src/migration/v1-addon/steps/create-file-path-maps/tests/map-services.ts
@@ -18,7 +18,7 @@ export function mapServices(options: Options): FilePathMapEntries {
 
   return filePaths.map((oldFilePath) => {
     const newFilePath = renamePodPath(oldFilePath, {
-      entityDir: podDir,
+      podDir,
       replace: (key: string) => {
         return `tests/unit/services/${key}-test`;
       },

--- a/src/migration/v1-addon/steps/create-file-path-maps/tests/map-services.ts
+++ b/src/migration/v1-addon/steps/create-file-path-maps/tests/map-services.ts
@@ -9,14 +9,16 @@ import { renamePodPath } from '../../../../../utils/files/index.js';
 export function mapServices(options: Options): FilePathMapEntries {
   const { projectRoot } = options;
 
-  const filePaths = findFiles('tests/unit/**/service-test.{js,ts}', {
+  const podDir = 'tests/unit';
+
+  const filePaths = findFiles(`${podDir}/**/service-test.{js,ts}`, {
     ignoreList: ['tests/unit/services/**'],
     projectRoot,
   });
 
   return filePaths.map((oldFilePath) => {
     const newFilePath = renamePodPath(oldFilePath, {
-      entityDir: 'tests/unit',
+      entityDir: podDir,
       replace: (key: string) => {
         return `tests/unit/services/${key}-test`;
       },

--- a/src/utils/files/rename-pod-path.ts
+++ b/src/utils/files/rename-pod-path.ts
@@ -3,21 +3,21 @@ import { parseFilePath } from '@codemod-utils/files';
 export function renamePodPath(
   filePath: string,
   options: {
-    entityDir: string;
+    podDir: string;
     replace: (key: string) => string;
   },
 ): string {
   const { dir, ext, name } = parseFilePath(filePath);
-  const { entityDir, replace } = options;
+  const { podDir, replace } = options;
 
-  if (!dir.startsWith(entityDir)) {
+  if (!dir.startsWith(podDir)) {
     throw new RangeError(
-      `ERROR: The provided path \`${filePath}\` doesn't match the directory pattern \`${entityDir}\`.\n`,
+      `ERROR: The provided path \`${filePath}\` doesn't match the directory pattern \`${podDir}\`.\n`,
     );
   }
 
   const key = filePath
-    .replace(new RegExp(`^${entityDir}/`), '')
+    .replace(new RegExp(`^${podDir}/`), '')
     .replace(new RegExp(`/${name}${ext}$`), '');
 
   return `${replace(key)}${ext}`;

--- a/tests/utils/files/rename-pod-path/base-case.test.ts
+++ b/tests/utils/files/rename-pod-path/base-case.test.ts
@@ -6,7 +6,7 @@ test('utils | files | rename-pod-path > base case', function () {
   const oldFilePath = 'app/pods/components/navigation-menu/component.d.ts';
 
   const newFilePath = renamePodPath(oldFilePath, {
-    entityDir: 'app/pods/components',
+    podDir: 'app/pods/components',
     replace: (key) => {
       return `app/components/${key}`;
     },

--- a/tests/utils/files/rename-pod-path/edge-case-replace-suffixes-file-name.test.ts
+++ b/tests/utils/files/rename-pod-path/edge-case-replace-suffixes-file-name.test.ts
@@ -6,7 +6,7 @@ test('utils | files | rename-pod-path > edge case (replace suffixes file name)',
   const oldFilePath = 'tests/unit/pods/index/controller-test.ts';
 
   const newFilePath = renamePodPath(oldFilePath, {
-    entityDir: 'tests/unit/pods',
+    podDir: 'tests/unit/pods',
     replace: (key) => {
       return `tests/unit/controllers/${key}-test`;
     },

--- a/tests/utils/files/rename-pod-path/error-handling-directory-does-not-match.test.ts
+++ b/tests/utils/files/rename-pod-path/error-handling-directory-does-not-match.test.ts
@@ -8,7 +8,7 @@ test('utils | files | rename-pod-path > error handling (directory does not match
   assert.throws(
     () => {
       renamePodPath(oldFilePath, {
-        entityDir: 'addon/components',
+        podDir: 'addon/components',
         replace: (key) => {
           return `addon/components/${key}`;
         },


### PR DESCRIPTION
## Description

Closes #61.

I refactored code and provided instructions in `README` so that end-developers may more easily change the source code to migrate their project one component or one route at a time. For now, the codemod won't provide additional CLI options to target a particular component or route. 
